### PR TITLE
fix: make docgen step non-blocking in CI

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -29,3 +29,4 @@ jobs:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
       - uses: leanprover-community/docgen-action@main
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to docgen step in CI
- docgen-action@main fails due to heartbeat timeouts in mathlib internals (not our code)
- Build and test steps are unaffected

## Root cause
- `leanprover-community/docgen-action@main` hits `maxHeartbeats` on mathlib definitions
- All IsingModel modules build successfully; only the `:docs` replay step fails
- Separate issue: elan CDN transient failures (`failed to parse latest release tag`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)