### PR TITLE
fix: investigate and resolve GitHub Pages 404

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -29,3 +29,5 @@ jobs:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
       - uses: leanprover-community/docgen-action@v1
+        with:
+          build-page: false


### PR DESCRIPTION
## Summary
- Investigate why https://phasetr.github.io/ising-model/ returns 404.
- The docs job (doc-gen4) runs on main push and reports success, but
  Pages content is not served.

## Test plan
- [ ] https://phasetr.github.io/ising-model/ returns 200 after fix.