### PR TITLE
fix: upgrade docgen-action to support build-page input

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -28,6 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
-      - uses: leanprover-community/docgen-action@v1
+      - uses: leanprover-community/docgen-action@main
         with:
           build-page: false


### PR DESCRIPTION
## Summary
- docgen-action@v1 does not recognize `build-page` input, causing docs job failure.
- Upgrade to a version that supports it.

## Test plan
- [ ] CI docs job passes.
- [ ] https://phasetr.github.io/ising-model/ returns 200.