### PR TITLE
feat: introduce Spin type

### DIFF
--- a/IsingModel/Basic.lean
+++ b/IsingModel/Basic.lean
@@ -4,7 +4,6 @@ import Mathlib.Tactic.DeriveFintype
 # Spin type
 
 Two-state spin values for the Ising model.
-See `.self-local/tex/0001-spin-type.tex` for the mathematical description.
 -/
 
 namespace IsingModel

--- a/IsingModel/Basic.lean
+++ b/IsingModel/Basic.lean
@@ -1,1 +1,27 @@
-def hello := "world"
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# Spin type
+
+Two-state spin values for the Ising model.
+See `.self-local/tex/0001-spin-type.tex` for the mathematical description.
+-/
+
+namespace IsingModel
+
+/-- A single-site spin in the Ising model: either `up` (+1) or `down` (-1). -/
+inductive Spin
+  | up
+  | down
+  deriving DecidableEq, Fintype, Inhabited, Repr
+
+namespace Spin
+
+/-- Map a spin to its physical sign value: `up ↦ 1`, `down ↦ -1`. -/
+def toSign : Spin → Int
+  | up   =>  1
+  | down => -1
+
+end Spin
+
+end IsingModel


### PR DESCRIPTION
## Summary
- Introduce `IsingModel.Spin` as an `inductive` type with `up`/`down`.
- Derive `DecidableEq`, `Fintype`, `Inhabited`, `Repr` (Fintype via
  `Mathlib.Tactic.DeriveFintype`).
- Add `Spin.toSign : Spin → Int` mapping `up ↦ 1`, `down ↦ -1`.

## Test plan
- [x] `lake build` passes locally.