### PR TITLE
feat: FKG inequality for Ising model

### DIFF
--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -3,3 +3,4 @@ import IsingModel.Hamiltonian
 import IsingModel.GibbsMeasure
 import IsingModel.Inequalities.NonnegCorrelations
 import IsingModel.Inequalities.GKS
+import IsingModel.Inequalities.FKG

--- a/IsingModel/Basic.lean
+++ b/IsingModel/Basic.lean
@@ -20,6 +20,37 @@ inductive Spin
 
 namespace Spin
 
+/-- Bijection Spin ≃ Bool: `down ↦ false`, `up ↦ true`. -/
+def toBool : Spin → Bool
+  | .down => false
+  | .up => true
+
+/-- Inverse of `toBool`. -/
+def ofBool : Bool → Spin
+  | false => .down
+  | true => .up
+
+/-- `toBool` is a bijection. -/
+@[simp] theorem ofBool_toBool (s : Spin) : ofBool (toBool s) = s := by cases s <;> rfl
+/-- `ofBool` is a bijection. -/
+@[simp] theorem toBool_ofBool (b : Bool) : toBool (ofBool b) = b := by cases b <;> rfl
+
+/-- Linear order on Spin: `down (-1) < up (+1)`. This induces the product order
+on `Config ι = ι → Spin`, which is the standard order for FKG inequalities. -/
+instance : LinearOrder Spin :=
+  LinearOrder.lift' toBool (fun a b h => by cases a <;> cases b <;> simp [toBool] at h <;> rfl)
+
+/-- `sup` on Spin: `max(down, up) = up`. -/
+@[simp] theorem sup_up_down : (Spin.up ⊔ Spin.down) = Spin.up := by decide
+@[simp] theorem sup_down_up : (Spin.down ⊔ Spin.up) = Spin.up := by decide
+@[simp] theorem sup_up_up : (Spin.up ⊔ Spin.up) = Spin.up := by decide
+@[simp] theorem sup_down_down : (Spin.down ⊔ Spin.down) = Spin.down := by decide
+/-- `inf` on Spin: `min(down, up) = down`. -/
+@[simp] theorem inf_up_down : (Spin.up ⊓ Spin.down) = Spin.down := by decide
+@[simp] theorem inf_down_up : (Spin.down ⊓ Spin.up) = Spin.down := by decide
+@[simp] theorem inf_up_up : (Spin.up ⊓ Spin.up) = Spin.up := by decide
+@[simp] theorem inf_down_down : (Spin.down ⊓ Spin.down) = Spin.down := by decide
+
 /-- Map a spin to its physical sign value: `up ↦ 1`, `down ↦ -1`. -/
 def toSign : Spin → Int
   | up   =>  1

--- a/IsingModel/Inequalities/FKG.lean
+++ b/IsingModel/Inequalities/FKG.lean
@@ -1,0 +1,90 @@
+import IsingModel.GibbsMeasure
+import IsingModel.Hamiltonian
+import Mathlib.Combinatorics.SetFamily.FourFunctions
+
+/-!
+# FKG inequality for the Ising model
+
+The Fortuin-Kasteleyn-Ginibre inequality states that monotone nondecreasing
+functions are positively correlated under the ferromagnetic Ising measure.
+
+We apply Mathlib's `fkg` from `Combinatorics.SetFamily.FourFunctions` to
+the Ising Boltzmann weight, after verifying log-supermodularity.
+
+Reference: Friedli–Velenik, Theorem 3.21 (p. 98), Theorem 3.50 (pp. 128–130).
+-/
+
+namespace IsingModel
+
+open Finset
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-! ## Lattice structure on Config ι -/
+
+-- Config ι = ι → Spin has DistribLattice from Pi instance + Spin LinearOrder.
+-- Sup/inf are pointwise: (σ ⊔ σ')_i = max(σ_i, σ'_i), (σ ⊓ σ')_i = min(σ_i, σ'_i).
+
+example : DistribLattice (Config ι) := inferInstance
+
+/-! ## Log-supermodularity of the Boltzmann weight -/
+
+/-- The key lattice inequality for ±1 spins:
+`σ_i σ_j + σ'_i σ'_j ≤ (σ_i ⊔ σ'_i)(σ_j ⊔ σ'_j) + (σ_i ⊓ σ'_i)(σ_j ⊓ σ'_j)`.
+Reference: Friedli–Velenik, p. 129. -/
+private theorem spin_edge_supermodular (a b c d : Spin) :
+    Spin.sign ℝ a * Spin.sign ℝ b + Spin.sign ℝ c * Spin.sign ℝ d ≤
+    Spin.sign ℝ (a ⊔ c) * Spin.sign ℝ (b ⊔ d) +
+    Spin.sign ℝ (a ⊓ c) * Spin.sign ℝ (b ⊓ d) := by
+  -- All 16 cases for (a,b,c,d) ∈ {up,down}⁴. Discharge by decide or norm_num.
+  cases a <;> cases b <;> cases c <;> cases d <;> norm_num [Spin.sign, Spin.toSign]
+
+/-- The Boltzmann weight is log-supermodular:
+`w(σ) * w(σ') ≤ w(σ ⊔ σ') * w(σ ⊓ σ')`.
+This follows from supermodularity of each edge term in the Hamiltonian. -/
+theorem boltzmannWeight_log_supermodular (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (σ σ' : Config ι) :
+    boltzmannWeight G p σ * boltzmannWeight G p σ' ≤
+    boltzmannWeight G p (σ ⊔ σ') * boltzmannWeight G p (σ ⊓ σ') := by
+  -- w(σ)w(σ') = exp(-βH(σ)-βH(σ')) and w(σ⊔σ')w(σ⊓σ') = exp(-βH(σ⊔σ')-βH(σ⊓σ'))
+  -- So need: -βH(σ)-βH(σ') ≤ -βH(σ⊔σ')-βH(σ⊓σ')
+  -- i.e. H(σ⊔σ')+H(σ⊓σ') ≤ H(σ)+H(σ')
+  -- This follows from edge supermodularity: σᵢσⱼ+σ'ᵢσ'ⱼ ≤ (σᵢ⊔σ'ᵢ)(σⱼ⊔σ'ⱼ)+(σᵢ⊓σ'ᵢ)(σⱼ⊓σ'ⱼ)
+  sorry
+
+/-! ## FKG inequality -/
+
+/-- **FKG inequality for the Ising model**: For a ferromagnetic Ising model,
+monotone nondecreasing nonneg functions `f, g` satisfy `⟨fg⟩ ≥ ⟨f⟩⟨g⟩`.
+
+Reference: Friedli–Velenik, Theorem 3.21, p. 98. -/
+theorem fkg_ising (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (f g : Config ι → ℝ)
+    (hf_nn : 0 ≤ f) (hg_nn : 0 ≤ g)
+    (hf_mono : Monotone f) (hg_mono : Monotone g) :
+    gibbsExpectation G p f * gibbsExpectation G p g ≤
+    gibbsExpectation G p (f * g) := by
+  -- Apply Mathlib's fkg with μ = boltzmannWeight
+  unfold gibbsExpectation
+  have hZ := partitionFunction_pos G p
+  have hZne := partitionFunction_ne_zero G p
+  have hw_nn : 0 ≤ boltzmannWeight G p := fun σ => le_of_lt (boltzmannWeight_pos G p σ)
+  have hw_sm : ∀ a b : Config ι,
+      boltzmannWeight G p a * boltzmannWeight G p b ≤
+      boltzmannWeight G p (a ⊓ b) * boltzmannWeight G p (a ⊔ b) := by
+    intro a b
+    have h := boltzmannWeight_log_supermodular G p hf a b
+    linarith [mul_comm (boltzmannWeight G p (a ⊔ b)) (boltzmannWeight G p (a ⊓ b))]
+  -- Mathlib fkg: (Σ μ*f)(Σ μ*g) ≤ (Σ μ)(Σ μ*f*g)
+  -- with μ = boltzmannWeight, args: hμ₀ hf₀ hg₀ hf_mono hg_mono hμ_sm
+  have hfkg := fkg (μ := boltzmannWeight G p) (f := f) (g := g)
+    hw_nn hf_nn hg_nn hf_mono hg_mono hw_sm
+  -- Mathlib fkg gives: (Σ w*f)(Σ w*g) ≤ (Σ w)(Σ w*fg)
+  -- We need: (Z⁻¹ Σ f*w)(Z⁻¹ Σ g*w) ≤ Z⁻¹ Σ fg*w
+  -- i.e. Z⁻² (Σ f*w)(Σ g*w) ≤ Z⁻¹ Σ fg*w
+  -- From fkg: (Σ w*f)(Σ w*g) ≤ Z (Σ w*fg)
+  sorry
+
+end IsingModel

--- a/IsingModel/Inequalities/FKG.lean
+++ b/IsingModel/Inequalities/FKG.lean
@@ -39,6 +39,7 @@ private theorem spin_edge_supermodular (a b c d : Spin) :
   -- All 16 cases for (a,b,c,d) ∈ {up,down}⁴. Discharge by decide or norm_num.
   cases a <;> cases b <;> cases c <;> cases d <;> norm_num [Spin.sign, Spin.toSign]
 
+omit [DecidableEq ι] in
 /-- The Boltzmann weight is log-supermodular:
 `w(σ) * w(σ') ≤ w(σ ⊔ σ') * w(σ ⊓ σ')`.
 This follows from supermodularity of each edge term in the Hamiltonian. -/
@@ -47,11 +48,57 @@ theorem boltzmannWeight_log_supermodular (G : SimpleGraph ι) [Fintype G.edgeSet
     (σ σ' : Config ι) :
     boltzmannWeight G p σ * boltzmannWeight G p σ' ≤
     boltzmannWeight G p (σ ⊔ σ') * boltzmannWeight G p (σ ⊓ σ') := by
-  -- w(σ)w(σ') = exp(-βH(σ)-βH(σ')) and w(σ⊔σ')w(σ⊓σ') = exp(-βH(σ⊔σ')-βH(σ⊓σ'))
-  -- So need: -βH(σ)-βH(σ') ≤ -βH(σ⊔σ')-βH(σ⊓σ')
+  -- w(σ)w(σ') = exp(-βH(σ)) * exp(-βH(σ')) = exp(-βH(σ)-βH(σ'))
+  -- Need: exp(-βH(σ)-βH(σ')) ≤ exp(-βH(σ⊔σ')-βH(σ⊓σ'))
+  -- By exp monotonicity, suffices: -βH(σ)-βH(σ') ≤ -βH(σ⊔σ')-βH(σ⊓σ')
   -- i.e. H(σ⊔σ')+H(σ⊓σ') ≤ H(σ)+H(σ')
-  -- This follows from edge supermodularity: σᵢσⱼ+σ'ᵢσ'ⱼ ≤ (σᵢ⊔σ'ᵢ)(σⱼ⊔σ'ⱼ)+(σᵢ⊓σ'ᵢ)(σⱼ⊓σ'ⱼ)
-  sorry
+  unfold boltzmannWeight
+  rw [← Real.exp_add, ← Real.exp_add]
+  apply Real.exp_le_exp_of_le
+  -- Goal: -β*H(σ) + -β*H(σ') ≤ -β*H(σ⊔σ') + -β*H(σ⊓σ')
+  -- Unfold H and show edge/site supermodularity
+  unfold hamiltonian interactionEnergy externalFieldEnergy
+  -- Site terms: sign(σ_i) + sign(σ'_i) = sign(σ_i⊔σ'_i) + sign(σ_i⊓σ'_i)
+  have hsite : ∀ i, Spin.sign ℝ (σ i) + Spin.sign ℝ (σ' i) =
+      Spin.sign ℝ ((σ ⊔ σ') i) + Spin.sign ℝ ((σ ⊓ σ') i) := by
+    intro i; simp only [Pi.sup_apply, Pi.inf_apply]
+    cases σ i <;> cases σ' i <;> simp [Spin.sign, Spin.toSign]
+  -- Edge terms: supermodularity
+  have hedge : ∀ e ∈ G.edgeFinset,
+      edgeSpin (K := ℝ) σ e + edgeSpin (K := ℝ) σ' e ≤
+      edgeSpin (K := ℝ) (σ ⊔ σ') e + edgeSpin (K := ℝ) (σ ⊓ σ') e := by
+    intro e _
+    refine Sym2.ind (fun i j => ?_) e
+    simp only [edgeSpin, Sym2.lift_mk, Spin.sign]
+    exact spin_edge_supermodular (σ i) (σ j) (σ' i) (σ' j)
+  -- Combine: sum of edge and site supermodularity
+  have hedge_sum : ∑ e ∈ G.edgeFinset, edgeSpin (K := ℝ) σ e +
+      ∑ e ∈ G.edgeFinset, edgeSpin (K := ℝ) σ' e ≤
+      ∑ e ∈ G.edgeFinset, edgeSpin (K := ℝ) (σ ⊔ σ') e +
+      ∑ e ∈ G.edgeFinset, edgeSpin (K := ℝ) (σ ⊓ σ') e := by
+    rw [← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+    exact Finset.sum_le_sum fun e he => hedge e he
+  have hsite_sum : ∑ i : ι, Spin.sign ℝ (σ i) + ∑ i, Spin.sign ℝ (σ' i) =
+      ∑ i, Spin.sign ℝ ((σ ⊔ σ') i) + ∑ i, Spin.sign ℝ ((σ ⊓ σ') i) := by
+    rw [← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun i _ => hsite i
+  -- -β(-J Σ edge - h Σ site) for σ and σ', vs σ⊔σ' and σ⊓σ'
+  -- The goal has -β * (-J * Σ edge + -(h) * Σ site) form.
+  -- Expand and use hedge_sum, hsite_sum with β ≥ 0, J ≥ 0, h ≥ 0.
+  have hβ := hf.hβ.le
+  have hJ := hf.hJ
+  have hh := hf.hh
+  -- Need: -β(-J·Σe_σ - h·Σs_σ) + -β(-J·Σe_σ' - h·Σs_σ')
+  --     ≤ -β(-J·Σe_sup - h·Σs_sup) + -β(-J·Σe_inf - h·Σs_inf)
+  -- i.e. β·J·(Σe_σ+Σe_σ') + β·h·(Σs_σ+Σs_σ')
+  --    ≤ β·J·(Σe_sup+Σe_inf) + β·h·(Σs_sup+Σs_inf)
+  -- From hedge_sum and hsite_sum (equality for sites, ≤ for edges):
+  -- β*J*(Σ_edge + Σ_edge') ≤ β*J*(Σ_edge_sup + Σ_edge_inf)
+  have h1 := mul_le_mul_of_nonneg_left
+    (mul_le_mul_of_nonneg_left hedge_sum hJ) hβ
+  -- β*h*(Σ_site + Σ_site') = β*h*(Σ_site_sup + Σ_site_inf)
+  -- Combine: the full inequality
+  linarith [h1, congrArg (p.β * p.h * ·) hsite_sum]
 
 /-! ## FKG inequality -/
 
@@ -77,14 +124,48 @@ theorem fkg_ising (G : SimpleGraph ι) [Fintype G.edgeSet]
     intro a b
     have h := boltzmannWeight_log_supermodular G p hf a b
     linarith [mul_comm (boltzmannWeight G p (a ⊔ b)) (boltzmannWeight G p (a ⊓ b))]
-  -- Mathlib fkg: (Σ μ*f)(Σ μ*g) ≤ (Σ μ)(Σ μ*f*g)
-  -- with μ = boltzmannWeight, args: hμ₀ hf₀ hg₀ hf_mono hg_mono hμ_sm
   have hfkg := fkg (μ := boltzmannWeight G p) (f := f) (g := g)
     hw_nn hf_nn hg_nn hf_mono hg_mono hw_sm
-  -- Mathlib fkg gives: (Σ w*f)(Σ w*g) ≤ (Σ w)(Σ w*fg)
-  -- We need: (Z⁻¹ Σ f*w)(Z⁻¹ Σ g*w) ≤ Z⁻¹ Σ fg*w
-  -- i.e. Z⁻² (Σ f*w)(Σ g*w) ≤ Z⁻¹ Σ fg*w
-  -- From fkg: (Σ w*f)(Σ w*g) ≤ Z (Σ w*fg)
-  sorry
+  -- hfkg: (Σ w*f)(Σ w*g) ≤ (Σ w)(Σ w*(f*g))
+  -- gibbsExpectation G p f = Z⁻¹ Σ f*w, where Z = Σ w = partitionFunction
+  -- Goal: (Z⁻¹ Σ f*w)(Z⁻¹ Σ g*w) ≤ Z⁻¹ Σ (f*g)*w
+  set_option linter.unusedSimpArgs false in
+  simp only [gibbsExpectation, partitionFunction]
+  have hZinv := inv_pos.mpr hZ
+  -- Rewrite Σ f σ * w σ = Σ w σ * f σ
+  simp_rw [show ∀ σ : Config ι, f σ * boltzmannWeight G p σ =
+    boltzmannWeight G p σ * f σ from fun σ => mul_comm _ _,
+    show ∀ σ : Config ι, g σ * boltzmannWeight G p σ =
+    boltzmannWeight G p σ * g σ from fun σ => mul_comm _ _,
+    show ∀ σ : Config ι, (f * g) σ * boltzmannWeight G p σ =
+    boltzmannWeight G p σ * (f σ * g σ) from fun σ => by simp [Pi.mul_apply]; ring]
+  -- Now: (Z⁻¹ Σ w*f)(Z⁻¹ Σ w*g) ≤ Z⁻¹ Σ w*(f*g)
+  -- i.e. Z⁻² (Σ w*f)(Σ w*g) ≤ Z⁻¹ Σ w*(f*g)
+  -- From hfkg: (Σ w*f)(Σ w*g) ≤ Z * Σ w*(f*g)
+  -- Divide by Z²: Z⁻² (Σ w*f)(Σ w*g) ≤ Z⁻¹ Σ w*(f*g)
+  rw [show (∑ σ, boltzmannWeight G p σ)⁻¹ * ∑ σ, boltzmannWeight G p σ * (f σ * g σ) =
+    (∑ σ, boltzmannWeight G p σ)⁻¹ * ∑ σ, boltzmannWeight G p σ * (f σ * g σ) from rfl]
+  have hZ' := hZ
+  rw [show partitionFunction G p = ∑ σ, boltzmannWeight G p σ from rfl] at hZ'
+  -- hfkg: (Σ w*f)(Σ w*g) ≤ Z * Σ w*(f*g) where Z = Σ w
+  -- Goal: Z⁻¹ * Σ w*f * (Z⁻¹ * Σ w*g) ≤ Z⁻¹ * Σ w*(f*g)
+  -- i.e. Z⁻² * (Σ w*f)(Σ w*g) ≤ Z⁻¹ * Σ w*(f*g)
+  -- From hfkg, dividing by Z² (Z > 0):
+  set Z := ∑ σ : Config ι, boltzmannWeight G p σ
+  have hZne := ne_of_gt hZ'
+  -- hfkg: (Σ w*f)(Σ w*g) ≤ Z * Σ w*(f*g)
+  -- Goal: (Z⁻¹ Σ w*f)(Z⁻¹ Σ w*g) ≤ Z⁻¹ Σ w*(f*g)
+  -- = Z⁻² (Σ w*f)(Σ w*g) ≤ Z⁻¹ Σ w*(f*g)
+  -- Multiply both sides by Z² > 0:
+  -- (Σ w*f)(Σ w*g) ≤ Z * Σ w*(f*g) = hfkg ✓
+  rw [show ((Z⁻¹ * ∑ x, boltzmannWeight G p x * f x) *
+      (Z⁻¹ * ∑ x, boltzmannWeight G p x * g x)) =
+    Z⁻¹ * Z⁻¹ * ((∑ x, boltzmannWeight G p x * f x) *
+      (∑ x, boltzmannWeight G p x * g x)) from by ring]
+  rw [show Z⁻¹ * Z⁻¹ = (Z * Z)⁻¹ from by rw [mul_inv_rev]]
+  rw [show Z⁻¹ * ∑ σ, boltzmannWeight G p σ * (f σ * g σ) =
+    (Z * Z)⁻¹ * (Z * ∑ σ, boltzmannWeight G p σ * (f σ * g σ)) from by
+      field_simp]
+  exact mul_le_mul_of_nonneg_left hfkg (by positivity)
 
 end IsingModel

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -20,6 +20,7 @@ name = "IsingModel"
 [[lean_lib]]
 name = "test"
 globs = ["test.+"]
+docGen = false
 
 [[lean_exe]]
 name = "GKSTest"

--- a/test/IsingModel/GKSTest.lean
+++ b/test/IsingModel/GKSTest.lean
@@ -143,6 +143,22 @@ def checkGKS2Violation (label : String) (n : Nat) (edges : List (Nat × Nat))
   IO.println s!"  FAIL: {label}: expected GKS-II violation but all pairs satisfied"
   return false
 
+-- FKG test: ⟨fg⟩ ≥ ⟨f⟩⟨g⟩ for monotone f, g
+-- f = magnetization (Σ σ_i), g = σ_0, both monotone nondecreasing
+def checkFKG (label : String) (n : Nat) (edges : List (Nat × Nat))
+    (J h β : Float) : IO Bool := do
+  let magnetization (σ : List Float) : Float := σ.foldl (· + ·) 0
+  let sigma0 (σ : List Float) : Float := σ.getD 0 0
+  let expect_fg := gibbsExpect n edges J h β (fun σ => magnetization σ * sigma0 σ)
+  let expect_f := gibbsExpect n edges J h β magnetization
+  let expect_g := gibbsExpect n edges J h β sigma0
+  if expect_fg - expect_f * expect_g >= -1e-10 then
+    IO.println s!"  {label}: FKG passed (⟨fg⟩-⟨f⟩⟨g⟩ = {expect_fg - expect_f * expect_g})"
+    return true
+  else
+    IO.println s!"  FAIL: {label}: FKG violated (⟨fg⟩-⟨f⟩⟨g⟩ = {expect_fg - expect_f * expect_g})"
+    return false
+
 -- Main test runner
 
 def main : IO UInt32 := do
@@ -178,6 +194,13 @@ def main : IO UInt32 := do
   allPassed := allPassed && (← checkGKS2 "triangle J=1 h=1 β=2" 3 triangle3 1.0 1.0 2.0)
   allPassed := allPassed && (← checkGKS2 "square J=0.5 h=0.3 β=1" 4 square4 0.5 0.3 1.0)
   allPassed := allPassed && (← checkGKS2 "square J=3 h=0 β=0.1" 4 square4 3.0 0.0 0.1)
+
+  IO.println ""
+  IO.println "--- FKG: ⟨fg⟩ ≥ ⟨f⟩⟨g⟩ for monotone f, g ---"
+  -- Test with f = magnetization = Σ σ_i, g = σ_0 (both monotone)
+  allPassed := allPassed && (← checkFKG "2-chain J=1 h=0.5 β=1" 2 graph2 1.0 0.5 1.0)
+  allPassed := allPassed && (← checkFKG "triangle J=1 h=1 β=2" 3 triangle3 1.0 1.0 2.0)
+  allPassed := allPassed && (← checkFKG "square J=0.5 h=0.3 β=1" 4 square4 0.5 0.3 1.0)
 
   IO.println ""
   IO.println "--- GKS-I violation (anti-ferromagnetic, J < 0) ---"

--- a/tex/gks-proof-guide.tex
+++ b/tex/gks-proof-guide.tex
@@ -332,6 +332,36 @@ A Float-based reference implementation verifies:
   \item GKS-I and GKS-II violation for anti-ferromagnetic $J < 0$
 \end{itemize}
 
+\section{FKG inequality (\texttt{Inequalities/FKG.lean})}
+
+The FKG inequality is proved by applying Mathlib's
+\texttt{Combinatorics.SetFamily.FourFunctions.fkg} to the Ising Boltzmann
+weight, following Friedli--Velenik~\cite{friedli-velenik}, Theorem~3.21
+(p.~98) and Theorem~3.50 (pp.~128--130).
+
+\begin{theorem}[\texttt{fkg\_ising}]
+For ferromagnetic parameters and monotone nondecreasing nonneg
+$f, g : \mathrm{Config}\;\iota \to \mathbb{R}$,
+$\langle fg \rangle \geq \langle f \rangle \langle g \rangle$.
+\end{theorem}
+
+\subsection{Proof outline}
+\begin{enumerate}
+\item Define a \texttt{LinearOrder} on \texttt{Spin}: $\mathrm{down} < \mathrm{up}$
+  ($-1 < +1$). The product order on $\mathrm{Config}\;\iota = \iota \to
+  \mathrm{Spin}$ makes it a \texttt{DistribLattice}.
+\item Prove log-supermodularity of the Boltzmann weight
+  (\texttt{boltzmannWeight\_log\_supermodular}):
+  $w(\sigma)w(\sigma') \leq w(\sigma \vee \sigma')w(\sigma \wedge \sigma')$.
+  This reduces to the edge inequality
+  $\sigma_i\sigma_j + \sigma'_i\sigma'_j \leq
+  (\sigma_i \vee \sigma'_i)(\sigma_j \vee \sigma'_j) +
+  (\sigma_i \wedge \sigma'_i)(\sigma_j \wedge \sigma'_j)$
+  (\texttt{spin\_edge\_supermodular}, verified by exhaustive case analysis).
+\item Apply Mathlib's \texttt{fkg} with $\mu = w$, then convert from
+  unnormalized sums to \texttt{gibbsExpectation} form.
+\end{enumerate}
+
 \begin{thebibliography}{9}
 \bibitem{glimm-jaffe}
 J.~Glimm and A.~Jaffe,


### PR DESCRIPTION
## Summary
- Formalize FKG inequality for ferromagnetic Ising model:
  ⟨fg⟩ ≥ ⟨f⟩⟨g⟩ for monotone f, g.
- Apply Mathlib's `fkg` (FourFunctions.lean) to Ising Boltzmann weight.
- Core work: prove Ising measure is log-supermodular on {±1}^Λ.
- Reference: Friedli-Velenik Theorem 3.21/3.50, pp. 98-99/128-130.

## Test plan
- [ ] `lake build` zero warnings, zero sorry.
- [ ] `lake exe GKSTest` passes.