### PR TITLE
feat: lattice-growth version of GJ Thm 4.2.3 & Prop 4.6.1 (infinite volume convergence)

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -479,4 +479,127 @@ theorem freeEnergyJ_analyticOn
     ((partitionFunctionJ_analyticAt G h β J₀).log
       (partitionFunction_pos G ⟨J₀, h, β⟩))).analyticWithinAt
 
+/-! ## Free energy infinite volume convergence (Proposition 4.6.1)
+
+For a ferromagnetic Ising model on a fixed ambient finite lattice `ι`,
+the free energy `f_G = |ι|⁻¹ ln Z_G` is monotone along the subgraph
+order and bounded above (by `f_⊤` on the complete ambient graph),
+hence converges for any increasing sequence of subgraphs.
+
+This is the formalization of Glimm–Jaffe Proposition 4.6.1 (p. 68)
+in its lattice-growth discretization: "Let Z_Λ denote the partition
+function for a lattice field with nearest neighbor, translation-invariant,
+ferromagnetic pair interaction. As Λ ↑ ∞, f_Λ converges". -/
+
+/-- The partition function is monotone in the subgraph order.
+For `G₁ ≤ G₂` and ferromagnetic `p`, `Z_{G₁} ≤ Z_{G₂}`.
+
+Proof: Factor `w_{G₂} = R · w_{G₁}` where
+`R(σ) = ∏_{e ∈ E(G₂)\E(G₁)} exp(βJ · edgeSpin σ e)`.
+Use `exp(x) ≥ 1 + x` and GKS-I (each `⟨σᵢσⱼ⟩_{G₁} ≥ 0`)
+to bound `∑ R · w_{G₁} ≥ Z_{G₁}`. -/
+theorem partitionFunction_monotone_subgraph
+    {G₁ G₂ : SimpleGraph ι} [Fintype G₁.edgeSet] [Fintype G₂.edgeSet]
+    (h₁₂ : G₁ ≤ G₂) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunction G₁ p ≤ partitionFunction G₂ p := by
+  have hfact : ∀ σ, boltzmannWeight G₂ p σ =
+      (∏ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+        Real.exp (p.β * p.J * edgeSpin (K := ℝ) σ e)) *
+      boltzmannWeight G₁ p σ :=
+    fun σ => boltzmannWeight_subgraph_factor h₁₂ p σ
+  have hZ : partitionFunction G₂ p =
+      ∑ σ : Config ι,
+        (∏ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+          Real.exp (p.β * p.J * edgeSpin (K := ℝ) σ e)) *
+        boltzmannWeight G₁ p σ := by
+    unfold partitionFunction
+    apply Finset.sum_congr rfl; intro σ _; exact hfact σ
+  rw [hZ]
+  have hR_lb : ∀ σ : Config ι,
+      1 + p.β * p.J * ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+        edgeSpin (K := ℝ) σ e ≤
+      (∏ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+        Real.exp (p.β * p.J * edgeSpin (K := ℝ) σ e)) := by
+    intro σ
+    rw [← Real.exp_sum]
+    simp_rw [← Finset.mul_sum]
+    linarith [Real.add_one_le_exp (p.β * p.J *
+      ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset, edgeSpin (K := ℝ) σ e)]
+  have hsum_lb : ∑ σ : Config ι,
+      (1 + p.β * p.J * ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+        edgeSpin (K := ℝ) σ e) *
+      boltzmannWeight G₁ p σ ≤
+    ∑ σ : Config ι,
+      (∏ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+        Real.exp (p.β * p.J * edgeSpin (K := ℝ) σ e)) *
+      boltzmannWeight G₁ p σ := by
+    apply Finset.sum_le_sum; intro σ _
+    exact mul_le_mul_of_nonneg_right (hR_lb σ) (boltzmannWeight_pos G₁ p σ).le
+  have hexpand : ∑ σ : Config ι,
+      (1 + p.β * p.J * ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+        edgeSpin (K := ℝ) σ e) *
+      boltzmannWeight G₁ p σ =
+    partitionFunction G₁ p +
+    p.β * p.J * ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+      ∑ σ : Config ι, edgeSpin (K := ℝ) σ e * boltzmannWeight G₁ p σ := by
+    unfold partitionFunction
+    simp_rw [add_mul, one_mul, Finset.sum_add_distrib]
+    congr 1
+    simp_rw [Finset.mul_sum, Finset.sum_mul]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl; intro e _
+    apply Finset.sum_congr rfl; intro σ _; ring
+  have hnum_nonneg : ∀ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+      0 ≤ ∑ σ : Config ι,
+        edgeSpin (K := ℝ) σ e * boltzmannWeight G₁ p σ := by
+    intro e he
+    have he₂ : e ∈ G₂.edgeFinset := (Finset.mem_sdiff.mp he).1
+    obtain ⟨⟨i, j⟩, rfl⟩ := Quot.exists_rep e
+    have hij : i ≠ j := by
+      intro h; subst h
+      exact (SimpleGraph.mem_edgeFinset.mp he₂).ne rfl
+    have hedge : ∀ σ : Config ι, edgeSpin (K := ℝ) σ (Quot.mk _ (i, j)) =
+        spinProduct {i, j} σ := by
+      intro σ; simp [edgeSpin, Sym2.lift, spinProduct, Finset.prod_pair hij, Spin.sign]
+    simp_rw [hedge]
+    exact (boltzmannWeight_hasNonnegCorrelations G₁ p hf) {i, j}
+  calc partitionFunction G₁ p
+      ≤ partitionFunction G₁ p +
+        p.β * p.J * ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+          ∑ σ : Config ι, edgeSpin (K := ℝ) σ e * boltzmannWeight G₁ p σ :=
+        le_add_of_nonneg_right (mul_nonneg (mul_nonneg hf.hβ.le hf.hJ)
+          (Finset.sum_nonneg (fun e he => hnum_nonneg e he)))
+    _ = _ := hexpand.symm
+    _ ≤ _ := hsum_lb
+
+/-- The free energy is monotone in the subgraph order.
+Follows from `partitionFunction_monotone_subgraph` and `Real.log_le_log`. -/
+theorem freeEnergy_monotone_subgraph
+    {G₁ G₂ : SimpleGraph ι} [Fintype G₁.edgeSet] [Fintype G₂.edgeSet]
+    (h₁₂ : G₁ ≤ G₂) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    freeEnergy G₁ p ≤ freeEnergy G₂ p := by
+  unfold freeEnergy
+  apply mul_le_mul_of_nonneg_left _ (inv_nonneg.mpr (Nat.cast_nonneg _))
+  exact Real.log_le_log (partitionFunction_pos G₁ p)
+    (partitionFunction_monotone_subgraph h₁₂ p hf)
+
+/-- **Proposition 4.6.1** (Glimm–Jaffe, p. 68): The free energy converges
+along any increasing sequence of subgraphs on a fixed ambient finite lattice.
+
+The free energy `n ↦ f_{Gₙ}` is monotone (by `freeEnergy_monotone_subgraph`)
+and bounded above by `f_⊤` (free energy on the complete graph, via
+`le_top`), hence converges to its supremum by `tendsto_atTop_ciSup`. -/
+theorem freeEnergy_convergent_subgraph
+    (Gn : ℕ → SimpleGraph ι) [∀ n, Fintype (Gn n).edgeSet]
+    (hmono : Monotone Gn) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => freeEnergy (Gn n) p)
+      Filter.atTop (nhds L) := by
+  have h_mono : Monotone (fun n : ℕ => freeEnergy (Gn n) p) :=
+    fun a b hab => freeEnergy_monotone_subgraph (hmono hab) p hf
+  have h_bdd : BddAbove (Set.range (fun n : ℕ => freeEnergy (Gn n) p)) :=
+    ⟨freeEnergy (⊤ : SimpleGraph ι) p,
+     fun _ ⟨n, hn⟩ => hn ▸ freeEnergy_monotone_subgraph le_top p hf⟩
+  exact ⟨_, tendsto_atTop_ciSup h_mono h_bdd⟩
+
 end IsingModel

--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -486,10 +486,18 @@ the free energy `f_G = |ι|⁻¹ ln Z_G` is monotone along the subgraph
 order and bounded above (by `f_⊤` on the complete ambient graph),
 hence converges for any increasing sequence of subgraphs.
 
-This is the formalization of Glimm–Jaffe Proposition 4.6.1 (p. 68)
-in its lattice-growth discretization: "Let Z_Λ denote the partition
-function for a lattice field with nearest neighbor, translation-invariant,
-ferromagnetic pair interaction. As Λ ↑ ∞, f_Λ converges". -/
+This is a *discretized* formalization of Glimm–Jaffe Proposition 4.6.1
+(p. 68): "Let Z_Λ denote the partition function for a lattice field
+with nearest-neighbor, translation-invariant, ferromagnetic pair
+interaction; with single-spin distribution satisfying (4.1.4). As
+Λ ↑ ∞, f_Λ = |Λ|⁻¹ ln Z_Λ converges". The original statement is
+for an infinite ambient lattice with finite-volume exhaustions; our
+formalization uses a fixed finite ambient lattice with growing subgraphs.
+The proof mechanism (monotonicity + boundedness) is the same.
+
+Note: GJ's Prop 4.6.1 is a general lattice-spin result, not Ising-only;
+the Ising model is a special case where the single-spin distribution
+is the symmetric Bernoulli measure on `{±1}`. -/
 
 /-- The partition function is monotone in the subgraph order.
 For `G₁ ≤ G₂` and ferromagnetic `p`, `Z_{G₁} ≤ Z_{G₂}`.

--- a/IsingModel/InfiniteVolume.lean
+++ b/IsingModel/InfiniteVolume.lean
@@ -573,7 +573,7 @@ private theorem hasNonnegCorrelations_edge_prod_of_finset
 /-- The Boltzmann weight on a larger graph factors through a reweighting
 `R(σ) = ∏_{e ∈ E(G₂)\E(G₁)} exp(βJ · edgeSpin σ e)`:
 `w_{G₂}(σ) = R(σ) · w_{G₁}(σ)`. -/
-private theorem boltzmannWeight_subgraph_factor
+theorem boltzmannWeight_subgraph_factor
     {G₁ G₂ : SimpleGraph ι} [Fintype G₁.edgeSet] [Fintype G₂.edgeSet]
     (h₁₂ : G₁ ≤ G₂) (p : IsingParams ℝ) (σ : Config ι) :
     boltzmannWeight G₂ p σ =
@@ -666,5 +666,36 @@ theorem correlation_convergent_subgraph
   have hbdd : BddAbove (Set.range (fun n : ℕ => correlation (Gn n) p A)) :=
     ⟨1, fun _ ⟨n, hn⟩ => hn ▸ correlation_le_one (Gn n) p A⟩
   exact ⟨_, tendsto_atTop_ciSup hcorr_mono hbdd⟩
+
+/-! ## Named corollaries of the lattice-growth convergence
+
+Direct specializations of `correlation_convergent_subgraph` at the most
+physically relevant subsets: single-site magnetization `⟨σᵢ⟩` and
+two-point correlation `⟨σᵢσⱼ⟩`.  Both are used downstream in §5
+(symmetry breaking, phase transitions). -/
+
+/-- **Magnetization convergence** (Glimm–Jaffe, §5.3 context):
+the single-site magnetization `⟨σᵢ⟩_{Gₙ}` converges along any increasing
+subgraph sequence. Direct specialization of `correlation_convergent_subgraph`
+to `A = {i}`. -/
+theorem magnetization_convergent_subgraph
+    (Gn : ℕ → SimpleGraph ι) [∀ n, Fintype (Gn n).edgeSet]
+    (hmono : Monotone Gn) (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : ι) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => correlation (Gn n) p {i})
+      Filter.atTop (nhds L) :=
+  correlation_convergent_subgraph Gn hmono p hf {i}
+
+/-- **Two-point correlation convergence** (Glimm–Jaffe, §5.1 context):
+the two-point correlation `⟨σᵢσⱼ⟩_{Gₙ}` converges along any increasing
+subgraph sequence. Direct specialization of `correlation_convergent_subgraph`
+to `A = {i, j}`. -/
+theorem twoPoint_convergent_subgraph
+    (Gn : ℕ → SimpleGraph ι) [∀ n, Fintype (Gn n).edgeSet]
+    (hmono : Monotone Gn) (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : ι) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => correlation (Gn n) p {i, j})
+      Filter.atTop (nhds L) :=
+  correlation_convergent_subgraph Gn hmono p hf {i, j}
 
 end IsingModel

--- a/IsingModel/InfiniteVolume.lean
+++ b/IsingModel/InfiniteVolume.lean
@@ -545,9 +545,12 @@ For a fixed ambient finite lattice `ι` and ferromagnetic parameters `p`,
 if `G₁ ≤ G₂` (subgraph of the interaction graph), then the correlation
 function is monotone: `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}`.
 
-This is the discrete formalization of GJ §4.2 Thm 4.2.3's statement
+This is the *discretized* formalization of GJ §4.2 Thm 4.2.3's statement
 "`Λ ↑ ℝᵈ`": increasing the lattice corresponds to turning on couplings
-`J_A : 0 → βJ` for new edges.
+`J_A : 0 → βJ` for new edges. The original GJ statement is over an
+infinite ambient lattice with finite-volume exhaustions; our version
+uses a fixed finite ambient lattice with growing subgraphs, preserving
+the proof mechanism (GKS-I + monotonicity + boundedness).
 
 Reference: Glimm–Jaffe, Theorem 4.2.3, p. 59. -/
 

--- a/IsingModel/InfiniteVolume.lean
+++ b/IsingModel/InfiniteVolume.lean
@@ -530,7 +530,141 @@ theorem correlation_monotone_h (G : SimpleGraph ι) [Fintype G.edgeSet]
   exact le_of_sub_nonneg (correlation_reweighting_h_nonneg G J β B h₁ h₂ hh
     hJ (Set.mem_Ici.mp hh₁_mem) hβ)
 
--- Future work: formalize lattice growth sequence Λ_n ↑ ℤ^d and relate
--- correlation functions across different lattice sizes via graph embeddings.
+/-! ## Upper bound on the correlation (without absolute value) -/
+
+/-- The correlation function is bounded above by `1`.
+Extracted from `abs_correlation_le_one` via `a ≤ |a|`. -/
+theorem correlation_le_one (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (A : Finset ι) :
+    correlation G p A ≤ 1 :=
+  le_trans (le_abs_self _) (abs_correlation_le_one G p A)
+
+/-! ## Monotonicity in the lattice (Theorem 4.2.3, lattice version)
+
+For a fixed ambient finite lattice `ι` and ferromagnetic parameters `p`,
+if `G₁ ≤ G₂` (subgraph of the interaction graph), then the correlation
+function is monotone: `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}`.
+
+This is the discrete formalization of GJ §4.2 Thm 4.2.3's statement
+"`Λ ↑ ℝᵈ`": increasing the lattice corresponds to turning on couplings
+`J_A : 0 → βJ` for new edges.
+
+Reference: Glimm–Jaffe, Theorem 4.2.3, p. 59. -/
+
+/-- HNC of a product `∏_{e ∈ E} exp(K e · edgeSpin σ e)` over an arbitrary
+non-diagonal Finset `E` of `Sym2 ι`, with non-negative `K`.
+A graph-free variant of `hasNonnegCorrelations_edge_site_product`. -/
+private theorem hasNonnegCorrelations_edge_prod_of_finset
+    (E : Finset (Sym2 ι)) (hE : ∀ e ∈ E, ¬ e.IsDiag)
+    (K : Sym2 ι → ℝ) (hK : ∀ e ∈ E, 0 ≤ K e) :
+    HasNonnegCorrelations
+      (fun σ => ∏ e ∈ E, Real.exp (K e * edgeSpin (K := ℝ) σ e)) := by
+  apply hasNonnegCorrelations_finset_prod
+  intro e he
+  obtain ⟨⟨i, j⟩, rfl⟩ := Quot.exists_rep e
+  have hne : i ≠ j := fun hij => hE _ he (Sym2.mk_isDiag_iff.mpr hij)
+  refine ⟨Real.cosh (K (Quot.mk _ (i, j))),
+    Real.sinh (K (Quot.mk _ (i, j))), {i, j},
+    (Real.cosh_pos _).le,
+    Real.sinh_nonneg_iff.mpr (hK _ he), fun σ => ?_⟩
+  simp only [spinProduct, Finset.prod_pair hne]
+  exact exp_edgeSpin_decomp _ σ _
+
+/-- The Boltzmann weight on a larger graph factors through a reweighting
+`R(σ) = ∏_{e ∈ E(G₂)\E(G₁)} exp(βJ · edgeSpin σ e)`:
+`w_{G₂}(σ) = R(σ) · w_{G₁}(σ)`. -/
+private theorem boltzmannWeight_subgraph_factor
+    {G₁ G₂ : SimpleGraph ι} [Fintype G₁.edgeSet] [Fintype G₂.edgeSet]
+    (h₁₂ : G₁ ≤ G₂) (p : IsingParams ℝ) (σ : Config ι) :
+    boltzmannWeight G₂ p σ =
+    (∏ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+      Real.exp (p.β * p.J * edgeSpin (K := ℝ) σ e)) *
+    boltzmannWeight G₁ p σ := by
+  have hsub : G₁.edgeFinset ⊆ G₂.edgeFinset := SimpleGraph.edgeFinset_mono h₁₂
+  rw [← Real.exp_sum]
+  unfold boltzmannWeight
+  rw [← Real.exp_add]
+  congr 1
+  unfold hamiltonian interactionEnergy externalFieldEnergy
+  have hdis : ∑ e ∈ G₂.edgeFinset, edgeSpin (K := ℝ) σ e =
+      ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset, edgeSpin (K := ℝ) σ e +
+      ∑ e ∈ G₁.edgeFinset, edgeSpin (K := ℝ) σ e := by
+    rw [← Finset.sum_sdiff hsub, add_comm]
+  rw [show ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset, p.β * p.J * edgeSpin (K := ℝ) σ e =
+      p.β * p.J * ∑ e ∈ G₂.edgeFinset \ G₁.edgeFinset, edgeSpin (K := ℝ) σ e from by
+      rw [Finset.mul_sum]]
+  rw [hdis]
+  ring
+
+/-- **Theorem 4.2.3** (Glimm–Jaffe, p. 59; lattice version):
+For a ferromagnetic Ising model, the correlation function is monotone
+under the subgraph ordering: if `G₁ ≤ G₂` (as `SimpleGraph` on the
+ambient lattice `ι`), then `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}`.
+
+Proof: Factor `w_{G₂} = R · w_{G₁}` where `R` has HNC (since it is a
+product of non-negative-coefficient exponentials of edge spins), then
+apply `cov_hnc_boltzmann_nonneg` on the base graph `G₁`. -/
+theorem correlation_monotone_subgraph
+    {G₁ G₂ : SimpleGraph ι} [Fintype G₁.edgeSet] [Fintype G₂.edgeSet]
+    (h₁₂ : G₁ ≤ G₂) (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset ι) :
+    correlation G₁ p A ≤ correlation G₂ p A := by
+  set R : Config ι → ℝ := fun σ =>
+    ∏ e ∈ G₂.edgeFinset \ G₁.edgeFinset,
+      Real.exp (p.β * p.J * edgeSpin (K := ℝ) σ e) with hR_def
+  have hR : HasNonnegCorrelations R :=
+    hasNonnegCorrelations_edge_prod_of_finset
+      (G₂.edgeFinset \ G₁.edgeFinset)
+      (fun e he =>
+        G₂.not_isDiag_of_mem_edgeFinset (Finset.mem_sdiff.mp he).1)
+      (fun _ => p.β * p.J)
+      (fun _ _ => mul_nonneg hf.hβ.le hf.hJ)
+  have hfact : ∀ σ, boltzmannWeight G₂ p σ = R σ * boltzmannWeight G₁ p σ :=
+    fun σ => boltzmannWeight_subgraph_factor h₁₂ p σ
+  have hcov := cov_hnc_boltzmann_nonneg G₁ p hf R hR A
+  have hnum : ∑ σ : Config ι, spinProduct A σ * R σ * boltzmannWeight G₁ p σ =
+      ∑ σ, spinProduct A σ * boltzmannWeight G₂ p σ := by
+    apply Finset.sum_congr rfl; intro σ _
+    rw [hfact σ]; ring
+  have hden : ∑ σ : Config ι, R σ * boltzmannWeight G₁ p σ =
+      ∑ σ, boltzmannWeight G₂ p σ := by
+    apply Finset.sum_congr rfl; intro σ _
+    exact (hfact σ).symm
+  rw [hnum, hden] at hcov
+  have hZ₁ := partitionFunction_pos G₁ p
+  have hZ₂ := partitionFunction_pos G₂ p
+  unfold correlation gibbsExpectation partitionFunction
+  unfold partitionFunction at hZ₁ hZ₂
+  rw [mul_comm ((∑ σ : Config ι, boltzmannWeight G₁ p σ)⁻¹)
+      (∑ σ, spinProduct A σ * boltzmannWeight G₁ p σ),
+      mul_comm ((∑ σ : Config ι, boltzmannWeight G₂ p σ)⁻¹)
+      (∑ σ, spinProduct A σ * boltzmannWeight G₂ p σ)]
+  rw [← div_eq_mul_inv, ← div_eq_mul_inv]
+  rw [div_le_div_iff₀ hZ₁ hZ₂]
+  linarith
+
+/-! ## Convergence along an increasing chain of subgraphs
+
+For an increasing sequence of subgraphs `Gn : ℕ → SimpleGraph ι` with
+ferromagnetic parameters, the correlation function `n ↦ ⟨σ^A⟩_{Gn n}`
+is monotone (by `correlation_monotone_subgraph`) and bounded above by
+`1` (by `correlation_le_one`), hence convergent by monotone-bounded. -/
+
+/-- **Theorem 4.2.3** (Glimm–Jaffe, p. 59; lattice version, convergence):
+For any increasing sequence of subgraphs `Gₙ ↑` on a fixed ambient finite
+lattice, with ferromagnetic parameters, the correlation function
+`n ↦ ⟨σ^A⟩_{Gₙ}` converges as `n → ∞`. -/
+theorem correlation_convergent_subgraph
+    (Gn : ℕ → SimpleGraph ι) [∀ n, Fintype (Gn n).edgeSet]
+    (hmono : Monotone Gn) (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset ι) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => correlation (Gn n) p A)
+      Filter.atTop (nhds L) := by
+  have hcorr_mono : Monotone (fun n : ℕ => correlation (Gn n) p A) :=
+    fun a b hab => correlation_monotone_subgraph (hmono hab) p hf A
+  have hbdd : BddAbove (Set.range (fun n : ℕ => correlation (Gn n) p A)) :=
+    ⟨1, fun _ ⟨n, hn⟩ => hn ▸ correlation_le_one (Gn n) p A⟩
+  exact ⟨_, tendsto_atTop_ciSup hcorr_mono hbdd⟩
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,8 @@ All theorems are formally proved with **zero `sorry`**.
 | **Correlation monotonicity (h)** (Prop 4.2.4) | `⟨σ^B⟩` monotone in h on `[0,∞)`                                               | `InfiniteVolume.lean`      |
 | **Covariance non-negativity**                 | `Cov(σ^B, f) ≥ 0` for HNC f under Boltzmann weight                             | `InfiniteVolume.lean`      |
 | **Correlation convergence** (Thm 4.2.3)       | `⟨σ^B⟩` converges as J → ∞                                                    | `InfiniteVolume.lean`      |
+| **Correlation monotonicity (lattice)** (Thm 4.2.3) | `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` for subgraph ordering `G₁ ≤ G₂`                | `InfiniteVolume.lean`      |
+| **Correlation convergence (lattice)** (Thm 4.2.3) | `⟨σ^A⟩_{Gₙ}` converges for any increasing sequence of subgraphs               | `InfiniteVolume.lean`      |
 | **Free energy** (§4.6)                       | `f = \|ι\|⁻¹ ln Z`, monotone in J and h                                        | `FreeEnergy.lean`          |
 | **Lee-Yang nonvanishing (Ising)**             | Ising partition polynomial ≠ 0 on polydisk                                      | `FreeEnergy.lean`          |
 | **GHS inequality** (Cor 4.3.4)                | `⟨σ_i; σ_j; σ_k⟩ ≤ 0` (from Lebowitz third inequality)                       | `Inequalities/GHS.lean`    |
@@ -87,7 +89,9 @@ heavy Lean measure theory assembly:
 | §4.1   | Thm 4.1.1 GKS-II                    | **Done**         | `gks_second`                          |                               |
 | §4.2   | Prop 4.2.1 (J-monotonicity)         | **Done**         | `correlation_monotone_J`              |                               |
 | §4.2   | Prop 4.2.2 (boundedness)            | **Done**         | `abs_correlation_le_one`              |                               |
-| §4.2   | Thm 4.2.3 (convergence)             | **Done**         | `correlation_convergent`              |                               |
+| §4.2   | Thm 4.2.3 (convergence, J → ∞)     | **Done**         | `correlation_convergent`              | Fixed graph                   |
+| §4.2   | Thm 4.2.3 (convergence, Λ ↑)       | **Done**         | `correlation_convergent_subgraph`     | Increasing subgraph sequence  |
+| §4.2   | Monotonicity in lattice             | **Done**         | `correlation_monotone_subgraph`       | `G₁ ≤ G₂ ⇒ corr₁ ≤ corr₂`    |
 | §4.2   | Prop 4.2.4 (h-monotonicity)         | **Done**         | `correlation_monotone_h`              |                               |
 | §4.3   | Thm 4.3.1 (φ⁴ non-negativity)     | **Axiom**        | `phi4_single_site_nonneg`             | Measure theory                |
 | §4.3   | Cor 4.3.2 (Lebowitz, 3-site)        | **Axiom**        | `lebowitz_third`                      | Via φ⁴ limit                |

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,11 @@ All theorems are formally proved with **zero `sorry`**.
 | **Correlation convergence** (Thm 4.2.3)       | `⟨σ^B⟩` converges as J → ∞                                                    | `InfiniteVolume.lean`      |
 | **Correlation monotonicity (lattice)** (Thm 4.2.3) | `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` for subgraph ordering `G₁ ≤ G₂`                | `InfiniteVolume.lean`      |
 | **Correlation convergence (lattice)** (Thm 4.2.3) | `⟨σ^A⟩_{Gₙ}` converges for any increasing sequence of subgraphs               | `InfiniteVolume.lean`      |
+| **Magnetization convergence (lattice)** | `⟨σᵢ⟩_{Gₙ}` converges for any increasing subgraph sequence                       | `InfiniteVolume.lean`      |
+| **Two-point convergence (lattice)**     | `⟨σᵢσⱼ⟩_{Gₙ}` converges for any increasing subgraph sequence                    | `InfiniteVolume.lean`      |
+| **Partition function monotonicity (lattice)** | `Z_{G₁} ≤ Z_{G₂}` for subgraph ordering `G₁ ≤ G₂`                         | `FreeEnergy.lean`          |
+| **Free energy monotonicity (lattice)**  | `f_{G₁} ≤ f_{G₂}` for subgraph ordering `G₁ ≤ G₂`                              | `FreeEnergy.lean`          |
+| **Free energy convergence** (Prop 4.6.1) | `f_{Gₙ}` converges for any increasing subgraph sequence                         | `FreeEnergy.lean`          |
 | **Free energy** (§4.6)                       | `f = \|ι\|⁻¹ ln Z`, monotone in J and h                                        | `FreeEnergy.lean`          |
 | **Lee-Yang nonvanishing (Ising)**             | Ising partition polynomial ≠ 0 on polydisk                                      | `FreeEnergy.lean`          |
 | **GHS inequality** (Cor 4.3.4)                | `⟨σ_i; σ_j; σ_k⟩ ≤ 0` (from Lebowitz third inequality)                       | `Inequalities/GHS.lean`    |
@@ -105,6 +110,7 @@ heavy Lean measure theory assembly:
 | §4.6   | Ising nonvanishing (Thm 4.6.2)      | **Done**         | `isingEdgePoly_nonvanishing_of_graph` |                               |
 | §4.6   | Free energy monotonicity (h)        | **Done**         | `freeEnergy_monotone_h`               |                               |
 | §4.6   | Free energy monotonicity (J)        | **Done**         | `freeEnergy_monotone_J`               |                               |
+| §4.6   | Prop 4.6.1 (f_Λ convergence)        | **Done**         | `freeEnergy_convergent_subgraph`      | Lattice version via subgraph  |
 | §4.6   | Thm 4.6.2 (free energy analyticity) | **Done**         | `freeEnergyH_analyticOn`              | Real-analytic in h, J         |
 | §4.7   | Thm 4.7.1 (two-component spins)     | **Out of scope** | —                                    | XY model; vector-valued spins |
 | §4.7   | Cor 4.7.2                           | **Out of scope** | —                                    | XY model                      |

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,8 +24,8 @@ All theorems are formally proved with **zero `sorry`**.
 | **Correlation monotonicity (h)** (Prop 4.2.4) | `⟨σ^B⟩` monotone in h on `[0,∞)`                                               | `InfiniteVolume.lean`      |
 | **Covariance non-negativity**                 | `Cov(σ^B, f) ≥ 0` for HNC f under Boltzmann weight                             | `InfiniteVolume.lean`      |
 | **Correlation convergence** (Thm 4.2.3)       | `⟨σ^B⟩` converges as J → ∞                                                    | `InfiniteVolume.lean`      |
-| **Correlation monotonicity (lattice)** (Thm 4.2.3) | `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` for subgraph ordering `G₁ ≤ G₂`                | `InfiniteVolume.lean`      |
-| **Correlation convergence (lattice)** (Thm 4.2.3) | `⟨σ^A⟩_{Gₙ}` converges for any increasing sequence of subgraphs               | `InfiniteVolume.lean`      |
+| **Correlation monotonicity (lattice)** (Thm 4.2.3, discretized) | `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` for subgraph ordering `G₁ ≤ G₂` | `InfiniteVolume.lean`      |
+| **Correlation convergence (lattice)** (Thm 4.2.3, discretized) | `⟨σ^A⟩_{Gₙ}` converges for any increasing sequence of subgraphs | `InfiniteVolume.lean`      |
 | **Magnetization convergence (lattice)** | `⟨σᵢ⟩_{Gₙ}` converges for any increasing subgraph sequence                       | `InfiniteVolume.lean`      |
 | **Two-point convergence (lattice)**     | `⟨σᵢσⱼ⟩_{Gₙ}` converges for any increasing subgraph sequence                    | `InfiniteVolume.lean`      |
 | **Partition function monotonicity (lattice)** | `Z_{G₁} ≤ Z_{G₂}` for subgraph ordering `G₁ ≤ G₂`                         | `FreeEnergy.lean`          |
@@ -110,7 +110,7 @@ heavy Lean measure theory assembly:
 | §4.6   | Ising nonvanishing (Thm 4.6.2)      | **Done**         | `isingEdgePoly_nonvanishing_of_graph` |                               |
 | §4.6   | Free energy monotonicity (h)        | **Done**         | `freeEnergy_monotone_h`               |                               |
 | §4.6   | Free energy monotonicity (J)        | **Done**         | `freeEnergy_monotone_J`               |                               |
-| §4.6   | Prop 4.6.1 (f_Λ convergence)        | **Done**         | `freeEnergy_convergent_subgraph`      | Lattice version via subgraph  |
+| §4.6   | Prop 4.6.1 (f_Λ convergence)        | **Done**         | `freeEnergy_convergent_subgraph`      | Discretized: fixed ambient + growing subgraph |
 | §4.6   | Thm 4.6.2 (free energy analyticity) | **Done**         | `freeEnergyH_analyticOn`              | Real-analytic in h, J         |
 | §4.7   | Thm 4.7.1 (two-component spins)     | **Out of scope** | —                                    | XY model; vector-valued spins |
 | §4.7   | Cor 4.7.2                           | **Out of scope** | —                                    | XY model                      |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -880,6 +880,55 @@ bounded above by $1$ via \texttt{correlation\_le\_one}, hence converges by
 \texttt{tendsto\_atTop\_ciSup}.
 \end{proof}
 
+Named specializations:
+\begin{itemize}
+  \item \texttt{magnetization\_convergent\_subgraph}: $\langle\sigma_i\rangle_{G_n}$
+        converges (case $A = \{i\}$).
+  \item \texttt{twoPoint\_convergent\_subgraph}: $\langle\sigma_i\sigma_j\rangle_{G_n}$
+        converges (case $A = \{i,j\}$).
+\end{itemize}
+
+\subsection{Free energy infinite volume convergence (Proposition 4.6.1)}
+
+GJ Proposition 4.6.1 (p.~68): for the ferromagnetic pair interaction
+$H = -J\sum_{\langle i,j\rangle}\sigma_i\sigma_j - h\sum_i\sigma_i$
+(strictly ferromagnetic), the free energy per site
+$f_\Lambda = |\Lambda|^{-1}\ln Z_\Lambda$ converges as $\Lambda\uparrow\mathbb{Z}^d$.
+The discretized (fixed ambient lattice $\iota$, growing subgraph) form:
+
+\begin{theorem}[\texttt{partitionFunction\_monotone\_subgraph}]
+For ferromagnetic $p$ and $G_1\le G_2$, $Z_{G_1}\le Z_{G_2}$.
+\end{theorem}
+
+\begin{proof}
+Factor $Z_{G_2} = \sum_\sigma R(\sigma) w_{G_1}(\sigma)$ with
+$R(\sigma)=\prod_{e\in E(G_2)\setminus E(G_1)}\exp(\beta J \sigma_i\sigma_j)$.
+Use $\exp(x)\ge 1+x$ to get
+$R(\sigma)\ge 1 + \beta J \sum_{e\in E(G_2)\setminus E(G_1)}\sigma_i\sigma_j$.
+Then $\sum_\sigma R w_{G_1} \ge Z_{G_1} + \beta J \sum_e \sum_\sigma \sigma_i\sigma_j w_{G_1}$,
+and each inner sum is $\ge 0$ by GKS-I (via \texttt{boltzmannWeight\_hasNonnegCorrelations})
+applied to the pair $\{i,j\}$. Hence $Z_{G_2}\ge Z_{G_1}$.
+\end{proof}
+
+\begin{theorem}[\texttt{freeEnergy\_monotone\_subgraph}]
+For ferromagnetic $p$ and $G_1\le G_2$, $f_{G_1}\le f_{G_2}$.
+\end{theorem}
+
+\begin{proof}
+$|\iota|$ is fixed; apply $\log$ (monotone) to $Z_{G_1}\le Z_{G_2}$.
+\end{proof}
+
+\begin{theorem}[\texttt{freeEnergy\_convergent\_subgraph}, = Prop 4.6.1]
+For any increasing subgraph sequence $G_n\uparrow$ on a fixed finite ambient
+lattice $\iota$ and ferromagnetic $p$, $n\mapsto f_{G_n}$ converges.
+\end{theorem}
+
+\begin{proof}
+Monotone by \texttt{freeEnergy\_monotone\_subgraph}.
+Bounded above by $f_{\top}$ (free energy on the complete graph $\top$)
+via \texttt{le\_top}. Converges by \texttt{tendsto\_atTop\_ciSup}.
+\end{proof}
+
 \section{Free energy (\texttt{FreeEnergy.lean})}
 
 The free energy and its monotonicity properties.

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -826,9 +826,59 @@ Auxiliary results:
 The original Glimm--Jaffe formulation uses lattice growth
 $\Lambda \uparrow \mathbb{Z}^d$. In the finite-volume setting,
 this reduces to increasing coupling constants from $0$ to $J$.
-The formalization of graph embeddings and cross-lattice correlation
-is deferred to future work.
+The lattice-growth version ($\Lambda \uparrow$) is formalized
+below via the subgraph order on a fixed ambient lattice.
 \end{remark}
+
+\subsection{Lattice-growth version of Theorem 4.2.3}
+
+The Glimm--Jaffe proof of Theorem~4.2.3 reads
+``increasing $\Lambda$ amounts to increasing certain $J_A$,
+and so $\langle\xi^B\rangle$ is monotone increasing in $\Lambda$''.
+We formalize this by taking a fixed ambient \texttt{Fintype} $\iota$
+and working with subgraphs $G_1 \le G_2$ of the interaction graph:
+new edges $e \in E(G_2) \setminus E(G_1)$ correspond exactly to the
+coupling $J_A$ going from $0$ to $\beta J$.
+
+\begin{theorem}[\texttt{correlation\_monotone\_subgraph},
+  Theorem 4.2.3 (lattice version), \cite{glimm-jaffe}, p.~59]
+For a ferromagnetic Ising model on the ambient lattice $\iota$
+and subgraphs $G_1 \le G_2$,
+$\langle \sigma^A\rangle_{G_1} \le \langle\sigma^A\rangle_{G_2}$.
+\end{theorem}
+
+\begin{proof}
+Let $R(\sigma) := \prod_{e \in E(G_2)\setminus E(G_1)} \exp(\beta J \sigma_i\sigma_j)$.
+\begin{itemize}
+  \item \textbf{Factorization.} Since $H_{G_2}(\sigma) - H_{G_1}(\sigma) = -J\sum_{E(G_2)\setminus E(G_1)} \sigma_i\sigma_j$,
+    we have $w_{G_2}(\sigma) = R(\sigma)\, w_{G_1}(\sigma)$
+    (\texttt{boltzmannWeight\_subgraph\_factor}).
+  \item \textbf{HNC.} Each factor decomposes as $\cosh(\beta J) + \sinh(\beta J)\,\sigma_i\sigma_j$
+    with both coefficients $\ge 0$; by
+    \texttt{hasNonnegCorrelations\_finset\_prod},
+    $R$ has non-negative correlations
+    (\texttt{hasNonnegCorrelations\_edge\_prod\_of\_finset}).
+  \item \textbf{Covariance.} Apply \texttt{cov\_hnc\_boltzmann\_nonneg}
+    with base graph $G_1$ and function $R$:
+    \[
+      \bigl(\textstyle\sum_\sigma \sigma^A R(\sigma) w_1\bigr)Z_{G_1}
+      \ge \bigl(\sum_\sigma \sigma^A w_1\bigr)\bigl(\sum_\sigma R(\sigma) w_1\bigr).
+    \]
+    Substituting $R w_1 = w_2$ yields $Z_{G_1} N_{G_2}(A) \ge Z_{G_2} N_{G_1}(A)$,
+    i.e., $\langle\sigma^A\rangle_{G_1} \le \langle\sigma^A\rangle_{G_2}$.
+\end{itemize}
+\end{proof}
+
+\begin{theorem}[\texttt{correlation\_convergent\_subgraph}]
+For any increasing sequence of subgraphs $G_1 \le G_2 \le \cdots$ of the ambient lattice,
+the correlation sequence $n \mapsto \langle\sigma^A\rangle_{G_n}$ converges.
+\end{theorem}
+
+\begin{proof}
+Monotone increasing by \texttt{correlation\_monotone\_subgraph},
+bounded above by $1$ via \texttt{correlation\_le\_one}, hence converges by
+\texttt{tendsto\_atTop\_ciSup}.
+\end{proof}
 
 \section{Free energy (\texttt{FreeEnergy.lean})}
 


### PR DESCRIPTION
## Summary

Complete the lattice-growth ($\Lambda \uparrow$) form of Glimm–Jaffe's
infinite volume convergence results, previously only formalized in
their $J \to \infty$ specializations.

- **Theorem 4.2.3 (lattice version)** — correlation functions converge
  along any increasing subgraph sequence $G_n \uparrow$ on a fixed
  ambient finite lattice.
- **Proposition 4.6.1** — free energy per site $f_{G_n}$ converges
  along any increasing subgraph sequence.

## New theorems

### `IsingModel/InfiniteVolume.lean`
- `correlation_le_one` — upper bound without absolute value.
- `boltzmannWeight_subgraph_factor` — factor $w_{G_2} = R \cdot w_{G_1}$
  with $R = \prod_{e \in E(G_2)\setminus E(G_1)} \exp(\beta J \sigma_i\sigma_j)$.
- `correlation_monotone_subgraph` — $\langle\sigma^A\rangle_{G_1} \le
  \langle\sigma^A\rangle_{G_2}$ for $G_1 \le G_2$, ferromagnetic.
- `correlation_convergent_subgraph` — convergence of
  $\langle\sigma^A\rangle_{G_n}$ for any increasing $G_n$.
- `magnetization_convergent_subgraph` — specialization to $A = \{i\}$.
- `twoPoint_convergent_subgraph` — specialization to $A = \{i, j\}$.

### `IsingModel/FreeEnergy.lean`
- `partitionFunction_monotone_subgraph` — $Z_{G_1} \le Z_{G_2}$ for
  $G_1 \le G_2$, ferromagnetic.
- `freeEnergy_monotone_subgraph` — $f_{G_1} \le f_{G_2}$.
- `freeEnergy_convergent_subgraph` — **Prop 4.6.1**: free energy
  converges along any increasing subgraph sequence, bounded by $f_\top$.

## Proof structure

The core identity is the reweighting factorization

$$w_{G_2}(\sigma) = \Big(\prod_{e \in E(G_2)\setminus E(G_1)} \exp(\beta J \sigma_i\sigma_j)\Big) w_{G_1}(\sigma).$$

For correlation monotonicity, the factor $R$ has non-negative correlations
(each factor decomposes as $\cosh + \sinh \cdot \sigma_i\sigma_j$ with both
coefficients $\ge 0$). Applying `cov_hnc_boltzmann_nonneg` on the base graph
$G_1$ and substituting $R w_{G_1} = w_{G_2}$ yields the monotonicity.

For partition function monotonicity, the simpler $\exp(x) \ge 1 + x$ bound
plus GKS-I on the pair $\{i, j\}$ gives $Z_{G_2} \ge Z_{G_1}$ directly.

## Test plan

- [x] `lake build` — all 2776 targets
- [x] `lake exe GKSTest` — all tests pass
- [x] Zero `sorry`, zero linter warnings
- [x] Documentation (`docs/index.md`, `tex/proof-guide.tex`) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)