### PR TITLE
feat: add spin algebra lemmas and ferromagnetic condition

### DIFF
--- a/IsingModel/Basic.lean
+++ b/IsingModel/Basic.lean
@@ -43,4 +43,16 @@ structure IsingParams (K : Type*) [Field K] [LinearOrder K] [IsStrictOrderedRing
   /-- Inverse temperature. -/
   β : K
 
+/-! ## Ferromagnetic condition -/
+
+/-- The ferromagnetic condition: non-negative coupling, non-negative field, positive temperature. -/
+structure Ferromagnetic {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
+    (p : IsingParams K) : Prop where
+  /-- Non-negative coupling constant. -/
+  hJ : 0 ≤ p.J
+  /-- Non-negative external field. -/
+  hh : 0 ≤ p.h
+  /-- Positive inverse temperature. -/
+  hβ : 0 < p.β
+
 end IsingModel

--- a/IsingModel/GibbsMeasure.lean
+++ b/IsingModel/GibbsMeasure.lean
@@ -67,4 +67,33 @@ noncomputable def correlation (G : SimpleGraph ι) [Fintype G.edgeSet]
     (p : IsingParams ℝ) (A : Finset ι) : ℝ :=
   gibbsExpectation G p (spinProduct A)
 
+/-! ## Spin product algebra -/
+
+omit [Fintype ι] [DecidableEq ι] in
+/-- The spin product over the empty set is `1`. -/
+@[simp]
+theorem spinProduct_empty (σ : Config ι) : spinProduct ∅ σ = 1 := by
+  simp [spinProduct]
+
+omit [Fintype ι] [DecidableEq ι] in
+/-- The spin product over a singleton is the spin sign at that site. -/
+@[simp]
+theorem spinProduct_singleton (i : ι) (σ : Config ι) :
+    spinProduct {i} σ = ↑(σ i).toSign := by
+  simp [spinProduct]
+
+omit [Fintype ι] in
+/-- The spin product over a disjoint union factors: `σ_{A ∪ B} = σ_A · σ_B`. -/
+theorem spinProduct_union {A B : Finset ι} (h : Disjoint A B) (σ : Config ι) :
+    spinProduct (A ∪ B) σ = spinProduct A σ * spinProduct B σ := by
+  simp [spinProduct, Finset.prod_union h]
+
+omit [Fintype ι] [DecidableEq ι] in
+/-- The square of any spin product is `1`, since each factor is `±1`. -/
+theorem spinProduct_sq (A : Finset ι) (σ : Config ι) :
+    spinProduct A σ ^ 2 = 1 := by
+  simp only [sq, spinProduct, ← Finset.prod_mul_distrib]
+  exact Finset.prod_eq_one fun i _ => by
+    simp [← sq, ← Int.cast_pow, Spin.toSign_sq]
+
 end IsingModel

--- a/IsingModel/Hamiltonian.lean
+++ b/IsingModel/Hamiltonian.lean
@@ -38,6 +38,17 @@ theorem Config.flip_flip {ι : Type*} (σ : Config ι) : σ.flip.flip = σ := by
 /-- The spin sign cast into the field `K`. -/
 def Spin.sign (K : Type*) [CommRing K] (s : Spin) : K := ↑s.toSign
 
+/-- The square of any spin sign is `1`: `(±1)² = 1`. -/
+@[simp]
+theorem Spin.toSign_sq (s : Spin) : s.toSign ^ 2 = 1 := by
+  cases s <;> simp [Spin.toSign]
+
+/-- The square of the spin sign in `K` is `1`: `(sign K s)² = 1`. -/
+@[simp]
+theorem Spin.sign_sq {K : Type*} [CommRing K] (s : Spin) :
+    Spin.sign K s ^ 2 = 1 := by
+  simp [Spin.sign, ← Int.cast_pow, Spin.toSign_sq]
+
 @[simp]
 theorem Spin.sign_flip {K : Type*} [CommRing K] (s : Spin) :
     Spin.sign K s.flip = -Spin.sign K s := by
@@ -50,6 +61,7 @@ def edgeSpin {ι K : Type*} [Field K] (σ : Config ι) : Sym2 ι → K :=
   Sym2.lift ⟨fun i j => Spin.sign K (σ i) * Spin.sign K (σ j),
     fun _ _ => mul_comm _ _⟩
 
+/-- The per-edge spin product is invariant under spin flip: `(-1)·(-1) = 1·1`. -/
 theorem edgeSpin_flip {ι K : Type*} [Field K] (σ : Config ι) (e : Sym2 ι) :
     edgeSpin (K := K) σ.flip e = edgeSpin σ e := by
   refine Sym2.ind (fun i j => ?_) e


### PR DESCRIPTION
## Summary
- Add algebraic properties of `Spin.toSign` and `spinProduct`.
- Add `Ferromagnetic` structure for the ferromagnetic condition.
- Preparatory work for GKS inequalities (work 0005).

## Test plan
- [ ] `lake build` passes with zero warnings.