### PR TITLE
feat: add Config type alias and IsingParams structure

### DIFF
--- a/IsingModel/Basic.lean
+++ b/IsingModel/Basic.lean
@@ -1,12 +1,17 @@
 import Mathlib.Tactic.DeriveFintype
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Order.Ring.Defs
 
 /-!
-# Spin type
+# Ising model: basic definitions
 
-Two-state spin values for the Ising model.
+Spin type, configuration space, and Ising parameters.
 -/
 
 namespace IsingModel
+
+/-! ## Spin -/
 
 /-- A single-site spin in the Ising model: either `up` (+1) or `down` (-1). -/
 inductive Spin
@@ -22,5 +27,21 @@ def toSign : Spin → Int
   | down => -1
 
 end Spin
+
+/-! ## Configuration space -/
+
+/-- A spin configuration on sites of type `ι`. -/
+abbrev Config (ι : Type*) := ι → Spin
+
+/-! ## Ising parameters -/
+
+/-- Parameters for the Ising model over an ordered field `K`. -/
+structure IsingParams (K : Type*) [Field K] [LinearOrder K] [IsStrictOrderedRing K] where
+  /-- Coupling constant. -/
+  J : K
+  /-- External magnetic field. -/
+  h : K
+  /-- Inverse temperature. -/
+  β : K
 
 end IsingModel


### PR DESCRIPTION
## Summary
- Define `Config ι := ι → Spin` as a type alias for spin configurations.
- Define `IsingParams K` structure with coupling `J`, external field `h`, and inverse temperature `β` over a generic ordered field `K` (`[Field K] [LinearOrder K] [IsStrictOrderedRing K]`).
- Import `Mathlib.Combinatorics.SimpleGraph.Basic` for future lattice graph usage.

## Test plan
- [x] `lake build` passes locally.