### PR TITLE
feat: correlation h → ∞ convergence

### DIFF
--- a/IsingModel/InfiniteVolume.lean
+++ b/IsingModel/InfiniteVolume.lean
@@ -786,4 +786,34 @@ theorem correlation_convergent_beta (G : SimpleGraph ι) [Fintype G.edgeSet]
     ⟨1, fun _ ⟨n, hn⟩ => hn ▸ correlation_le_one G ⟨J, h, (n + 1 : ℝ)⟩ A⟩
   exact ⟨_, tendsto_atTop_ciSup h_mono h_bdd⟩
 
+/-! ## Convergence as h → ∞
+
+Filling the monotonicity/convergence matrix: we had `J → ∞`
+(`correlation_convergent`) and `β → ∞` (`correlation_convergent_beta`);
+this section adds `h → ∞` by the same monotone-bounded argument using
+`correlation_monotone_h` (Prop 4.2.4). -/
+
+/-- **Correlation h → ∞ convergence**: for ferromagnetic parameters
+(`J ≥ 0`, `β > 0`), the sequence `n ↦ ⟨σ^A⟩_{(J, n, β)}` converges as
+`n → ∞`.
+
+Proof: Monotone increasing by `correlation_monotone_h` (Prop 4.2.4),
+bounded above by `1` via `correlation_le_one`, hence converges by
+`tendsto_atTop_ciSup`. -/
+theorem correlation_convergent_h (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J : ℝ) (hJ : 0 ≤ J) (β : ℝ) (hβ : 0 < β) (A : Finset ι) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => correlation G ⟨J, (n : ℝ), β⟩ A)
+      Filter.atTop (nhds L) := by
+  have h_mono : Monotone (fun n : ℕ => correlation G ⟨J, (n : ℝ), β⟩ A) := by
+    intro a b hab
+    have ha : (0 : ℝ) ≤ (a : ℝ) := Nat.cast_nonneg a
+    have hb : (0 : ℝ) ≤ (b : ℝ) := Nat.cast_nonneg b
+    exact correlation_monotone_h G J hJ β hβ A
+      (Set.mem_Ici.mpr ha) (Set.mem_Ici.mpr hb) (by exact_mod_cast hab)
+  have h_bdd : BddAbove (Set.range
+      (fun n : ℕ => correlation G ⟨J, (n : ℝ), β⟩ A)) :=
+    ⟨1, fun _ ⟨n, hn⟩ => hn ▸ correlation_le_one G ⟨J, (n : ℝ), β⟩ A⟩
+  exact ⟨_, tendsto_atTop_ciSup h_mono h_bdd⟩
+
 end IsingModel

--- a/IsingModel/PhaseTransition.lean
+++ b/IsingModel/PhaseTransition.lean
@@ -225,6 +225,16 @@ theorem magnetization_convergent_beta (G : SimpleGraph ι) [Fintype G.edgeSet]
       Filter.atTop (nhds L) :=
   correlation_convergent_beta G J hJ h hh {i}
 
+/-- **Magnetization h → ∞ convergence**: for `J ≥ 0`, `β > 0`, the sequence
+`n ↦ Mᵢ(J, n, β)` converges as `n → ∞`.
+Direct specialization of `correlation_convergent_h` at `A = {i}`. -/
+theorem magnetization_convergent_h (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J : ℝ) (hJ : 0 ≤ J) (β : ℝ) (hβ : 0 < β) (i : ι) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => magnetization G ⟨J, (n : ℝ), β⟩ i)
+      Filter.atTop (nhds L) :=
+  correlation_convergent_h G J hJ β hβ {i}
+
 /-! ## Critical exponents (§17.7)
 
 Glimm–Jaffe §17.7 (pp. 314–316) derives bounds on critical exponents

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,9 +24,11 @@ All theorems are formally proved with **zero `sorry`**.
 | **Correlation monotonicity (h)** (Prop 4.2.4) | `⟨σ^B⟩` monotone in h on `[0,∞)`                                               | `InfiniteVolume.lean`      |
 | **Correlation monotonicity (β)**             | `⟨σ^A⟩` monotone in β on `(0,∞)` for ferromagnetic                            | `InfiniteVolume.lean`      |
 | **Correlation β → ∞ convergence**           | `⟨σ^A⟩_{(J,h,n+1)}` converges for ferromagnetic                                | `InfiniteVolume.lean`      |
+| **Correlation h → ∞ convergence**           | `⟨σ^A⟩_{(J,n,β)}` converges for ferromagnetic                                  | `InfiniteVolume.lean`      |
 | **Free energy monotonicity (β)**             | `f(J,h,β)` monotone in β on `(0,∞)` for ferromagnetic                         | `FreeEnergy.lean`          |
 | **Magnetization monotonicity (β)**           | `Mᵢ` monotone in β on `(0,∞)` for ferromagnetic                               | `PhaseTransition.lean`     |
 | **Magnetization β → ∞ convergence**         | `Mᵢ(J,h,n+1)` converges for ferromagnetic                                      | `PhaseTransition.lean`     |
+| **Magnetization h → ∞ convergence**         | `Mᵢ(J,n,β)` converges for ferromagnetic                                        | `PhaseTransition.lean`     |
 | **Covariance non-negativity**                 | `Cov(σ^B, f) ≥ 0` for HNC f under Boltzmann weight                             | `InfiniteVolume.lean`      |
 | **Correlation convergence** (Thm 4.2.3)       | `⟨σ^B⟩` converges as J → ∞                                                    | `InfiniteVolume.lean`      |
 | **Correlation monotonicity (lattice)** (Thm 4.2.3, discretized) | `⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` for subgraph ordering `G₁ ≤ G₂` | `InfiniteVolume.lean`      |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -973,6 +973,21 @@ Specializations to magnetization:
 \texttt{magnetization\_monotone\_beta},
 \texttt{magnetization\_convergent\_beta} (both via $A = \{i\}$).
 
+\subsection{Convergence as $h \to \infty$}
+
+\begin{theorem}[\texttt{correlation\_convergent\_h}]
+For $J \ge 0$, $\beta > 0$, the sequence
+$n \mapsto \langle\sigma^A\rangle_{(J,n,\beta)}$ converges.
+\end{theorem}
+
+\begin{proof}
+Monotone by \texttt{correlation\_monotone\_h} (Prop.~4.2.4),
+bounded above by $1$ via \texttt{correlation\_le\_one}.
+Apply \texttt{tendsto\_atTop\_ciSup}.
+\end{proof}
+
+Specialization: \texttt{magnetization\_convergent\_h} via $A = \{i\}$.
+
 \begin{theorem}[\texttt{freeEnergy\_convergent\_subgraph}, = Prop 4.6.1]
 For any increasing subgraph sequence $G_n\uparrow$ on a fixed finite ambient
 lattice $\iota$ and ferromagnetic $p$, $n\mapsto f_{G_n}$ converges.


### PR DESCRIPTION
## Summary

Complete the monotonicity/convergence matrix by filling in the missing
h → ∞ direction. We already had J → ∞ and β → ∞; this PR adds h → ∞.

## New theorems

- \`correlation_convergent_h\` (\`IsingModel/InfiniteVolume.lean\`):
  for $J \ge 0$, $\beta > 0$, the sequence $n \mapsto \langle\sigma^A\rangle_{(J,n,\beta)}$
  converges. Proof: \`correlation_monotone_h\` + \`correlation_le_one\` +
  \`tendsto_atTop_ciSup\`.

- \`magnetization_convergent_h\` (\`IsingModel/PhaseTransition.lean\`):
  specialization at $A = \{i\}$.

## Test plan

- [ ] \`lake build\`
- [ ] \`lake exe GKSTest\`
- [ ] Zero \`sorry\` / linter warnings
- [ ] \`copilot -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)