### PR TITLE
fix: add dedicated Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem
https://phasetr.github.io/ising-model/ shows outdated content.

Root cause: the existing `docs` job in `lean_action_ci.yml` uses
\`leanprover-community/docgen-action@main\` which has been failing
with \`error: no such file or directory ... docbuild/.lake/build/doc/style.css\`.
Because Pages is configured with \`build_type: workflow\`, the site
never gets updated.

## Fix
Add a separate \`pages.yml\` workflow that:
- Triggers on push to main when \`docs/\` changes
- Builds \`docs/\` with Jekyll (already the intended setup)
- Deploys to GitHub Pages independently of doc-gen4

The existing doc-gen4 API docs workflow remains unchanged (it was already
failing silently with \`continue-on-error: true\`).

## Test plan
- [ ] Workflow runs successfully on main
- [ ] https://phasetr.github.io/ising-model/ shows updated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)