### PR TITLE
chore: refactor GKS-I code and update docs

### DIFF
--- a/IsingModel/Basic.lean
+++ b/IsingModel/Basic.lean
@@ -5,7 +5,7 @@ import Mathlib.Algebra.Order.Ring.Defs
 /-!
 # Ising model: basic definitions
 
-Spin type, configuration space, and Ising parameters.
+Spin type, spin operations, configuration space, and Ising parameters.
 -/
 
 namespace IsingModel
@@ -25,12 +25,85 @@ def toSign : Spin → Int
   | up   =>  1
   | down => -1
 
+/-- Flip a spin: `up ↔ down`. -/
+def flip : Spin → Spin
+  | .up   => .down
+  | .down => .up
+
+/-- The spin sign cast into a commutative ring `K`. -/
+def sign (K : Type*) [CommRing K] (s : Spin) : K := ↑s.toSign
+
+/-- The square of any spin sign is `1`: `(±1)² = 1`. -/
+@[simp]
+theorem toSign_sq (s : Spin) : s.toSign ^ 2 = 1 := by
+  cases s <;> simp [toSign]
+
+/-- The square of the spin sign in `K` is `1`: `(sign K s)² = 1`. -/
+@[simp]
+theorem sign_sq {K : Type*} [CommRing K] (s : Spin) :
+    Spin.sign K s ^ 2 = 1 := by
+  cases s
+  · simp [sign, toSign]
+  · simp [sign, toSign, sq, neg_neg]
+
+/-- Flipping a spin negates its sign: `toSign(flip s) = -toSign(s)`. -/
+@[simp]
+theorem toSign_flip (s : Spin) : s.flip.toSign = -s.toSign := by
+  cases s <;> simp [flip, toSign]
+
+/-- Flipping a spin negates its sign in `K`: `sign K (flip s) = -sign K s`. -/
+@[simp]
+theorem sign_flip {K : Type*} [CommRing K] (s : Spin) :
+    Spin.sign K s.flip = -Spin.sign K s := by
+  cases s <;> simp [sign, flip, toSign]
+
+/-- Flipping twice is the identity. -/
+@[simp]
+theorem flip_flip (s : Spin) : s.flip.flip = s := by
+  cases s <;> rfl
+
+/-- A flipped spin is different from the original. -/
+theorem flip_ne (s : Spin) : s.flip ≠ s := by
+  cases s <;> simp [flip]
+
 end Spin
 
 /-! ## Configuration space -/
 
 /-- A spin configuration on sites of type `ι`. -/
 abbrev Config (ι : Type*) := ι → Spin
+
+namespace Config
+
+/-- Flip all spins in a configuration. -/
+def flip {ι : Type*} (σ : Config ι) : Config ι := fun i => (σ i).flip
+
+/-- Flipping all spins twice recovers the original configuration. -/
+@[simp]
+theorem flip_flip {ι : Type*} (σ : Config ι) : σ.flip.flip = σ := by
+  ext i; exact Spin.flip_flip (σ i)
+
+/-- Flip a configuration at a single site `j`. -/
+def flipAt {ι : Type*} [DecidableEq ι] (j : ι) (σ : Config ι) : Config ι :=
+  Function.update σ j (σ j).flip
+
+/-- `flipAt j` is an involution. -/
+@[simp]
+theorem flipAt_flipAt {ι : Type*} [DecidableEq ι] (j : ι) (σ : Config ι) :
+    (σ.flipAt j).flipAt j = σ := by
+  ext i
+  simp [flipAt, Function.update]
+  split <;> simp_all
+
+/-- Flipping at any site produces a different configuration. -/
+theorem flipAt_ne {ι : Type*} [DecidableEq ι] (j : ι) (σ : Config ι) :
+    σ.flipAt j ≠ σ := by
+  intro h
+  have h1 := congr_fun h j
+  simp only [flipAt, Function.update_self] at h1
+  exact absurd h1 (Spin.flip_ne (σ j))
+
+end Config
 
 /-! ## Ising parameters -/
 

--- a/IsingModel/Hamiltonian.lean
+++ b/IsingModel/Hamiltonian.lean
@@ -11,53 +11,6 @@ with interaction and external field terms.
 
 namespace IsingModel
 
-/-! ## Spin flip -/
-
-/-- Flip a spin: `up ↔ down`. -/
-def Spin.flip : Spin → Spin
-  | .up   => .down
-  | .down => .up
-
-/-- Flip all spins in a configuration. -/
-def Config.flip {ι : Type*} (σ : Config ι) : Config ι := fun i => (σ i).flip
-
-/-- Flipping a spin negates its sign: `toSign(flip s) = -toSign(s)`. -/
-@[simp]
-theorem Spin.toSign_flip (s : Spin) : s.flip.toSign = -s.toSign := by
-  cases s <;> simp [Spin.flip, Spin.toSign]
-
-/-- Flipping twice is the identity. -/
-@[simp]
-theorem Spin.flip_flip (s : Spin) : s.flip.flip = s := by
-  cases s <;> rfl
-
-/-- Flipping all spins twice recovers the original configuration. -/
-@[simp]
-theorem Config.flip_flip {ι : Type*} (σ : Config ι) : σ.flip.flip = σ := by
-  ext i; exact Spin.flip_flip (σ i)
-
-/-! ## Spin sign as field element -/
-
-/-- The spin sign cast into the field `K`. -/
-def Spin.sign (K : Type*) [CommRing K] (s : Spin) : K := ↑s.toSign
-
-/-- The square of any spin sign is `1`: `(±1)² = 1`. -/
-@[simp]
-theorem Spin.toSign_sq (s : Spin) : s.toSign ^ 2 = 1 := by
-  cases s <;> simp [Spin.toSign]
-
-/-- The square of the spin sign in `K` is `1`: `(sign K s)² = 1`. -/
-@[simp]
-theorem Spin.sign_sq {K : Type*} [CommRing K] (s : Spin) :
-    Spin.sign K s ^ 2 = 1 := by
-  simp [Spin.sign, ← Int.cast_pow, Spin.toSign_sq]
-
-/-- Flipping a spin negates its sign in `K`: `sign K (flip s) = -sign K s`. -/
-@[simp]
-theorem Spin.sign_flip {K : Type*} [CommRing K] (s : Spin) :
-    Spin.sign K s.flip = -Spin.sign K s := by
-  cases s <;> simp [Spin.sign, Spin.flip, Spin.toSign]
-
 /-! ## Per-edge interaction -/
 
 /-- Per-edge interaction: `s(σ_i) * s(σ_j)` for an edge `{i, j}`. -/

--- a/IsingModel/Inequalities/GKS.lean
+++ b/IsingModel/Inequalities/GKS.lean
@@ -59,30 +59,6 @@ theorem sum_spin_toSign : ∑ s : Spin, (↑s.toSign : ℝ) = 0 := by
   have : Fintype.elems (α := Spin) = {.up, .down} := by decide
   simp [Finset.sum, Finset.univ, this, Spin.toSign]
 
-/-- Flip a configuration at a single site `j`. -/
-def Config.flipAt {ι : Type*} [DecidableEq ι] (j : ι) (σ : Config ι) : Config ι :=
-  Function.update σ j (σ j).flip
-
-/-- `flipAt j` is an involution. -/
-@[simp]
-theorem Config.flipAt_flipAt {ι : Type*} [DecidableEq ι] (j : ι) (σ : Config ι) :
-    (σ.flipAt j).flipAt j = σ := by
-  ext i
-  simp [Config.flipAt, Function.update]
-  split <;> simp_all
-
-/-- A flipped spin is different from the original. -/
-theorem Spin.flip_ne (s : Spin) : s.flip ≠ s := by
-  cases s <;> simp [Spin.flip]
-
-omit [Fintype ι] in
-/-- Flipping at any site produces a different configuration. -/
-theorem Config.flipAt_ne (j : ι) (σ : Config ι) : σ.flipAt j ≠ σ := by
-  intro h
-  have h1 := congr_fun h j
-  simp only [Config.flipAt, Function.update_self] at h1
-  exact absurd h1 (Spin.flip_ne (σ j))
-
 omit [Fintype ι] in
 /-- Flipping at `j ∈ A` negates the spin product.
 The factor at `j` changes sign; all other factors are unchanged. -/

--- a/docs/gks-proof-guide.tex
+++ b/docs/gks-proof-guide.tex
@@ -29,6 +29,10 @@ make the formal proof readable as ordinary mathematics.
 
 \section{Basic definitions (\texttt{Basic.lean})}
 
+\texttt{Basic.lean} contains all fundamental types (Spin, Config,
+IsingParams, Ferromagnetic) as well as spin operations (flip,
+flipAt, sign, toSign) and their basic properties.
+
 \begin{definition}[Spin]
 $\mathrm{Spin} = \{\mathrm{up}, \mathrm{down}\}$ with sign function
 $s : \mathrm{Spin} \to \mathbb{Z}$, $s(\mathrm{up})=+1$,
@@ -66,10 +70,14 @@ For a simple graph $G$ on $\iota$,
 \noindent\textbf{Lean:} \texttt{interactionEnergy} $+$
 \texttt{externalFieldEnergy} $=$ \texttt{hamiltonian}
 
-Key auxiliary definitions:
+Key auxiliary definitions (in \texttt{Basic.lean}):
 \begin{itemize}
   \item \texttt{Spin.flip}: $\mathrm{up} \leftrightarrow \mathrm{down}$
   \item \texttt{Spin.sign $K$ $s$}: cast $s(\cdot)$ into the field $K$
+  \item \texttt{Config.flip}, \texttt{Config.flipAt}: global and single-site spin flip
+\end{itemize}
+Key auxiliary definitions (in \texttt{Hamiltonian.lean}):
+\begin{itemize}
   \item \texttt{edgeSpin}: $s(\sigma_i) \cdot s(\sigma_j)$ for an edge
     $\{i,j\}$, defined via \texttt{Sym2.lift}
 \end{itemize}


### PR DESCRIPTION
## Summary
- Reorganize auxiliary lemmas across files (Spin flip → Basic.lean, etc.)
- Clean up private definitions in GKS.lean
- Update docs/gks-proof-guide.tex to reflect file/theorem name changes
- Update design docs (.self-local) to match actual module structure

## Test plan
- [ ] `lake build` passes with zero warnings (excluding sorry).
- [ ] `lake exe GKSTest` passes.
- [ ] docs/gks-proof-guide.tex compiles with latexmk.