### PR TITLE
fix: API documentation (doc-gen4) returns 404

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -29,4 +29,3 @@ jobs:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
       - uses: leanprover-community/docgen-action@main
-        continue-on-error: true


### PR DESCRIPTION
## Root cause

A known cache-consistency bug in `leanprover-community/docgen-action`, fixed earlier today (2026-04-14 12:46 UTC) in [docgen-action#29](https://github.com/leanprover-community/docgen-action/pull/29).

### Details

- The docgen-action cache was missing static files such as `docbuild/.lake/build/doc/style.css`.
- Only the build trace (DB) was cached; on cache hit, Lake's `Replay` step then failed looking for the un-cached static files:
  ```
  error: no such file or directory (error code: 4294967294)
    file: /home/runner/work/ising-model/ising-model/docbuild/.lake/build/doc/style.css
  Some required targets logged failures:
  - «ising-model»/IsingModel:docs
  ```
- docgen-action#29 adds `style.css`, `favicon.svg`, `declaration-data.js`, `color-scheme.js`, …, `find/find.js` and friends to the list of cacheable paths.

Our most recent CI run (2026-04-14 04:05 UTC) hit the bug because it ran before the fix was merged. `docgen-action@main` no longer has this problem.

### Secondary issue: stale broken cache

The cache key is `Docs-${hashFiles('lake-manifest.json', inputs.references)}`. As long as `lake-manifest.json` stays the same, the broken cache is restored on every run. It had to be evicted manually.

## Changes

1. Deleted the stale broken cache (id `3738068549`, key `Docs-f1005cfb...`) via `gh api -X DELETE`, forcing a fresh rebuild on the next main push.
2. Removed `continue-on-error: true` from `.github/workflows/lean_action_ci.yml` so future docgen regressions surface loudly instead of silently marking the job green.
3. The action reference `leanprover-community/docgen-action@main` automatically picks up the upstream fix on the next run.

## Note on `pages.yml`

`pages.yml` (added in #60) and the docgen-action step in `lean_action_ci.yml` both deploy to GitHub Pages, which is redundant. Removing `pages.yml` now would leave the Jekyll homepage unprotected if docgen-action breaks again. Once the docgen-action deploy is confirmed healthy on main, `pages.yml` should be cleaned up in a follow-up PR.

## Test plan

- [ ] On the post-merge main push, `Lean Action CI / docs` finishes with status `success` (no more silent pass via `continue-on-error`).
- [ ] `https://phasetr.github.io/ising-model/docs/` returns 200 and serves the API docs.
- [ ] `https://phasetr.github.io/ising-model/` (Jekyll homepage) continues to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)