### PR TITLE
fix: remove unused SimpleGraph import

### DIFF
--- a/IsingModel/Basic.lean
+++ b/IsingModel/Basic.lean
@@ -1,5 +1,4 @@
 import Mathlib.Tactic.DeriveFintype
-import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Order.Ring.Defs
 


### PR DESCRIPTION
## Summary
- Address Copilot review comments on PR #4.
- Remove unused `import Mathlib.Combinatorics.SimpleGraph.Basic` (will re-add
  when lattice graph code actually uses it).
- `[Field K] [LinearOrder K] [IsStrictOrderedRing K]` は現行 mathlib で
  `LinearOrderedField` が deprecated (2025-10) になったための正しい置き換え.
  変更不要.

## Test plan
- [ ] `lake build` passes.