### PR TITLE
feat: correlation monotonicity in h (Prop 4.2.4)

### DIFF
--- a/IsingModel/InfiniteVolume.lean
+++ b/IsingModel/InfiniteVolume.lean
@@ -452,6 +452,84 @@ theorem correlation_convergent (G : SimpleGraph ι) [Fintype G.edgeSet]
   -- Step 3: Monotone + bounded above → convergent (to the supremum)
   exact ⟨_, tendsto_atTop_ciSup hmono hbdd⟩
 
+/-! ## Monotonicity in external field (Proposition 4.2.4)
+
+The correlation function `⟨σ^B⟩` is monotone increasing in the external
+field `h`. This follows from GKS-II via the reweighting factor
+`R(σ) = ∏_i exp(β(h₂-h₁) · sign(σ_i))`, which has HNC.
+
+Reference: Glimm–Jaffe, Proposition 4.2.4 (Exercise), p. 58. -/
+
+/-- The correlation function as a function of h (external field),
+with J and β fixed. -/
+noncomputable def correlationH (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J β : ℝ) (B : Finset ι) : ℝ → ℝ :=
+  fun h => correlation G ⟨J, h, β⟩ B
+
+/-- The reweighting inequality for correlation functions in h.
+For `0 ≤ h₁ ≤ h₂`, the numerator cross-difference is non-negative. -/
+private theorem correlation_reweighting_h_nonneg
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J β : ℝ) (B : Finset ι) (h₁ h₂ : ℝ) (hh : h₁ ≤ h₂)
+    (hJ : 0 ≤ J) (hh₁ : 0 ≤ h₁) (hβ : 0 < β) :
+    0 ≤ (∑ σ : Config ι, spinProduct B σ * Real.exp
+          (-β * hamiltonian G ⟨J, h₂, β⟩ σ)) *
+        (∑ σ, Real.exp (-β * hamiltonian G ⟨J, h₁, β⟩ σ)) -
+      (∑ σ, spinProduct B σ * Real.exp
+          (-β * hamiltonian G ⟨J, h₁, β⟩ σ)) *
+        (∑ σ, Real.exp (-β * hamiltonian G ⟨J, h₂, β⟩ σ)) := by
+  -- Step 1: Hamiltonian splitting: exp(-β H_{h₂}) = R · exp(-β H_{h₁})
+  -- where R(σ) = ∏_i exp(β(h₂-h₁) · sign(σ_i))
+  have hexp : ∀ σ, Real.exp (-β * hamiltonian G ⟨J, h₂, β⟩ σ) =
+      (∏ i : ι, Real.exp (β * (h₂ - h₁) * Spin.sign ℝ (σ i))) *
+      Real.exp (-β * hamiltonian G ⟨J, h₁, β⟩ σ) := by
+    intro σ
+    rw [← Real.exp_sum, ← Real.exp_add]
+    congr 1
+    unfold hamiltonian interactionEnergy externalFieldEnergy
+    simp only [Spin.sign, ← Finset.mul_sum]; ring
+  -- Step 2: R has non-negative correlations (HNC)
+  have hR : HasNonnegCorrelations (fun σ =>
+      ∏ i : ι, Real.exp (β * (h₂ - h₁) * Spin.sign ℝ (σ i))) := by
+    intro S
+    have hhnc := hasNonnegCorrelations_edge_site_product G
+      (fun _ => 0) (fun _ => β * (h₂ - h₁))
+      (fun _ _ => le_refl 0)
+      (fun _ => mul_nonneg hβ.le (sub_nonneg.mpr hh)) S
+    simp only [zero_mul, Real.exp_zero, Finset.prod_const_one, one_mul] at hhnc
+    convert hhnc using 1
+  -- Step 3: ⟨J, h₁, β⟩ is ferromagnetic
+  have hferm : Ferromagnetic (⟨J, h₁, β⟩ : IsingParams ℝ) := ⟨hJ, hh₁, hβ⟩
+  -- Step 4: Apply cov_hnc_boltzmann_nonneg
+  simp_rw [hexp]
+  simp only [← mul_assoc]
+  exact cov_hnc_boltzmann_nonneg G ⟨J, h₁, β⟩ hferm _ hR B
+
+/-- **Proposition 4.2.4** (Glimm–Jaffe, p. 58, exercise):
+The correlation function is monotone increasing in h on `[0, ∞)`.
+
+Proof: For `0 ≤ h₁ ≤ h₂`, use the reweighting factor
+`R = ∏_i exp(β(h₂-h₁) · sign(σ_i))` (which has HNC) and `gks_second`. -/
+theorem correlation_monotone_h (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J : ℝ) (hJ : 0 ≤ J) (β : ℝ) (hβ : 0 < β) (B : Finset ι) :
+    MonotoneOn (correlationH G J β B) (Set.Ici 0) := by
+  let E : ℝ → Config ι → ℝ := fun h σ =>
+    -β * hamiltonian G ⟨J, h, β⟩ σ
+  let den : ℝ → ℝ := fun h => ∑ σ : Config ι, Real.exp (E h σ)
+  have hden_pos : ∀ h, 0 < den h := fun h =>
+    Finset.sum_pos (fun σ _ => Real.exp_pos _) Finset.univ_nonempty
+  let num : ℝ → ℝ := fun h =>
+    ∑ σ : Config ι, spinProduct B σ * Real.exp (E h σ)
+  have hf_eq : correlationH G J β B = num / den := by
+    ext h; simp only [correlationH, correlation, gibbsExpectation,
+      partitionFunction, boltzmannWeight, Pi.div_apply, div_eq_mul_inv]
+    ring
+  intro h₁ hh₁_mem h₂ _hh₂_mem hh
+  simp only [hf_eq, Pi.div_apply]
+  rw [div_le_div_iff₀ (hden_pos h₁) (hden_pos h₂)]
+  exact le_of_sub_nonneg (correlation_reweighting_h_nonneg G J β B h₁ h₂ hh
+    hJ (Set.mem_Ici.mp hh₁_mem) hβ)
+
 -- Future work: formalize lattice growth sequence Λ_n ↑ ℤ^d and relate
 -- correlation functions across different lattice sizes via graph embeddings.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ All theorems are formally proved with **zero `sorry`**.
 | Spin flip symmetry | `H(flip σ) = H(σ)` when h = 0 | — |
 | φ⁴ algebraic identities | quartic/orthogonal transformation identities | Glimm-Jaffe §4.3 |
 | Correlation boundedness | `\|⟨σ^A⟩\| ≤ 1` (Prop 4.2.2) | Glimm-Jaffe §4.2 |
-| Correlation monotonicity | `⟨σ^B⟩` monotone in J on `[0,∞)` (Prop 4.2.1) | Glimm-Jaffe §4.2 |
+| Correlation monotonicity (J) | `⟨σ^B⟩` monotone in J on `[0,∞)` (Prop 4.2.1) | Glimm-Jaffe §4.2 |
+| Correlation monotonicity (h) | `⟨σ^B⟩` monotone in h on `[0,∞)` (Prop 4.2.4) | Glimm-Jaffe §4.2 |
 | Covariance non-negativity | `Cov(σ^B, f) ≥ 0` for HNC f | Glimm-Jaffe §4.2 |
 | Correlation convergence | `⟨σ^B⟩` converges as J → ∞ (Thm 4.2.3) | Glimm-Jaffe §4.2 |
 | Free energy monotonicity | Z and f monotone in J and h on [0,∞) | Glimm-Jaffe §4.6 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,8 @@ All theorems are formally proved with **zero `sorry`**.
 | **Lee-Yang circle theorem**               | Ising partition polynomial nonvanishing on the open polydisk                                        | `LeeYang.lean`             |
 | **φ⁴ algebraic identities**             | Quartic/orthogonal transformation identities (axioms: `phi4_integrable`, `phi4_single_site_nonneg`) | `ContinuousSpin/Phi4.lean` |
 | **Correlation boundedness** (Prop 4.2.2)  | `|⟨σ^A⟩| ≤ 1`                                                                                     | `InfiniteVolume.lean`      |
-| **Correlation monotonicity** (Prop 4.2.1) | `⟨σ^B⟩` monotone in J on `[0,∞)`                                                                  | `InfiniteVolume.lean`      |
+| **Correlation monotonicity (J)** (Prop 4.2.1) | `⟨σ^B⟩` monotone in J on `[0,∞)`                                                               | `InfiniteVolume.lean`      |
+| **Correlation monotonicity (h)** (Prop 4.2.4) | `⟨σ^B⟩` monotone in h on `[0,∞)`                                                               | `InfiniteVolume.lean`      |
 | **Covariance non-negativity**             | `Cov(σ^B, f) ≥ 0` for HNC f under Boltzmann weight                                                | `InfiniteVolume.lean`      |
 | **Correlation convergence** (Thm 4.2.3)   | `⟨σ^B⟩` converges as J → ∞                                                                       | `InfiniteVolume.lean`      |
 | **Free energy** (§4.6)                   | `f = |ι|⁻¹ ln Z`, monotone in J and h                                                             | `FreeEnergy.lean`          |


### PR DESCRIPTION
## Summary
- Add `correlationH`: correlation function parameterized by external field h
- Prove `correlation_monotone_h`: ⟨σ^B⟩ monotone in h on [0,∞) (Prop 4.2.4)
- Same reweighting technique as existing `correlation_monotone_J`

## Test plan
- [x] `lake build` passes
- [x] No `sorry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)