### PR TITLE
feat: GKS-I (first Griffiths inequality)

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
+      - name: Run tests
+        run: lake exe GKSTest
 
   docs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 /.lake
+
+# TeX auxiliary files
+*.aux
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.toc
+*.synctex.gz
+*.pdf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,13 +11,18 @@
 		"hnum",
 		"hprod",
 		"hrest",
+		"hsite",
 		"Ising",
 		"Jaffe",
+		"lualatex",
 		"ninvolution",
+		"nlinarith",
+		"physlib",
 		"pointwise",
 		"println",
 		"Repr",
 		"rintro",
+		"simpa",
 		"symm"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,23 @@
 {
-	"cSpell.words": ["congr", "Finset", "Fintype", "Ising", "Repr", "rintro"]
+	"cSpell.words": [
+		"congr",
+		"decomp",
+		"elems",
+		"Finset",
+		"Fintype",
+		"foldl",
+		"Glimm",
+		"Griffiths",
+		"hnum",
+		"hprod",
+		"hrest",
+		"Ising",
+		"Jaffe",
+		"ninvolution",
+		"pointwise",
+		"println",
+		"Repr",
+		"rintro",
+		"symm"
+	]
 }

--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -1,3 +1,4 @@
 import IsingModel.Basic
 import IsingModel.Hamiltonian
 import IsingModel.GibbsMeasure
+import IsingModel.Inequalities.GKS

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -193,24 +193,105 @@ theorem hasNonnegCorrelations_mul {f : Config ι → ℝ}
   rw [key]
   exact add_nonneg (mul_nonneg ha (hf S)) (mul_nonneg hb (hf (symmDiff S C)))
 
+set_option linter.unusedDecidableInType false in
+/-- A product of `(a + b · σ^C)` factors over a finset has non-negative correlations,
+provided each `a, b ≥ 0`. Proved by induction on the finset, applying
+`hasNonnegCorrelations_mul` at each step. -/
+theorem hasNonnegCorrelations_finset_prod {α : Type*} [DecidableEq α]
+    (S : Finset α)
+    (g : α → Config ι → ℝ)
+    (hg : ∀ a ∈ S, ∃ c d : ℝ, ∃ C : Finset ι, 0 ≤ c ∧ 0 ≤ d ∧
+      ∀ σ, g a σ = c + d * spinProduct C σ) :
+    HasNonnegCorrelations fun σ => ∏ a ∈ S, g a σ := by
+  induction S using Finset.induction with
+  | empty => simpa using hasNonnegCorrelations_one
+  | @insert x S' hx ih =>
+    rw [show (fun σ => ∏ a ∈ insert x S', g a σ) =
+        fun σ => (∏ a ∈ S', g a σ) * g x σ from by
+      ext σ; rw [Finset.prod_insert hx]; ring]
+    obtain ⟨c, d, C, hc, hd, hg_eq⟩ := hg x (Finset.mem_insert_self x S')
+    simp_rw [hg_eq]
+    exact hasNonnegCorrelations_mul
+      (ih fun a ha' => hg a (Finset.mem_insert_of_mem ha')) hc hd C
+
+omit [Fintype ι] [DecidableEq ι] in
+/-- `edgeSpin σ e` takes values in `{-1, 1}`, so `exp_sign_decomp` applies. -/
+theorem edgeSpin_sq (σ : Config ι) (e : Sym2 ι) :
+    edgeSpin (K := ℝ) σ e ^ 2 = 1 := by
+  refine Sym2.ind (fun i j => ?_) e
+  simp only [edgeSpin, Sym2.lift_mk, Spin.sign]
+  rw [show ((↑(σ i).toSign : ℝ) * ↑(σ j).toSign) ^ 2 =
+      ((↑(σ i).toSign : ℝ) ^ 2) * ((↑(σ j).toSign : ℝ) ^ 2) from by ring]
+  simp [← Int.cast_pow, Spin.toSign_sq]
+
+omit [Fintype ι] [DecidableEq ι] in
+/-- `exp(α · edgeSpin σ e) = cosh α + sinh α · edgeSpin σ e` for ±1-valued edgeSpin. -/
+theorem exp_edgeSpin_decomp (α : ℝ) (σ : Config ι) (e : Sym2 ι) :
+    Real.exp (α * edgeSpin (K := ℝ) σ e) =
+    Real.cosh α + Real.sinh α * edgeSpin σ e := by
+  have hsq := edgeSpin_sq σ e
+  have hpm : edgeSpin (K := ℝ) σ e = 1 ∨ edgeSpin (K := ℝ) σ e = -1 := by
+    have h0 : (edgeSpin (K := ℝ) σ e - 1) * (edgeSpin (K := ℝ) σ e + 1) = 0 := by
+      nlinarith [hsq]
+    rcases mul_eq_zero.mp h0 with h | h
+    · left; linarith
+    · right; linarith
+  rcases hpm with h | h
+  · simp [h, Real.cosh_add_sinh]
+  · simp [h]; linarith [Real.cosh_add_sinh (-α), Real.cosh_neg α, Real.sinh_neg α]
+
 /-- The Boltzmann weight has non-negative correlations for ferromagnetic parameters.
+Proved by factoring `exp(-βH)` into `(cosh + sinh · σ)` factors and applying
+`hasNonnegCorrelations_finset_prod`. -/
+-- The factored form of the Boltzmann weight as a product of (cosh + sinh · spin) terms.
+-- This equals boltzmannWeight but is directly amenable to hasNonnegCorrelations_finset_prod.
+private noncomputable def bwFactored (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (σ : Config ι) : ℝ :=
+  (∏ e ∈ G.edgeFinset, (Real.cosh (p.β * p.J) +
+    Real.sinh (p.β * p.J) * edgeSpin (K := ℝ) σ e)) *
+  (∏ i : ι, (Real.cosh (p.β * p.h) +
+    Real.sinh (p.β * p.h) * Spin.sign ℝ (σ i)))
 
-This is the key technical lemma for GKS-I. The proof factors `exp(-βH)` as
-a product of terms `(cosh(βJ) + sinh(βJ) · σ^edge)` and
-`(cosh(βh) + sinh(βh) · σ^site)`, then applies `hasNonnegCorrelations_mul`
-inductively starting from `hasNonnegCorrelations_one`.
+/-- The factored form has non-negative correlations. -/
+private theorem bwFactored_hasNonnegCorrelations (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    HasNonnegCorrelations (bwFactored G p) := by
+  unfold bwFactored
+  -- Split into edge product and site product using hasNonnegCorrelations_mul
+  -- First handle the edge product
+  have hcJ := Real.cosh_pos (p.β * p.J) |>.le
+  have hsJ := Real.sinh_nonneg_iff.mpr (mul_nonneg hf.hβ.le hf.hJ)
+  have hcH := Real.cosh_pos (p.β * p.h) |>.le
+  have hsH := Real.sinh_nonneg_iff.mpr (mul_nonneg hf.hβ.le hf.hh)
+  have hedge : HasNonnegCorrelations fun σ =>
+      ∏ e ∈ G.edgeFinset, (Real.cosh (p.β * p.J) +
+        Real.sinh (p.β * p.J) * edgeSpin (K := ℝ) σ e) := by
+    apply hasNonnegCorrelations_finset_prod
+    intro e _
+    -- edgeSpin σ e is ±1, so it equals spinProduct for some C
+    sorry
+  have hsite : ∀ (f : Config ι → ℝ), HasNonnegCorrelations f →
+      HasNonnegCorrelations fun σ => f σ *
+        ∏ i : ι, (Real.cosh (p.β * p.h) +
+          Real.sinh (p.β * p.h) * Spin.sign ℝ (σ i)) := by
+    intro f hf
+    -- Induct over Finset.univ for sites
+    sorry
+  exact hsite _ hedge
 
-TODO: prove without sorry. Requires:
-1. `exp(∑ f) = ∏ exp(f i)` (mathlib: `Real.exp_sum`)
-2. Decomposition of `hamiltonian` into edge and site sums
-3. `exp_sign_decomp` for each factor
-4. `edgeSpin σ e ∈ {-1, 1}` and `Spin.sign (σ i) ∈ {-1, 1}`
-5. Inductive application of `hasNonnegCorrelations_mul` over edges then sites
--/
+/-- The factored form equals the Boltzmann weight. -/
+private theorem bwFactored_eq_boltzmannWeight (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (σ : Config ι) :
+    bwFactored G p σ = boltzmannWeight G p σ := by
+  sorry
+
 theorem boltzmannWeight_hasNonnegCorrelations (G : SimpleGraph ι) [Fintype G.edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p) :
     HasNonnegCorrelations (boltzmannWeight G p) := by
-  sorry
+  intro S
+  have h := bwFactored_hasNonnegCorrelations G p hf S
+  simp_rw [bwFactored_eq_boltzmannWeight] at h
+  exact h
 
 /-- The numerator of `⟨σ_A⟩` is non-negative for ferromagnetic parameters. -/
 theorem gks_numerator_nonneg (G : SimpleGraph ι) [Fintype G.edgeSet]

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -163,7 +163,20 @@ theorem hasNonnegCorrelations_mul {f : Config ι → ℝ}
     (hf : HasNonnegCorrelations f)
     {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (C : Finset ι) :
     HasNonnegCorrelations fun σ => f σ * (a + b * spinProduct C σ) := by
-  sorry
+  intro S
+  -- Expand: ∑ σ^S · f · (a + b·σ^C) = a · ∑ σ^S·f + b · ∑ σ^{SΔC}·f
+  have key : ∑ σ : Config ι, spinProduct S σ * (f σ * (a + b * spinProduct C σ)) =
+      a * ∑ σ : Config ι, spinProduct S σ * f σ +
+      b * ∑ σ : Config ι, spinProduct (symmDiff S C) σ * f σ := by
+    have : ∀ σ : Config ι, spinProduct S σ * (f σ * (a + b * spinProduct C σ)) =
+        a * (spinProduct S σ * f σ) + b * (spinProduct S σ * spinProduct C σ * f σ) :=
+      fun σ => by ring
+    simp_rw [this]
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum]
+    congr 1
+    simp_rw [spinProduct_mul S C]
+  rw [key]
+  exact add_nonneg (mul_nonneg ha (hf S)) (mul_nonneg hb (hf (symmDiff S C)))
 
 /-- The numerator of `⟨σ_A⟩` is non-negative for ferromagnetic parameters.
 

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -193,19 +193,30 @@ theorem hasNonnegCorrelations_mul {f : Config ι → ℝ}
   rw [key]
   exact add_nonneg (mul_nonneg ha (hf S)) (mul_nonneg hb (hf (symmDiff S C)))
 
-/-- The numerator of `⟨σ_A⟩` is non-negative for ferromagnetic parameters.
+/-- The Boltzmann weight has non-negative correlations for ferromagnetic parameters.
 
-Proof strategy: factor `exp(-βH)` using `exp_sign_decomp` into a product
-of terms `(cosh + sinh · σ^edge)` and `(cosh + sinh · σ^site)`, then
-apply `hasNonnegCorrelations_mul` inductively starting from
-`hasNonnegCorrelations_one`.
+This is the key technical lemma for GKS-I. The proof factors `exp(-βH)` as
+a product of terms `(cosh(βJ) + sinh(βJ) · σ^edge)` and
+`(cosh(βh) + sinh(βh) · σ^site)`, then applies `hasNonnegCorrelations_mul`
+inductively starting from `hasNonnegCorrelations_one`.
 
-TODO: prove without sorry. Requires factoring exp(-βH) and applying
-the preservation lemma inductively over edges and sites. -/
+TODO: prove without sorry. Requires:
+1. `exp(∑ f) = ∏ exp(f i)` (mathlib: `Real.exp_sum`)
+2. Decomposition of `hamiltonian` into edge and site sums
+3. `exp_sign_decomp` for each factor
+4. `edgeSpin σ e ∈ {-1, 1}` and `Spin.sign (σ i) ∈ {-1, 1}`
+5. Inductive application of `hasNonnegCorrelations_mul` over edges then sites
+-/
+theorem boltzmannWeight_hasNonnegCorrelations (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    HasNonnegCorrelations (boltzmannWeight G p) := by
+  sorry
+
+/-- The numerator of `⟨σ_A⟩` is non-negative for ferromagnetic parameters. -/
 theorem gks_numerator_nonneg (G : SimpleGraph ι) [Fintype G.edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p) (A : Finset ι) :
-    0 ≤ numerator G p (spinProduct A) := by
-  sorry
+    0 ≤ numerator G p (spinProduct A) :=
+  boltzmannWeight_hasNonnegCorrelations G p hf A
 
 /-! ## GKS-I: main theorem -/
 

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -194,6 +194,25 @@ theorem hasNonnegCorrelations_mul {f : Config ι → ℝ}
   exact add_nonneg (mul_nonneg ha (hf S)) (mul_nonneg hb (hf (symmDiff S C)))
 
 set_option linter.unusedDecidableInType false in
+/-- Multiplying a function with HNC by a product of `(a + b · σ^C)` factors preserves HNC. -/
+theorem hasNonnegCorrelations_mul_prod {α : Type*} [DecidableEq α]
+    (S : Finset α) {f : Config ι → ℝ} (hf : HasNonnegCorrelations f)
+    (g : α → Config ι → ℝ)
+    (hg : ∀ a ∈ S, ∃ c d : ℝ, ∃ C : Finset ι, 0 ≤ c ∧ 0 ≤ d ∧
+      ∀ σ, g a σ = c + d * spinProduct C σ) :
+    HasNonnegCorrelations fun σ => f σ * ∏ a ∈ S, g a σ := by
+  induction S using Finset.induction with
+  | empty => simpa using hf
+  | @insert x S' hx ih =>
+    rw [show (fun σ => f σ * ∏ a ∈ insert x S', g a σ) =
+        fun σ => (f σ * ∏ a ∈ S', g a σ) * g x σ from by
+      ext σ; rw [Finset.prod_insert hx]; ring]
+    obtain ⟨c, d, C, hc, hd, hg_eq⟩ := hg x (Finset.mem_insert_self x S')
+    simp_rw [hg_eq]
+    exact hasNonnegCorrelations_mul
+      (ih fun a ha' => hg a (Finset.mem_insert_of_mem ha')) hc hd C
+
+set_option linter.unusedDecidableInType false in
 /-- A product of `(a + b · σ^C)` factors over a finset has non-negative correlations,
 provided each `a, b ≥ 0`. Proved by induction on the finset, applying
 `hasNonnegCorrelations_mul` at each step. -/
@@ -263,27 +282,59 @@ private theorem bwFactored_hasNonnegCorrelations (G : SimpleGraph ι) [Fintype G
   have hsJ := Real.sinh_nonneg_iff.mpr (mul_nonneg hf.hβ.le hf.hJ)
   have hcH := Real.cosh_pos (p.β * p.h) |>.le
   have hsH := Real.sinh_nonneg_iff.mpr (mul_nonneg hf.hβ.le hf.hh)
+  -- Edge factors have HNC
   have hedge : HasNonnegCorrelations fun σ =>
       ∏ e ∈ G.edgeFinset, (Real.cosh (p.β * p.J) +
         Real.sinh (p.β * p.J) * edgeSpin (K := ℝ) σ e) := by
     apply hasNonnegCorrelations_finset_prod
-    intro e _
-    -- edgeSpin σ e is ±1, so it equals spinProduct for some C
-    sorry
-  have hsite : ∀ (f : Config ι → ℝ), HasNonnegCorrelations f →
-      HasNonnegCorrelations fun σ => f σ *
-        ∏ i : ι, (Real.cosh (p.β * p.h) +
-          Real.sinh (p.β * p.h) * Spin.sign ℝ (σ i)) := by
-    intro f hf
-    -- Induct over Finset.univ for sites
-    sorry
-  exact hsite _ hedge
+    intro e he
+    obtain ⟨⟨i, j⟩, rfl⟩ := Quot.exists_rep e
+    have hne : i ≠ j := by
+      intro h; subst h
+      have hadj := SimpleGraph.mem_edgeFinset.mp he
+      rw [SimpleGraph.mem_edgeSet] at hadj
+      exact hadj.ne rfl
+    exact ⟨_, _, {i, j}, hcJ, hsJ, fun σ => by
+      simp [edgeSpin, Sym2.lift_mk, spinProduct, Finset.prod_pair hne, Spin.sign]⟩
+  -- Multiply edge product by site factors
+  have hsite := hasNonnegCorrelations_mul_prod Finset.univ hedge
+      (fun i σ => Real.cosh (p.β * p.h) + Real.sinh (p.β * p.h) * Spin.sign ℝ (σ i))
+      (fun i _ => ⟨_, _, {i}, hcH, hsH, fun σ => by
+        simp [spinProduct, Spin.sign]⟩)
+  -- Combine: bwFactored = edge_prod * site_prod
+  convert hsite using 1
 
+set_option linter.unusedDecidableInType false in
+set_option linter.unusedSectionVars false in
 /-- The factored form equals the Boltzmann weight. -/
 private theorem bwFactored_eq_boltzmannWeight (G : SimpleGraph ι) [Fintype G.edgeSet]
     (p : IsingParams ℝ) (σ : Config ι) :
     bwFactored G p σ = boltzmannWeight G p σ := by
-  sorry
+  unfold bwFactored boltzmannWeight hamiltonian interactionEnergy externalFieldEnergy
+  -- RHS: exp(-β * (-J * ∑_e edgeSpin - h * ∑_i sign)) = exp(βJ * ∑_e edgeSpin + βh * ∑_i sign)
+  rw [show -p.β * (-(p.J) * ∑ e ∈ G.edgeFinset, edgeSpin σ e +
+      -(p.h) * ∑ i : ι, Spin.sign ℝ (σ i)) =
+      p.β * p.J * ∑ e ∈ G.edgeFinset, edgeSpin σ e +
+      p.β * p.h * ∑ i : ι, Spin.sign ℝ (σ i) from by ring]
+  rw [Real.exp_add]
+  -- exp(βJ * ∑ edgeSpin) = ∏ exp(βJ * edgeSpin e)
+  rw [show p.β * p.J * ∑ e ∈ G.edgeFinset, edgeSpin (K := ℝ) σ e =
+      ∑ e ∈ G.edgeFinset, p.β * p.J * edgeSpin (K := ℝ) σ e from by
+    rw [Finset.mul_sum]]
+  rw [Real.exp_sum]
+  -- exp(βh * ∑ sign) = ∏ exp(βh * sign(σ i))
+  rw [show p.β * p.h * ∑ i : ι, Spin.sign ℝ (σ i) =
+      ∑ i : ι, p.β * p.h * Spin.sign ℝ (σ i) from by
+    rw [Finset.mul_sum]]
+  rw [Real.exp_sum]
+  -- Each exp(βJ * edgeSpin) = cosh + sinh * edgeSpin
+  congr 1
+  · apply Finset.prod_congr rfl; intro e _
+    exact (exp_edgeSpin_decomp (p.β * p.J) σ e).symm
+  · apply Finset.prod_congr rfl; intro i _
+    simp only [Spin.sign]
+    rw [exp_sign_decomp (p.β * p.h) (σ i)]
+    ring
 
 theorem boltzmannWeight_hasNonnegCorrelations (G : SimpleGraph ι) [Fintype G.edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p) :

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -1,0 +1,80 @@
+import IsingModel.GibbsMeasure
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+
+/-!
+# GKS (Griffiths) inequalities
+
+The first Griffiths inequality for the ferromagnetic Ising model:
+for `J ≥ 0`, `h ≥ 0`, `β > 0`, the correlation `⟨σ_A⟩ ≥ 0`.
+
+Reference: Glimm–Jaffe, *Quantum Physics*, Theorem 4.1.1.
+-/
+
+namespace IsingModel
+
+open Finset Real
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-! ## Numerator of the Gibbs expectation -/
+
+/-- The unnormalized expectation (numerator): `∑_σ F(σ) · exp(-β H(σ))`. -/
+noncomputable def numerator (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (F : Config ι → ℝ) : ℝ :=
+  ∑ σ : Config ι, F σ * boltzmannWeight G p σ
+
+/-- The Gibbs expectation equals `Z⁻¹ · numerator`. -/
+theorem gibbsExpectation_eq_div (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (F : Config ι → ℝ) :
+    gibbsExpectation G p F = (partitionFunction G p)⁻¹ * numerator G p F := by
+  unfold gibbsExpectation numerator
+  rfl
+
+/-- If the numerator is non-negative, then the Gibbs expectation is non-negative. -/
+theorem gibbsExpectation_nonneg_of_numerator_nonneg (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (F : Config ι → ℝ)
+    (hnum : 0 ≤ numerator G p F) :
+    0 ≤ gibbsExpectation G p F := by
+  rw [gibbsExpectation_eq_div]
+  exact mul_nonneg (inv_nonneg.mpr (le_of_lt (partitionFunction_pos G p))) hnum
+
+/-! ## Auxiliary: exp decomposition for ±1 spins -/
+
+/-- For `s ∈ {+1, -1}`, `exp(α * s) = cosh(α) + s * sinh(α)`. -/
+theorem exp_sign_decomp (α : ℝ) (s : Spin) :
+    Real.exp (α * ↑s.toSign) = Real.cosh α + ↑s.toSign * Real.sinh α := by
+  cases s with
+  | up => simp [Spin.toSign, Real.cosh_add_sinh]
+  | down =>
+    simp only [Spin.toSign, Int.cast_neg, Int.cast_one, mul_neg, mul_one, neg_mul, one_mul]
+    linarith [Real.cosh_add_sinh α, Real.sinh_add_cosh α,
+              Real.cosh_add_sinh (-α), Real.sinh_add_cosh (-α),
+              Real.cosh_neg α, Real.sinh_neg α]
+
+/-! ## GKS-I: core non-negativity -/
+
+/-- The numerator of `⟨σ_A⟩` is non-negative for ferromagnetic parameters.
+
+This is the core of GKS-I. The proof uses the cosh/sinh decomposition of
+the Boltzmann weight and the fact that sums over `{±1}` configurations
+vanish for odd powers and are positive for even powers.
+
+TODO: complete the proof (currently `sorry`).
+-/
+theorem gks_numerator_nonneg (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (A : Finset ι) :
+    0 ≤ numerator G p (spinProduct A) := by
+  sorry
+
+/-! ## GKS-I: main theorem -/
+
+/-- **First Griffiths inequality (GKS-I)**: For a ferromagnetic Ising model
+(`J ≥ 0`, `h ≥ 0`, `β > 0`), all correlation functions are non-negative:
+`⟨σ_A⟩ ≥ 0` for any subset `A`. -/
+theorem gks_first (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (A : Finset ι) :
+    0 ≤ correlation G p A := by
+  unfold correlation
+  exact gibbsExpectation_nonneg_of_numerator_nonneg G p _ (gks_numerator_nonneg G p hf A)
+
+end IsingModel

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -124,15 +124,30 @@ theorem sum_config_spinProduct_empty :
 
 /-! ## Spin product multiplication (Fourier structure) -/
 
-omit [Fintype ι] in
+set_option linter.unusedFintypeInType false in
 /-- Multiplying spin products corresponds to symmetric difference of index sets.
 This follows from `s(σ_i)² = 1`: shared indices cancel.
 
-TODO: prove without sorry. The proof requires splitting products over
-`A \ C`, `A ∩ C`, `C \ A` and using `s(σ_i)² = 1` on the intersection. -/
+The proof converts each `spinProduct S σ` to `∏ i ∈ univ, if i ∈ S then s_i else 1`,
+multiplies pointwise using `prod_mul_distrib`, and checks each factor by cases on
+membership in `A` and `C`, using `s_i² = 1`. -/
 theorem spinProduct_mul (A C : Finset ι) (σ : Config ι) :
     spinProduct A σ * spinProduct C σ = spinProduct (symmDiff A C) σ := by
-  sorry
+  let s : ι → ℝ := fun i => ↑(σ i).toSign
+  have hsq : ∀ i, s i * s i = 1 :=
+    fun i => by simp [s, ← sq, ← Int.cast_pow, Spin.toSign_sq]
+  -- Rewrite spinProduct as ∏ over univ with indicator
+  have hprod : ∀ S : Finset ι, spinProduct S σ =
+      ∏ i ∈ Finset.univ, if i ∈ S then s i else 1 := by
+    intro S
+    simp only [spinProduct, s]
+    conv_lhs => rw [show S = Finset.univ.filter (· ∈ S) from by ext; simp]
+    rw [Finset.prod_filter]
+  rw [hprod A, hprod C, ← Finset.prod_mul_distrib, hprod]
+  apply Finset.prod_congr rfl
+  intro i _
+  simp only [Finset.mem_symmDiff]
+  by_cases hiA : i ∈ A <;> by_cases hiC : i ∈ C <;> simp_all [hsq i]
 
 /-! ## Preservation of non-negative correlations -/
 

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -53,6 +53,24 @@ theorem exp_sign_decomp (α : ℝ) (s : Spin) :
 
 /-! ## GKS-I: core non-negativity -/
 
+/-! ## Sum over configurations -/
+
+/-- The sum of `toSign(s)` over all spins is zero: `1 + (-1) = 0`. -/
+theorem sum_spin_toSign : ∑ s : Spin, (↑s.toSign : ℝ) = 0 := by
+  have : Fintype.elems (α := Spin) = {.up, .down} := by decide
+  simp [Finset.sum, Finset.univ, this, Spin.toSign]
+
+/-- The sum of `spinProduct A` over all configurations is zero when `A` is nonempty.
+This is because each site `i ∈ A` contributes a factor `∑_{s=±1} s = 0`. -/
+theorem sum_config_spinProduct_eq_zero (A : Finset ι) (hA : A.Nonempty) :
+    ∑ σ : Config ι, spinProduct A σ = 0 := by
+  sorry
+
+/-- The sum of `spinProduct ∅` over all configurations is `2^|ι|`. -/
+theorem sum_config_spinProduct_empty :
+    ∑ σ : Config ι, spinProduct ∅ σ = (Fintype.card (Config ι) : ℝ) := by
+  simp [spinProduct_empty]
+
 /-- The numerator of `⟨σ_A⟩` is non-negative for ferromagnetic parameters.
 
 This is the core of GKS-I. The proof uses the cosh/sinh decomposition of

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -1,5 +1,6 @@
 import IsingModel.GibbsMeasure
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+import Mathlib.Data.Finset.SymmDiff
 
 /-!
 # GKS (Griffiths) inequalities
@@ -51,8 +52,6 @@ theorem exp_sign_decomp (α : ℝ) (s : Spin) :
               Real.cosh_add_sinh (-α), Real.sinh_add_cosh (-α),
               Real.cosh_neg α, Real.sinh_neg α]
 
-/-! ## GKS-I: core non-negativity -/
-
 /-! ## Sum over configurations -/
 
 /-- The sum of `toSign(s)` over all spins is zero: `1 + (-1) = 0`. -/
@@ -72,6 +71,18 @@ theorem Config.flipAt_flipAt {ι : Type*} [DecidableEq ι] (j : ι) (σ : Config
   simp [Config.flipAt, Function.update]
   split <;> simp_all
 
+/-- A flipped spin is different from the original. -/
+theorem Spin.flip_ne (s : Spin) : s.flip ≠ s := by
+  cases s <;> simp [Spin.flip]
+
+omit [Fintype ι] in
+/-- Flipping at any site produces a different configuration. -/
+theorem Config.flipAt_ne (j : ι) (σ : Config ι) : σ.flipAt j ≠ σ := by
+  intro h
+  have h1 := congr_fun h j
+  simp only [Config.flipAt, Function.update_self] at h1
+  exact absurd h1 (Spin.flip_ne (σ j))
+
 omit [Fintype ι] in
 /-- Flipping at `j ∈ A` negates the spin product.
 The factor at `j` changes sign; all other factors are unchanged. -/
@@ -88,18 +99,6 @@ theorem spinProduct_flipAt_neg (A : Finset ι) (j : ι) (hj : j ∈ A)
     simp [Config.flipAt, Function.update_of_ne hne]
   rw [hj_flip, Finset.prod_congr rfl hrest]
   ring
-
-/-- A flipped spin is different from the original. -/
-theorem Spin.flip_ne (s : Spin) : s.flip ≠ s := by
-  cases s <;> simp [Spin.flip]
-
-omit [Fintype ι] in
-/-- Flipping at any site produces a different configuration. -/
-theorem Config.flipAt_ne (j : ι) (σ : Config ι) : σ.flipAt j ≠ σ := by
-  intro h
-  have h1 := congr_fun h j
-  simp only [Config.flipAt, Function.update_self] at h1
-  exact absurd h1 (Spin.flip_ne (σ j))
 
 /-- The sum of `spinProduct A` over all configurations is zero when `A` is nonempty.
 Uses the involution `flipAt j` for some `j ∈ A`: each pair `(σ, flipAt j σ)`
@@ -123,14 +122,58 @@ theorem sum_config_spinProduct_empty :
     ∑ σ : Config ι, spinProduct ∅ σ = (Fintype.card (Config ι) : ℝ) := by
   simp [spinProduct_empty]
 
+/-! ## Spin product multiplication (Fourier structure) -/
+
+omit [Fintype ι] in
+/-- Multiplying spin products corresponds to symmetric difference of index sets.
+This follows from `s(σ_i)² = 1`: shared indices cancel.
+
+TODO: prove without sorry. The proof requires splitting products over
+`A \ C`, `A ∩ C`, `C \ A` and using `s(σ_i)² = 1` on the intersection. -/
+theorem spinProduct_mul (A C : Finset ι) (σ : Config ι) :
+    spinProduct A σ * spinProduct C σ = spinProduct (symmDiff A C) σ := by
+  sorry
+
+/-! ## Preservation of non-negative correlations -/
+
+/-- A function `f` on configurations has **non-negative correlations** if
+`∑_σ σ^S · f(σ) ≥ 0` for every subset `S`. -/
+def HasNonnegCorrelations (f : Config ι → ℝ) : Prop :=
+  ∀ S : Finset ι, 0 ≤ ∑ σ : Config ι, spinProduct S σ * f σ
+
+/-- The constant function `1` has non-negative correlations.
+For `S = ∅`, the sum is `2^|ι|`. For `S ≠ ∅`, it is `0`. -/
+theorem hasNonnegCorrelations_one : HasNonnegCorrelations (ι := ι) (fun _ => 1) := by
+  intro S
+  simp only [mul_one]
+  by_cases hS : S.Nonempty
+  · rw [sum_config_spinProduct_eq_zero S hS]
+  · simp only [not_nonempty_iff_eq_empty] at hS
+    subst hS
+    exact Finset.sum_nonneg fun _ _ => by norm_num
+
+/-- If `f` has non-negative correlations, then so does `f · (a + b · σ^C)`
+when `a, b ≥ 0`. This is the key inductive step for GKS-I.
+
+The proof uses: `∑_σ σ^S f(σ)(a + b σ^C) = a ∑_σ σ^S f(σ) + b ∑_σ σ^{S Δ C} f(σ)`,
+where both terms are non-negative by hypothesis.
+
+TODO: prove without sorry. Requires spinProduct_mul and sum rearrangement. -/
+theorem hasNonnegCorrelations_mul {f : Config ι → ℝ}
+    (hf : HasNonnegCorrelations f)
+    {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (C : Finset ι) :
+    HasNonnegCorrelations fun σ => f σ * (a + b * spinProduct C σ) := by
+  sorry
+
 /-- The numerator of `⟨σ_A⟩` is non-negative for ferromagnetic parameters.
 
-This is the core of GKS-I. The proof uses the cosh/sinh decomposition of
-the Boltzmann weight and the fact that sums over `{±1}` configurations
-vanish for odd powers and are positive for even powers.
+Proof strategy: factor `exp(-βH)` using `exp_sign_decomp` into a product
+of terms `(cosh + sinh · σ^edge)` and `(cosh + sinh · σ^site)`, then
+apply `hasNonnegCorrelations_mul` inductively starting from
+`hasNonnegCorrelations_one`.
 
-TODO: complete the proof (currently `sorry`).
--/
+TODO: prove without sorry. Requires factoring exp(-βH) and applying
+the preservation lemma inductively over edges and sites. -/
 theorem gks_numerator_nonneg (G : SimpleGraph ι) [Fintype G.edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p) (A : Finset ι) :
     0 ≤ numerator G p (spinProduct A) := by

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -60,11 +60,63 @@ theorem sum_spin_toSign : ∑ s : Spin, (↑s.toSign : ℝ) = 0 := by
   have : Fintype.elems (α := Spin) = {.up, .down} := by decide
   simp [Finset.sum, Finset.univ, this, Spin.toSign]
 
+/-- Flip a configuration at a single site `j`. -/
+def Config.flipAt {ι : Type*} [DecidableEq ι] (j : ι) (σ : Config ι) : Config ι :=
+  Function.update σ j (σ j).flip
+
+/-- `flipAt j` is an involution. -/
+@[simp]
+theorem Config.flipAt_flipAt {ι : Type*} [DecidableEq ι] (j : ι) (σ : Config ι) :
+    (σ.flipAt j).flipAt j = σ := by
+  ext i
+  simp [Config.flipAt, Function.update]
+  split <;> simp_all
+
+omit [Fintype ι] in
+/-- Flipping at `j ∈ A` negates the spin product.
+The factor at `j` changes sign; all other factors are unchanged. -/
+theorem spinProduct_flipAt_neg (A : Finset ι) (j : ι) (hj : j ∈ A)
+    (σ : Config ι) :
+    spinProduct A (σ.flipAt j) = -spinProduct A σ := by
+  unfold spinProduct
+  rw [← Finset.mul_prod_erase _ _ hj, ← Finset.mul_prod_erase _ _ hj]
+  have hj_flip : (↑((σ.flipAt j j).toSign) : ℝ) = -↑(σ j).toSign := by
+    simp [Config.flipAt, Function.update_self, Spin.toSign_flip]
+  have hrest : ∀ i ∈ A.erase j, (↑((σ.flipAt j i).toSign) : ℝ) = ↑(σ i).toSign := by
+    intro i hi
+    have hne : i ≠ j := Finset.ne_of_mem_erase hi
+    simp [Config.flipAt, Function.update_of_ne hne]
+  rw [hj_flip, Finset.prod_congr rfl hrest]
+  ring
+
+/-- A flipped spin is different from the original. -/
+theorem Spin.flip_ne (s : Spin) : s.flip ≠ s := by
+  cases s <;> simp [Spin.flip]
+
+omit [Fintype ι] in
+/-- Flipping at any site produces a different configuration. -/
+theorem Config.flipAt_ne (j : ι) (σ : Config ι) : σ.flipAt j ≠ σ := by
+  intro h
+  have h1 := congr_fun h j
+  simp only [Config.flipAt, Function.update_self] at h1
+  exact absurd h1 (Spin.flip_ne (σ j))
+
 /-- The sum of `spinProduct A` over all configurations is zero when `A` is nonempty.
-This is because each site `i ∈ A` contributes a factor `∑_{s=±1} s = 0`. -/
+Uses the involution `flipAt j` for some `j ∈ A`: each pair `(σ, flipAt j σ)`
+contributes `spinProduct A σ + spinProduct A (flipAt j σ) = 0`. -/
 theorem sum_config_spinProduct_eq_zero (A : Finset ι) (hA : A.Nonempty) :
     ∑ σ : Config ι, spinProduct A σ = 0 := by
-  sorry
+  obtain ⟨j, hj⟩ := hA
+  apply Finset.sum_ninvolution (Config.flipAt j)
+  · intro σ
+    rw [spinProduct_flipAt_neg A j hj σ]
+    ring
+  · intro σ _
+    exact fun h => Config.flipAt_ne j σ h
+  · intro _
+    exact Finset.mem_univ _
+  · intro σ
+    exact Config.flipAt_flipAt j σ
 
 /-- The sum of `spinProduct ∅` over all configurations is `2^|ι|`. -/
 theorem sum_config_spinProduct_empty :

--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ inequalities; the thermodynamic limit and related topics are out of scope for
 now. This project is not intended to interfere with the work of researchers in
 the field, and if any overlap arises I am happy to coordinate accordingly.
 
+## Documentation
+
+Mathematical documentation for the formalized proofs is in `docs/` as
+LaTeX source files. To compile:
+
+```sh
+cd docs
+latexmk -lualatex gks-proof-guide.tex
+```
+
+Requires a TeX Live installation with LuaLaTeX. PDFs are not committed
+to the repository.
+
+| File                       | Description                                 |
+|----------------------------|---------------------------------------------|
+| `docs/gks-proof-guide.tex` | Mathematical walkthrough of the GKS-I proof |
+
 ## Related projects and references
 
 - Glimm, J. and Jaffe, A., *Quantum Physics: A Functional Integral Point of View* — [Springer](https://link.springer.com/book/10.1007/978-1-4612-4728-9)

--- a/docs/gks-proof-guide.tex
+++ b/docs/gks-proof-guide.tex
@@ -1,0 +1,257 @@
+\documentclass[a4paper,11pt]{article}
+
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{amsthm}
+\usepackage{hyperref}
+
+\newtheorem{theorem}{Theorem}
+\newtheorem{lemma}[theorem]{Lemma}
+\newtheorem{definition}[theorem]{Definition}
+\newtheorem{remark}[theorem]{Remark}
+
+\title{GKS-I Formal Proof: A Mathematical Guide to the Lean 4 Code}
+\author{ising-model project}
+\date{2026-04-10}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This document provides a mathematical walkthrough of the Lean~4
+formalization of the first Griffiths inequality (GKS-I) for
+the finite Ising model. Each section corresponds to a Lean source file
+and lists the relevant definitions and theorems. The purpose is to
+make the formal proof readable as ordinary mathematics.
+\end{abstract}
+
+\tableofcontents
+
+\section{Basic definitions (\texttt{Basic.lean})}
+
+\begin{definition}[Spin]
+$\mathrm{Spin} = \{\mathrm{up}, \mathrm{down}\}$ with sign function
+$s : \mathrm{Spin} \to \mathbb{Z}$, $s(\mathrm{up})=+1$,
+$s(\mathrm{down})=-1$.
+\end{definition}
+
+\noindent\textbf{Lean:} \texttt{inductive Spin}, \texttt{Spin.toSign}
+
+\begin{definition}[Configuration]
+A configuration on a type $\iota$ is a function
+$\sigma : \iota \to \mathrm{Spin}$.
+\end{definition}
+
+\noindent\textbf{Lean:} \texttt{abbrev Config ($\iota$) := $\iota$ $\to$ Spin}
+
+\begin{definition}[Ising parameters]
+Over an ordered field $K$: coupling $J : K$, external field $h : K$,
+inverse temperature $\beta : K$.
+Ferromagnetic condition: $J \geq 0$, $h \geq 0$, $\beta > 0$.
+\end{definition}
+
+\noindent\textbf{Lean:} \texttt{structure IsingParams},
+\texttt{structure Ferromagnetic}
+
+\section{Hamiltonian (\texttt{Hamiltonian.lean})}
+
+\begin{definition}[Ising Hamiltonian]
+For a simple graph $G$ on $\iota$,
+\[
+  H_G(\sigma) = -J \sum_{\{i,j\} \in E(G)} s(\sigma_i)\,s(\sigma_j)
+  - h \sum_{i \in \iota} s(\sigma_i).
+\]
+\end{definition}
+
+\noindent\textbf{Lean:} \texttt{interactionEnergy} $+$
+\texttt{externalFieldEnergy} $=$ \texttt{hamiltonian}
+
+Key auxiliary definitions:
+\begin{itemize}
+  \item \texttt{Spin.flip}: $\mathrm{up} \leftrightarrow \mathrm{down}$
+  \item \texttt{Spin.sign $K$ $s$}: cast $s(\cdot)$ into the field $K$
+  \item \texttt{edgeSpin}: $s(\sigma_i) \cdot s(\sigma_j)$ for an edge
+    $\{i,j\}$, defined via \texttt{Sym2.lift}
+\end{itemize}
+
+\begin{lemma}[Spin flip symmetry --- \texttt{hamiltonian\_flip\_eq}]
+If $h = 0$, then $H_G(\bar{\sigma}) = H_G(\sigma)$ where
+$\bar{\sigma}_i = \mathrm{flip}(\sigma_i)$.
+\end{lemma}
+
+\begin{proof}
+Each edge factor satisfies $(-s_i)(-s_j) = s_i s_j$
+(\texttt{edgeSpin\_flip}), and the field term vanishes since $h=0$.
+\end{proof}
+
+\section{Partition function and Gibbs measure (\texttt{GibbsMeasure.lean})}
+
+\begin{definition}[Partition function]
+$Z_G = \sum_{\sigma : \iota \to \mathrm{Spin}} \exp(-\beta\, H_G(\sigma))$.
+\end{definition}
+
+\begin{theorem}[$Z > 0$ --- \texttt{partitionFunction\_pos}]
+$Z_G > 0$.
+\end{theorem}
+
+\begin{proof}
+Each summand $\exp(\cdot) > 0$ (\texttt{Real.exp\_pos}), and the
+index set $\iota \to \mathrm{Spin}$ is nonempty
+(\texttt{Finset.univ\_nonempty}).
+Apply \texttt{Finset.sum\_pos}.
+\end{proof}
+
+\begin{definition}[Gibbs expectation, correlation]
+$\langle F \rangle = Z^{-1} \sum_\sigma F(\sigma)\,e^{-\beta H}$, \quad
+$\langle \sigma_A \rangle = \langle \prod_{i \in A} s(\sigma_i) \rangle$.
+\end{definition}
+
+\noindent\textbf{Lean:} \texttt{gibbsExpectation},
+\texttt{spinProduct}, \texttt{correlation}
+
+\subsection{Spin product algebra}
+
+\begin{lemma}[\texttt{spinProduct\_sq}]
+$(\sigma^A)^2 = 1$ for any $A$.
+\end{lemma}
+
+\begin{lemma}[\texttt{spinProduct\_mul}]
+$\sigma^A \cdot \sigma^C = \sigma^{A \bigtriangleup C}$.
+\end{lemma}
+
+\begin{proof}
+Write $\sigma^A = \prod_{i \in \iota}
+(\text{if } i \in A \text{ then } s_i \text{ else } 1)$
+(using \texttt{Finset.prod\_filter}).
+Multiply pointwise (\texttt{Finset.prod\_mul\_distrib}).
+At each site: if $i \in A \cap C$, $s_i \cdot s_i = 1$ (by
+\texttt{Spin.toSign\_sq}); otherwise the factor is $s_i$ or $1$,
+matching $A \bigtriangleup C$.
+\end{proof}
+
+\section{GKS-I proof (\texttt{Inequalities/GKS.lean})}
+
+\subsection{Reduction to non-negative correlations}
+
+\begin{theorem}[GKS-I --- \texttt{gks\_first}]
+For ferromagnetic parameters, $\langle \sigma_A \rangle \geq 0$
+for all $A$.
+\end{theorem}
+
+The proof factors as:
+\begin{enumerate}
+  \item Since $Z > 0$, it suffices to show the numerator
+    $\sum_\sigma \sigma^A e^{-\beta H} \geq 0$
+    (\texttt{gibbsExpectation\_nonneg\_of\_numerator\_nonneg}).
+  \item This follows from a property of $e^{-\beta H}$ called
+    \emph{non-negative correlations}
+    (\texttt{gks\_numerator\_nonneg}).
+\end{enumerate}
+
+\subsection{Non-negative correlations (HNC)}
+
+\begin{definition}[\texttt{HasNonnegCorrelations}]
+A function $f : (\iota \to \mathrm{Spin}) \to \mathbb{R}$ has
+\textbf{non-negative correlations} (HNC) if
+$\sum_\sigma \sigma^S \cdot f(\sigma) \geq 0$ for every
+$S \subseteq \iota$.
+\end{definition}
+
+\begin{lemma}[Base case --- \texttt{hasNonnegCorrelations\_one}]
+$f \equiv 1$ has HNC.
+\end{lemma}
+
+\begin{proof}
+For $S = \emptyset$: $\sum_\sigma 1 = 2^{|\iota|} > 0$.
+For $S \neq \emptyset$: $\sum_\sigma \sigma^S = 0$.
+
+The vanishing is proved via the involution
+$\mathrm{flipAt}(j)$ for any $j \in S$
+(\texttt{sum\_config\_spinProduct\_eq\_zero}).
+Each pair $(\sigma, \mathrm{flipAt}(j, \sigma))$ contributes
+$\sigma^S + (-\sigma^S) = 0$ because flipping at $j \in S$ negates
+the spin product (\texttt{spinProduct\_flipAt\_neg}).
+The involution is applied via \texttt{Finset.sum\_ninvolution}.
+\end{proof}
+
+\begin{lemma}[Preservation --- \texttt{hasNonnegCorrelations\_mul}]
+\label{lem:mul}
+If $f$ has HNC and $a, b \geq 0$, then
+$\sigma \mapsto f(\sigma)(a + b\,\sigma^C)$ has HNC.
+\end{lemma}
+
+\begin{proof}
+\[
+  \sum_\sigma \sigma^S f(\sigma)(a + b\,\sigma^C)
+  = a \underbrace{\sum_\sigma \sigma^S f(\sigma)}_{\geq 0}
+  + b \underbrace{\sum_\sigma \sigma^{S \bigtriangleup C} f(\sigma)}_{\geq 0}
+\]
+using $\sigma^S \sigma^C = \sigma^{S \bigtriangleup C}$
+(\texttt{spinProduct\_mul}).
+\end{proof}
+
+\begin{lemma}[Iterated product --- \texttt{hasNonnegCorrelations\_finset\_prod},
+\texttt{hasNonnegCorrelations\_mul\_prod}]
+A product of factors $(a_k + b_k \sigma^{C_k})$ with $a_k, b_k \geq 0$
+has HNC. More generally, multiplying an HNC function by such a product
+preserves HNC.
+\end{lemma}
+
+\begin{proof}
+By induction on the index set, applying Lemma~\ref{lem:mul} at each step.
+\end{proof}
+
+\subsection{Factoring the Boltzmann weight}
+
+\begin{lemma}[\texttt{exp\_sign\_decomp}, \texttt{exp\_edgeSpin\_decomp}]
+For $x \in \{+1, -1\}$ and $\alpha \geq 0$:
+$e^{\alpha x} = \cosh\alpha + x\,\sinh\alpha$,
+with $\cosh\alpha > 0$ and $\sinh\alpha \geq 0$.
+\end{lemma}
+
+\begin{lemma}[\texttt{bwFactored\_eq\_boltzmannWeight}]
+\[
+  e^{-\beta H_G(\sigma)}
+  = \prod_{\{i,j\} \in E(G)} (\cosh(\beta J) + \sinh(\beta J)\,s_i s_j)
+  \cdot \prod_{i \in \iota} (\cosh(\beta h) + \sinh(\beta h)\,s_i).
+\]
+\end{lemma}
+
+\begin{proof}
+$-\beta H = \beta J \sum_e s_i s_j + \beta h \sum_i s_i$.
+Apply $\exp(\text{sum}) = \prod\exp$ (\texttt{Real.exp\_sum}),
+then decompose each factor.
+\end{proof}
+
+\subsection{Conclusion}
+
+\begin{theorem}[\texttt{boltzmannWeight\_hasNonnegCorrelations}]
+$e^{-\beta H_G}$ has HNC for ferromagnetic parameters.
+\end{theorem}
+
+\begin{proof}
+The factored form is a product of $(a+b\,\sigma^C)$ terms with
+$a,b \geq 0$. Start from $f \equiv 1$ (HNC by base case),
+multiply by each edge factor, then by each site factor. HNC is
+preserved at each step by Lemma~\ref{lem:mul}.
+\end{proof}
+
+\noindent
+GKS-I follows: $\langle \sigma_A \rangle
+= Z^{-1}\sum_\sigma \sigma^A e^{-\beta H} \geq 0$
+since $Z > 0$ and the numerator $\geq 0$ by HNC.
+
+\section{Numerical tests (\texttt{test/IsingModel/GKSTest.lean})}
+
+A Float-based reference implementation verifies:
+\begin{itemize}
+  \item $Z > 0$ for 4 graph types
+  \item Spin flip symmetry ($h = 0$)
+  \item GKS-I for 6 parameter sets (2--4 sites, all subsets)
+  \item GKS-II ($\langle\sigma_A\sigma_B\rangle \geq
+    \langle\sigma_A\rangle\langle\sigma_B\rangle$)
+    for 3 parameter sets
+  \item GKS-I violation for anti-ferromagnetic $J < 0$
+\end{itemize}
+
+\end{document}

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -16,3 +16,7 @@ rev = "v4.29.0"
 
 [[lean_lib]]
 name = "IsingModel"
+
+[[lean_exe]]
+name = "GKSTest"
+root = "test.IsingModel.GKSTest"

--- a/test/IsingModel/GKSTest.lean
+++ b/test/IsingModel/GKSTest.lean
@@ -1,0 +1,157 @@
+-- Numerical verification of GKS and basic Ising model properties
+-- Float-based reference implementation for property testing.
+
+def allSpins : List Float := [1.0, -1.0]
+
+def allConfigs : Nat → List (List Float)
+  | 0 => [[]]
+  | n + 1 => Id.run do
+    let mut result : List (List Float) := []
+    for rest in allConfigs n do
+      for s in allSpins do
+        result := (s :: rest) :: result
+    return result
+
+def testHamiltonian (edges : List (Nat × Nat)) (J hf : Float) (σ : List Float) : Float :=
+  let interaction := edges.foldl (fun acc (i, j) => acc + σ.getD i 0 * σ.getD j 0) 0
+  let field := σ.foldl (· + ·) 0
+  (0.0 - J) * interaction - hf * field
+
+def boltzmann (edges : List (Nat × Nat)) (J h β : Float) (σ : List Float) : Float :=
+  Float.exp (-β * testHamiltonian edges J h σ)
+
+def partitionFn (n : Nat) (edges : List (Nat × Nat)) (J h β : Float) : Float :=
+  (allConfigs n).foldl (fun acc σ => acc + boltzmann edges J h β σ) 0
+
+def gibbsExpect (n : Nat) (edges : List (Nat × Nat)) (J h β : Float)
+    (F : List Float → Float) : Float :=
+  let Z := partitionFn n edges J h β
+  (allConfigs n).foldl (fun acc σ => acc + F σ * boltzmann edges J h β σ) 0 / Z
+
+def spinProd (A : List Nat) (σ : List Float) : Float :=
+  A.foldl (fun acc i => acc * σ.getD i 0) 1
+
+def testCorrelation (n : Nat) (edges : List (Nat × Nat)) (J h β : Float)
+    (A : List Nat) : Float :=
+  gibbsExpect n edges J h β (spinProd A)
+
+-- Test graphs
+
+-- 2-site chain: 0 — 1
+def graph2 : List (Nat × Nat) := [(0, 1)]
+
+-- 3-site chain: 0 — 1 — 2
+def graph3 : List (Nat × Nat) := [(0, 1), (1, 2)]
+
+-- 3-site triangle: 0 — 1 — 2 — 0
+def triangle3 : List (Nat × Nat) := [(0, 1), (1, 2), (0, 2)]
+
+-- 4-site square: 0 — 1 — 2 — 3 — 0
+def square4 : List (Nat × Nat) := [(0, 1), (1, 2), (2, 3), (0, 3)]
+
+-- GKS-I tests
+
+-- Helper: check all subsets up to given size
+def allSubsets (n : Nat) : List (List Nat) :=
+  let sites := List.range n
+  sites.foldl (fun acc i =>
+    acc ++ acc.map (fun s => i :: s)) [[]]
+
+def checkGKS1 (label : String) (n : Nat) (edges : List (Nat × Nat))
+    (J h β : Float) : IO Bool := do
+  let mut ok := true
+  let subsets := allSubsets n
+  for A in subsets do
+    let c := testCorrelation n edges J h β A
+    if c < -1e-10 then
+      IO.println s!"  FAIL: ⟨σ_{A}⟩ = {c} < 0"
+      ok := false
+  if ok then
+    IO.println s!"  {label}: GKS-I passed for all {subsets.length} subsets"
+  return ok
+
+-- GKS-II tests
+
+def checkGKS2 (label : String) (n : Nat) (edges : List (Nat × Nat))
+    (J h β : Float) : IO Bool := do
+  let mut ok := true
+  let subsets := allSubsets n
+  for A in subsets do
+    for B in subsets do
+      let cAB := testCorrelation n edges J h β (A ++ B)
+      let cA := testCorrelation n edges J h β A
+      let cB := testCorrelation n edges J h β B
+      if cAB - cA * cB < -1e-10 then
+        IO.println s!"  FAIL: ⟨σ_{A}σ_{B}⟩ - ⟨σ_{A}⟩⟨σ_{B}⟩ = {cAB - cA * cB} < 0"
+        ok := false
+  if ok then
+    IO.println s!"  {label}: GKS-II passed for all subset pairs"
+  return ok
+
+-- Z > 0 test
+
+def checkZPos (label : String) (n : Nat) (edges : List (Nat × Nat))
+    (J h β : Float) : IO Bool := do
+  let Z := partitionFn n edges J h β
+  if Z > 0 then
+    IO.println s!"  {label}: Z = {Z} > 0 ✓"
+    return true
+  else
+    IO.println s!"  {label}: Z = {Z} NOT > 0 ✗"
+    return false
+
+-- Spin flip symmetry test
+
+def checkFlipSymmetry (label : String) (n : Nat) (edges : List (Nat × Nat))
+    (J : Float) : IO Bool := do
+  let mut ok := true
+  for σ in allConfigs n do
+    let σ_flip := σ.map (· * (-1))
+    let h1 := testHamiltonian edges J 0 σ
+    let h2 := testHamiltonian edges J 0 σ_flip
+    if (h1 - h2).abs > 1e-10 then
+      IO.println s!"  FAIL: H({σ}) = {h1} ≠ H({σ_flip}) = {h2}"
+      ok := false
+  if ok then
+    IO.println s!"  {label}: Spin flip symmetry (h=0) ✓"
+  return ok
+
+-- Main test runner
+
+def main : IO Unit := do
+  IO.println "=== Ising Model Numerical Tests ==="
+  IO.println ""
+
+  IO.println "--- Z > 0 ---"
+  let _ ← checkZPos "2-chain J=1 h=0.5 β=1" 2 graph2 1.0 0.5 1.0
+  let _ ← checkZPos "3-chain J=2 h=0 β=0.5" 3 graph3 2.0 0.0 0.5
+  let _ ← checkZPos "triangle J=1 h=1 β=2" 3 triangle3 1.0 1.0 2.0
+  let _ ← checkZPos "square J=0.5 h=0.3 β=1" 4 square4 0.5 0.3 1.0
+
+  IO.println ""
+  IO.println "--- Spin flip symmetry (h=0) ---"
+  let _ ← checkFlipSymmetry "2-chain J=1" 2 graph2 1.0
+  let _ ← checkFlipSymmetry "triangle J=2" 3 triangle3 2.0
+
+  IO.println ""
+  IO.println "--- GKS-I: ⟨σ_A⟩ ≥ 0 (ferromagnetic) ---"
+  let _ ← checkGKS1 "2-chain J=1 h=0.5 β=1" 2 graph2 1.0 0.5 1.0
+  let _ ← checkGKS1 "2-chain J=1 h=0 β=1" 2 graph2 1.0 0.0 1.0
+  let _ ← checkGKS1 "3-chain J=2 h=0.3 β=0.5" 3 graph3 2.0 0.3 0.5
+  let _ ← checkGKS1 "triangle J=1 h=1 β=2" 3 triangle3 1.0 1.0 2.0
+  let _ ← checkGKS1 "square J=0.5 h=0.3 β=1" 4 square4 0.5 0.3 1.0
+  let _ ← checkGKS1 "square J=3 h=0 β=0.1" 4 square4 3.0 0.0 0.1
+
+  IO.println ""
+  IO.println "--- GKS-II: ⟨σ_Aσ_B⟩ ≥ ⟨σ_A⟩⟨σ_B⟩ (ferromagnetic) ---"
+  let _ ← checkGKS2 "2-chain J=1 h=0.5 β=1" 2 graph2 1.0 0.5 1.0
+  let _ ← checkGKS2 "3-chain J=2 h=0.3 β=0.5" 3 graph3 2.0 0.3 0.5
+  let _ ← checkGKS2 "triangle J=1 h=1 β=2" 3 triangle3 1.0 1.0 2.0
+
+  IO.println ""
+  IO.println "--- GKS-I violation check (anti-ferromagnetic, J < 0) ---"
+  IO.println "  (GKS-I should NOT hold for J < 0)"
+  let _ ← checkGKS1 "2-chain J=-1 h=0 β=1" 2 graph2 (-1.0) 0.0 1.0
+
+  IO.println ""
+  IO.println "=== Done ==="


### PR DESCRIPTION
## Summary
- Formalize GKS-I: ⟨σ_A⟩ ≥ 0 for ferromagnetic Ising model.
- New file `IsingModel/Inequalities/GKS.lean`.
- Work 0005. See `.self-local/tex/0005-gks.tex` for mathematical details.

## Test plan
- [ ] `lake build` passes with zero warnings.