### PR TITLE
fix: disable docgen-action cache to stop 404s on module pages

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -29,3 +29,5 @@ jobs:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
       - uses: leanprover-community/docgen-action@main
+        with:
+          use-github-cache: false


### PR DESCRIPTION
## Problem

Individual API doc pages 404:

- `https://phasetr.github.io/ising-model/docs/` — 200 OK (only the bare index)
- `https://phasetr.github.io/ising-model/docs/IsingModel/Asano.html` — **404**
- `https://phasetr.github.io/ising-model/docs/IsingModel.html` — **404**

## Root cause

`leanprover-community/docgen-action` caches a fixed list of paths under
`docbuild/.lake/build/doc/` (see `src/index.js`):

- One directory per manifest **dependency** (`.../doc/Mathlib`, `.../doc/Aesop`, …)
- Static files (`style.css`, `favicon.svg`, `declaration-data.js`, …, `find/find.js`)
- `api-docs.db`, `doc-manifest.json`, `doc-data`

The project's **own** output directory (`docbuild/.lake/build/doc/IsingModel/`)
is **not** in that list. On cache hit, Lake replays the `:docs` facet (replay
does not verify every individual output file — only the trace). The final
`cp -r docbuild/.lake/build/doc $HOMEPAGE/docs` step then copies everything
that was restored, minus the missing `IsingModel/` tree.

### Evidence

Comparing archived paths (from `actions/upload-pages-artifact`) across runs:

| Run | Trigger | Docs cache state | `./docs/IsingModel/` in archive |
|-----|---------|------------------|--------------------------------|
| 24449104668 | post-#61 main push | cache MISS (deleted by hand earlier) | **present** (IsingModel/, IsingModel.html) |
| 24453784477 | post-#62 main push | cache HIT | **absent** |

The 24453784477 run logs also show:

```
ℹ [5569/5569] Replayed «ising-model»/IsingModel:docs
info: Generating documentation for IsingModel (1 root modules)
Build completed successfully (5569 jobs).
```

i.e. Lake replays the docs facet without regenerating, so the missing
`IsingModel/*.html` files are never produced on this run.

## Fix

Pass `use-github-cache: false` to `docgen-action` (the input added in
`leanprover-community/docgen-action#31`, commit `ca33d60`). This forces
a full rebuild every time, which is slow (~90 min) but deterministic.

## Follow-ups (out of scope for this PR)

- Also delete the currently-poisoned `Docs-f1005cfb…` cache (ID `3771060554`)
  via `gh api -X DELETE`, to make the very first post-merge run pick up a
  clean state. I will do this manually at merge time.
- File an upstream issue on `leanprover-community/docgen-action` asking for
  the project's own `doc/<Package>/` directory to be included in the cache
  list, so we can re-enable the cache once fixed.

## Test plan

- [ ] Post-merge main push runs `Lean Action CI / docs` and takes ~90 min.
- [ ] `https://phasetr.github.io/ising-model/docs/IsingModel/Asano.html` returns 200.
- [ ] `https://phasetr.github.io/ising-model/docs/IsingModel.html` returns 200.
- [ ] `https://phasetr.github.io/ising-model/` (Jekyll homepage) still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)