### PR TITLE
feat: free energy β-monotonicity + magnetization β corollaries

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -591,6 +591,52 @@ theorem freeEnergy_monotone_subgraph
   exact Real.log_le_log (partitionFunction_pos G₁ p)
     (partitionFunction_monotone_subgraph h₁₂ p hf)
 
+/-- The free energy rescaling identity in `β`:
+`f(J, h, β) = f(βJ, βh, 1)`. Follows from `partitionFunction_beta_rescale`
+(after taking `log` and multiplying by `|ι|⁻¹`). -/
+private theorem freeEnergy_rescale_beta
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h β : ℝ) :
+    freeEnergy G ⟨J, h, β⟩ = freeEnergy G ⟨β * J, β * h, 1⟩ := by
+  unfold freeEnergy
+  congr 1
+  have hw : ∀ σ : Config ι,
+      boltzmannWeight G ⟨J, h, β⟩ σ = boltzmannWeight G ⟨β * J, β * h, 1⟩ σ := by
+    intro σ
+    unfold boltzmannWeight hamiltonian interactionEnergy externalFieldEnergy
+    congr 1; ring
+  unfold partitionFunction
+  simp_rw [hw]
+
+/-- **Free energy β-monotonicity**: for `J, h ≥ 0`, the free energy per
+site is monotone increasing in the inverse temperature `β` on `(0, ∞)`.
+
+Proof: Apply the rescaling identity `freeEnergy_rescale_beta` and
+combine `freeEnergy_monotone_J` and `freeEnergy_monotone_h`. -/
+theorem freeEnergy_monotone_beta (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J : ℝ) (hJ : 0 ≤ J) (h : ℝ) (hh : 0 ≤ h) :
+    MonotoneOn (fun β : ℝ => freeEnergy G ⟨J, h, β⟩) (Set.Ioi 0) := by
+  intro β₁ hβ₁ β₂ _ hβ
+  change freeEnergy G ⟨J, h, β₁⟩ ≤ freeEnergy G ⟨J, h, β₂⟩
+  rw [freeEnergy_rescale_beta G J h β₁, freeEnergy_rescale_beta G J h β₂]
+  have hβ₁' : 0 < β₁ := hβ₁
+  have hβ₂' : 0 < β₂ := lt_of_lt_of_le hβ₁' hβ
+  have hβ₁J : 0 ≤ β₁ * J := mul_nonneg hβ₁'.le hJ
+  have hβ₂J : 0 ≤ β₂ * J := mul_nonneg hβ₂'.le hJ
+  have hβ₁h : 0 ≤ β₁ * h := mul_nonneg hβ₁'.le hh
+  have hβ₂h : 0 ≤ β₂ * h := mul_nonneg hβ₂'.le hh
+  calc freeEnergy G ⟨β₁ * J, β₁ * h, 1⟩
+      ≤ freeEnergy G ⟨β₂ * J, β₁ * h, 1⟩ := by
+        have := freeEnergy_monotone_J G (β₁ * h) 1 hβ₁h one_pos
+          (Set.mem_Ici.mpr hβ₁J) (Set.mem_Ici.mpr hβ₂J)
+          (mul_le_mul_of_nonneg_right hβ hJ)
+        exact this
+    _ ≤ freeEnergy G ⟨β₂ * J, β₂ * h, 1⟩ := by
+        have := freeEnergy_monotone_h G (β₂ * J) 1 hβ₂J one_pos
+          (Set.mem_Ici.mpr hβ₁h) (Set.mem_Ici.mpr hβ₂h)
+          (mul_le_mul_of_nonneg_right hβ hh)
+        exact this
+
 /-- **Proposition 4.6.1** (Glimm–Jaffe, p. 68): The free energy converges
 along any increasing sequence of subgraphs on a fixed ambient finite lattice.
 

--- a/IsingModel/PhaseTransition.lean
+++ b/IsingModel/PhaseTransition.lean
@@ -205,6 +205,26 @@ theorem magnetization_monotone_h (G : SimpleGraph ι) [Fintype G.edgeSet]
   unfold magnetization
   exact correlation_monotone_h G J hJ β hβ {i} hh₁ hh₂ hh
 
+/-- **Magnetization β-monotonicity**: for `J, h ≥ 0`, the magnetization
+`Mᵢ = ⟨σᵢ⟩` is monotone increasing in `β` on `(0, ∞)`.
+Direct specialization of `correlation_monotone_beta` at `A = {i}`. -/
+theorem magnetization_monotone_beta (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J : ℝ) (hJ : 0 ≤ J) (h : ℝ) (hh : 0 ≤ h) (i : ι) :
+    MonotoneOn (fun β : ℝ => magnetization G ⟨J, h, β⟩ i) (Set.Ioi 0) := by
+  intro β₁ hβ₁ β₂ hβ₂ hβ
+  unfold magnetization
+  exact correlation_monotone_beta G J hJ h hh {i} hβ₁ hβ₂ hβ
+
+/-- **Magnetization β → ∞ convergence**: for `J, h ≥ 0`, the sequence
+`n ↦ Mᵢ(J, h, n+1)` converges as `n → ∞`.
+Direct specialization of `correlation_convergent_beta` at `A = {i}`. -/
+theorem magnetization_convergent_beta (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J : ℝ) (hJ : 0 ≤ J) (h : ℝ) (hh : 0 ≤ h) (i : ι) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => magnetization G ⟨J, h, (n + 1 : ℝ)⟩ i)
+      Filter.atTop (nhds L) :=
+  correlation_convergent_beta G J hJ h hh {i}
+
 /-! ## Critical exponents (§17.7)
 
 Glimm–Jaffe §17.7 (pp. 314–316) derives bounds on critical exponents

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,9 @@ All theorems are formally proved with **zero `sorry`**.
 | **Correlation monotonicity (h)** (Prop 4.2.4) | `⟨σ^B⟩` monotone in h on `[0,∞)`                                               | `InfiniteVolume.lean`      |
 | **Correlation monotonicity (β)**             | `⟨σ^A⟩` monotone in β on `(0,∞)` for ferromagnetic                            | `InfiniteVolume.lean`      |
 | **Correlation β → ∞ convergence**           | `⟨σ^A⟩_{(J,h,n+1)}` converges for ferromagnetic                                | `InfiniteVolume.lean`      |
+| **Free energy monotonicity (β)**             | `f(J,h,β)` monotone in β on `(0,∞)` for ferromagnetic                         | `FreeEnergy.lean`          |
+| **Magnetization monotonicity (β)**           | `Mᵢ` monotone in β on `(0,∞)` for ferromagnetic                               | `PhaseTransition.lean`     |
+| **Magnetization β → ∞ convergence**         | `Mᵢ(J,h,n+1)` converges for ferromagnetic                                      | `PhaseTransition.lean`     |
 | **Covariance non-negativity**                 | `Cov(σ^B, f) ≥ 0` for HNC f under Boltzmann weight                             | `InfiniteVolume.lean`      |
 | **Correlation convergence** (Thm 4.2.3)       | `⟨σ^B⟩` converges as J → ∞                                                    | `InfiniteVolume.lean`      |
 | **Correlation monotonicity (lattice)** (Thm 4.2.3, discretized) | `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` for subgraph ordering `G₁ ≤ G₂` | `InfiniteVolume.lean`      |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -920,8 +920,15 @@ $|\iota|$ is fixed; apply $\log$ (monotone) to $Z_{G_1}\le Z_{G_2}$.
 
 \subsection{$\beta$-monotonicity and $\beta \to \infty$ convergence}
 
-Rescale identity (\texttt{correlation\_rescale\_beta}):
-$\langle\sigma^A\rangle_{(J,h,\beta)} = \langle\sigma^A\rangle_{(\beta J, \beta h, 1)}$.
+Rescale identities:
+\[
+  \langle\sigma^A\rangle_{(J,h,\beta)} = \langle\sigma^A\rangle_{(\beta J, \beta h, 1)}
+  \quad\text{(\texttt{correlation\_rescale\_beta})}
+\]
+\[
+  f(J,h,\beta) = f(\beta J, \beta h, 1)
+  \quad\text{(\texttt{freeEnergy\_rescale\_beta})}
+\]
 
 \begin{theorem}[\texttt{correlation\_monotone\_beta}]
 For $J, h \ge 0$, the correlation function is monotone increasing in
@@ -945,6 +952,26 @@ Monotone by \texttt{correlation\_monotone\_beta}, bounded above by
 $1$ via \texttt{correlation\_le\_one}. Converges by
 \texttt{tendsto\_atTop\_ciSup}.
 \end{proof}
+
+\begin{theorem}[\texttt{freeEnergy\_monotone\_beta}]
+For $J, h \ge 0$, the free energy $f(J,h,\beta)$ is monotone in $\beta$
+on $(0,\infty)$.
+\end{theorem}
+
+\begin{proof}
+Apply the rescale identity, then \texttt{freeEnergy\_monotone\_J} and
+\texttt{freeEnergy\_monotone\_h}.
+\end{proof}
+
+\begin{remark}
+The free energy does not converge as $\beta\to\infty$
+(it grows linearly in $\beta$, since $\log Z \sim \beta(J|E| + h|\iota|)$
+at low temperature).
+\end{remark}
+
+Specializations to magnetization:
+\texttt{magnetization\_monotone\_beta},
+\texttt{magnetization\_convergent\_beta} (both via $A = \{i\}$).
 
 \begin{theorem}[\texttt{freeEnergy\_convergent\_subgraph}, = Prop 4.6.1]
 For any increasing subgraph sequence $G_n\uparrow$ on a fixed finite ambient


### PR DESCRIPTION
## Summary

Follow-up to PR #66. Lift the correlation β-monotonicity to the free
energy level, and add named magnetization β corollaries.

## New theorems

### \`IsingModel/FreeEnergy.lean\`
- \`freeEnergy_rescale_beta\` — $f(J,h,\beta) = f(\beta J, \beta h, 1)$
- \`freeEnergy_monotone_beta\` — $f$ monotone in $\beta$ on $(0,\infty)$
  for $J, h \ge 0$

### \`IsingModel/PhaseTransition.lean\`
- \`magnetization_monotone_beta\` — $M_i$ monotone in $\beta$ (corollary of
  \`correlation_monotone_beta\` at $A = \{i\}$)
- \`magnetization_convergent_beta\` — $M_i(J, h, n+1)$ converges

## Note

Free energy does **not** converge as $\beta \to \infty$ (it grows
linearly, since $\log Z \sim \beta (J |E| + h |\iota|)$ at low
temperature). Only the monotonicity is meaningful in that direction.

Correlation functions, by contrast, are bounded and do converge
(already in PR #66).

## Test plan

- [ ] \`lake build\`
- [ ] \`lake exe GKSTest\`
- [ ] Zero \`sorry\` / linter warnings
- [ ] \`copilot -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)