### PR TITLE
feat: correlation β-monotonicity and β → ∞ convergence

### DIFF
--- a/IsingModel/InfiniteVolume.lean
+++ b/IsingModel/InfiniteVolume.lean
@@ -701,4 +701,89 @@ theorem twoPoint_convergent_subgraph
       Filter.atTop (nhds L) :=
   correlation_convergent_subgraph Gn hmono p hf {i, j}
 
+/-! ## Monotonicity in β (inverse temperature)
+
+The correlation function is monotone increasing in β for ferromagnetic
+parameters. Proof uses the rescaling identity
+`⟨σ^A⟩_{(J,h,β)} = ⟨σ^A⟩_{(βJ, βh, 1)}`
+(analogous to `partitionFunction_beta_rescale` in `Conditioning.lean`)
+to reduce to the already-established `correlation_monotone_J`
+(Prop 4.2.1) and `correlation_monotone_h` (Prop 4.2.4).
+
+Reference: Glimm–Jaffe, Propositions 4.2.1 and 4.2.4 (the J- and h-
+monotonicity of correlation); Cor. 10.2.3 is the corresponding statement
+for the partition function `Z`. -/
+
+/-- The rescaling identity for the correlation function:
+`⟨σ^A⟩_{(J, h, β)} = ⟨σ^A⟩_{(βJ, βh, 1)}`. Follows from the fact that
+the Boltzmann weights `exp(-β H_{J,h}(σ))` and `exp(-1 · H_{βJ,βh}(σ))`
+are pointwise equal. -/
+private theorem correlation_rescale_beta
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h β : ℝ) (A : Finset ι) :
+    correlation G ⟨J, h, β⟩ A = correlation G ⟨β * J, β * h, 1⟩ A := by
+  have hw : ∀ σ : Config ι,
+      boltzmannWeight G ⟨J, h, β⟩ σ = boltzmannWeight G ⟨β * J, β * h, 1⟩ σ := by
+    intro σ
+    unfold boltzmannWeight hamiltonian interactionEnergy externalFieldEnergy
+    congr 1; ring
+  unfold correlation gibbsExpectation partitionFunction
+  simp_rw [hw]
+
+/-- **Correlation β-monotonicity**: for ferromagnetic parameters
+(`J ≥ 0`, `h ≥ 0`), the correlation function is monotone increasing in
+the inverse temperature `β` on `(0, ∞)`.
+
+Proof: Apply the rescaling identity `correlation_rescale_beta` to
+reduce to `correlation_monotone_J` and `correlation_monotone_h`:
+increasing β from β₁ to β₂ moves `(β₁J, β₁h)` to `(β₂J, β₂h)` with
+both components non-decreasing. -/
+theorem correlation_monotone_beta (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J : ℝ) (hJ : 0 ≤ J) (h : ℝ) (hh : 0 ≤ h) (A : Finset ι) :
+    MonotoneOn (fun β : ℝ => correlation G ⟨J, h, β⟩ A) (Set.Ioi 0) := by
+  intro β₁ hβ₁ β₂ _ hβ
+  change correlation G ⟨J, h, β₁⟩ A ≤ correlation G ⟨J, h, β₂⟩ A
+  rw [correlation_rescale_beta G J h β₁ A,
+      correlation_rescale_beta G J h β₂ A]
+  have hβ₁' : 0 < β₁ := hβ₁
+  have hβ₂' : 0 < β₂ := lt_of_lt_of_le hβ₁' hβ
+  have hβ₁J : 0 ≤ β₁ * J := mul_nonneg hβ₁'.le hJ
+  have hβ₂J : 0 ≤ β₂ * J := mul_nonneg hβ₂'.le hJ
+  have hβ₁h : 0 ≤ β₁ * h := mul_nonneg hβ₁'.le hh
+  have hβ₂h : 0 ≤ β₂ * h := mul_nonneg hβ₂'.le hh
+  calc correlation G ⟨β₁ * J, β₁ * h, 1⟩ A
+      ≤ correlation G ⟨β₂ * J, β₁ * h, 1⟩ A :=
+        correlation_monotone_J G (β₁ * h) hβ₁h 1 one_pos A
+          (Set.mem_Ici.mpr hβ₁J) (Set.mem_Ici.mpr hβ₂J)
+          (mul_le_mul_of_nonneg_right hβ hJ)
+    _ ≤ correlation G ⟨β₂ * J, β₂ * h, 1⟩ A :=
+        correlation_monotone_h G (β₂ * J) hβ₂J 1 one_pos A
+          (Set.mem_Ici.mpr hβ₁h) (Set.mem_Ici.mpr hβ₂h)
+          (mul_le_mul_of_nonneg_right hβ hh)
+
+/-- **Correlation β-convergence**: for ferromagnetic parameters
+(`J ≥ 0`, `h ≥ 0`), the sequence `⟨σ^A⟩_{(J, h, n+1)}` converges as
+`n → ∞`. Uses `β = n + 1` to keep `β > 0`.
+
+Proof: Monotone increasing by `correlation_monotone_beta`, bounded above
+by `1` via `correlation_le_one`, hence converges by `tendsto_atTop_ciSup`. -/
+theorem correlation_convergent_beta (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J : ℝ) (hJ : 0 ≤ J) (h : ℝ) (hh : 0 ≤ h) (A : Finset ι) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => correlation G ⟨J, h, (n + 1 : ℝ)⟩ A)
+      Filter.atTop (nhds L) := by
+  have h_mono : Monotone (fun n : ℕ => correlation G ⟨J, h, (n + 1 : ℝ)⟩ A) := by
+    intro a b hab
+    have ha : (0 : ℝ) < (a : ℝ) + 1 := by positivity
+    have hb : (0 : ℝ) < (b : ℝ) + 1 := by positivity
+    have hab' : (a : ℝ) + 1 ≤ (b : ℝ) + 1 := by
+      have : (a : ℝ) ≤ (b : ℝ) := Nat.cast_le.mpr hab
+      linarith
+    exact correlation_monotone_beta G J hJ h hh A
+      (Set.mem_Ioi.mpr ha) (Set.mem_Ioi.mpr hb) hab'
+  have h_bdd : BddAbove (Set.range
+      (fun n : ℕ => correlation G ⟨J, h, (n + 1 : ℝ)⟩ A)) :=
+    ⟨1, fun _ ⟨n, hn⟩ => hn ▸ correlation_le_one G ⟨J, h, (n + 1 : ℝ)⟩ A⟩
+  exact ⟨_, tendsto_atTop_ciSup h_mono h_bdd⟩
+
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ All theorems are formally proved with **zero `sorry`**.
 | **Correlation boundedness** (Prop 4.2.2)      | `\|⟨σ^A⟩\| ≤ 1`                                                                | `InfiniteVolume.lean`      |
 | **Correlation monotonicity (J)** (Prop 4.2.1) | `⟨σ^B⟩` monotone in J on `[0,∞)`                                               | `InfiniteVolume.lean`      |
 | **Correlation monotonicity (h)** (Prop 4.2.4) | `⟨σ^B⟩` monotone in h on `[0,∞)`                                               | `InfiniteVolume.lean`      |
+| **Correlation monotonicity (β)**             | `⟨σ^A⟩` monotone in β on `(0,∞)` for ferromagnetic                            | `InfiniteVolume.lean`      |
+| **Correlation β → ∞ convergence**           | `⟨σ^A⟩_{(J,h,n+1)}` converges for ferromagnetic                                | `InfiniteVolume.lean`      |
 | **Covariance non-negativity**                 | `Cov(σ^B, f) ≥ 0` for HNC f under Boltzmann weight                             | `InfiniteVolume.lean`      |
 | **Correlation convergence** (Thm 4.2.3)       | `⟨σ^B⟩` converges as J → ∞                                                    | `InfiniteVolume.lean`      |
 | **Correlation monotonicity (lattice)** (Thm 4.2.3, discretized) | `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` for subgraph ordering `G₁ ≤ G₂` | `InfiniteVolume.lean`      |
@@ -135,7 +137,7 @@ heavy Lean measure theory assembly:
 | Section | Result                                     | Status   | Lean                | Notes                                                |
 |---------|--------------------------------------------|----------|---------------------|------------------------------------------------------|
 | §10.1  | Introduction                               | **Done** | —                  | Overview; lattice version is Ch.4                    |
-| §10.2  | Correlation inequalities / β-monotonicity | **Done** | `Conditioning.lean` | Cor 10.2.3: Z monotone in β                         |
+| §10.2  | Correlation inequalities / β-monotonicity | **Done** | `Conditioning.lean`, `InfiniteVolume.lean` | Cor 10.2.3: Z and ⟨σ^A⟩ monotone in β; ⟨σ^A⟩ β → ∞ convergence |
 | §10.3  | Dirichlet/Neumann monotonicity             | **Done** | `Conditioning.lean` | Hamiltonian bound, Z upper/lower bounds (Cor 10.3.2) |
 | §10.4  | Reflection positivity                      | **Done** | `Conditioning.lean` | Definition, discriminant/Schwarz inequality          |
 | §10.5  | Multiple reflections                       | **Done** | `Conditioning.lean` | Iterated Schwarz inequality                          |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -918,6 +918,34 @@ For ferromagnetic $p$ and $G_1\le G_2$, $f_{G_1}\le f_{G_2}$.
 $|\iota|$ is fixed; apply $\log$ (monotone) to $Z_{G_1}\le Z_{G_2}$.
 \end{proof}
 
+\subsection{$\beta$-monotonicity and $\beta \to \infty$ convergence}
+
+Rescale identity (\texttt{correlation\_rescale\_beta}):
+$\langle\sigma^A\rangle_{(J,h,\beta)} = \langle\sigma^A\rangle_{(\beta J, \beta h, 1)}$.
+
+\begin{theorem}[\texttt{correlation\_monotone\_beta}]
+For $J, h \ge 0$, the correlation function is monotone increasing in
+$\beta$ on $(0, \infty)$.
+\end{theorem}
+
+\begin{proof}
+Apply the rescale identity; then $\beta_1 \le \beta_2$ gives
+$\beta_1 J \le \beta_2 J$ and $\beta_1 h \le \beta_2 h$ at both
+endpoints.  Apply \texttt{correlation\_monotone\_J} and
+\texttt{correlation\_monotone\_h}.
+\end{proof}
+
+\begin{theorem}[\texttt{correlation\_convergent\_beta}]
+For $J, h \ge 0$ and any finite set $A$, the sequence
+$\langle\sigma^A\rangle_{(J,h,n+1)}$ converges as $n \to \infty$.
+\end{theorem}
+
+\begin{proof}
+Monotone by \texttt{correlation\_monotone\_beta}, bounded above by
+$1$ via \texttt{correlation\_le\_one}. Converges by
+\texttt{tendsto\_atTop\_ciSup}.
+\end{proof}
+
 \begin{theorem}[\texttt{freeEnergy\_convergent\_subgraph}, = Prop 4.6.1]
 For any increasing subgraph sequence $G_n\uparrow$ on a fixed finite ambient
 lattice $\iota$ and ferromagnetic $p$, $n\mapsto f_{G_n}$ converges.


### PR DESCRIPTION
## Summary

Complete the monotonicity matrix for correlation functions by adding the
**β (inverse temperature)** direction. Previously PRs covered J, h, and
lattice (subgraph) monotonicity and convergence; this PR adds β.

## New theorems (\`IsingModel/InfiniteVolume.lean\`)

- \`correlation_rescale_beta\` — $\langle\sigma^A\rangle_{(J,h,\beta)}
  = \langle\sigma^A\rangle_{(\beta J, \beta h, 1)}$.
- \`correlation_monotone_beta\` — for $J, h \ge 0$, the correlation is
  monotone in $\beta$ on $(0, \infty)$.
- \`correlation_convergent_beta\` — for $J, h \ge 0$, the sequence
  $\langle\sigma^A\rangle_{(J, h, n)}$ converges as $n \to \infty$.

## Proof

The β-rescale identity reduces β-monotonicity to J-monotonicity and
h-monotonicity (already formalized). Boundedness by 1 (\`abs_correlation_le_one\`)
and \`tendsto_atTop_ciSup\` give convergence.

## Test plan

- [ ] \`lake build\` — all targets
- [ ] \`lake exe GKSTest\` — all tests pass
- [ ] Zero \`sorry\`, zero linter warnings
- [ ] \`copilot -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)