### PR TITLE
feat: ambient subgraph monotonicity on Λ

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -188,5 +188,57 @@ theorem abs_correlationAlongExhaustion_eventually_le_one
   rw [heq]
   exact abs_correlationΛ_le_one G (Λ.volume n) p (liftFinset A hA)
 
+/-! ## Monotonicity in the ambient subgraph direction
+
+For a fixed finite volume `Λ : Finset V`, if `G₁ ≤ G₂` as
+`SimpleGraph V`, then the induced subgraphs satisfy
+`G₁.induce Λ ≤ G₂.induce Λ` as `SimpleGraph (↑Λ)`.  Applying the
+existing `partitionFunction_monotone_subgraph`,
+`correlation_monotone_subgraph`, and `freeEnergy_monotone_subgraph`
+on the finite `Fintype (↑Λ)` then gives monotonicity on `Λ` in the
+ambient subgraph direction. -/
+
+omit [DecidableEq V] in
+/-- The induced subgraph is monotone in the ambient graph. -/
+theorem inducedGraph_mono {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂)
+    (Λ : Finset V) : inducedGraph G₁ Λ ≤ inducedGraph G₂ Λ := by
+  intro u v hadj
+  exact h hadj
+
+/-- **Partition function ambient-subgraph monotonicity**:
+for `G₁ ≤ G₂` (ambient) and ferromagnetic `p`,
+`Z_{G₁,Λ} ≤ Z_{G₂,Λ}` on any finite volume `Λ`. -/
+theorem partitionFunctionΛ_monotone_ambient_subgraph
+    {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂) (Λ : Finset V)
+    [Fintype (inducedGraph G₁ Λ).edgeSet]
+    [Fintype (inducedGraph G₂ Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunctionΛ G₁ Λ p ≤ partitionFunctionΛ G₂ Λ p :=
+  IsingModel.partitionFunction_monotone_subgraph (inducedGraph_mono h Λ) p hf
+
+/-- **Correlation ambient-subgraph monotonicity**:
+for `G₁ ≤ G₂` (ambient) and ferromagnetic `p`,
+`⟨σ^A⟩_{G₁,Λ} ≤ ⟨σ^A⟩_{G₂,Λ}` on any finite volume `Λ` and
+`A : Finset (↑Λ)`. -/
+theorem correlationΛ_monotone_ambient_subgraph
+    {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂) (Λ : Finset V)
+    [Fintype (inducedGraph G₁ Λ).edgeSet]
+    [Fintype (inducedGraph G₂ Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset (↑Λ : Type _)) :
+    correlationΛ G₁ Λ p A ≤ correlationΛ G₂ Λ p A :=
+  IsingModel.correlation_monotone_subgraph (inducedGraph_mono h Λ) p hf A
+
+/-- **Free energy ambient-subgraph monotonicity**:
+for `G₁ ≤ G₂` (ambient) and ferromagnetic `p`,
+`f_{G₁,Λ} ≤ f_{G₂,Λ}` on any finite volume `Λ`. -/
+theorem freeEnergyΛ_monotone_ambient_subgraph
+    {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂) (Λ : Finset V)
+    [Fintype (inducedGraph G₁ Λ).edgeSet]
+    [Fintype (inducedGraph G₂ Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    freeEnergyΛ G₁ Λ p ≤ freeEnergyΛ G₂ Λ p :=
+  IsingModel.freeEnergy_monotone_subgraph (inducedGraph_mono h Λ) p hf
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,6 +134,10 @@ ambient framework:
 | `Exhaustion V` | structure: monotone `Λₙ` covering any finite set eventually |
 | `correlationAlongExhaustion` | correlation along an exhaustion for fixed `A : Finset V` |
 | `abs_correlationAlongExhaustion_eventually_le_one` | eventual boundedness |
+| `inducedGraph_mono` | `G₁ ≤ G₂ ⇒ G₁.induce Λ ≤ G₂.induce Λ` |
+| `partitionFunctionΛ_monotone_ambient_subgraph` | `G₁ ≤ G₂ ⇒ Z_{G₁,Λ} ≤ Z_{G₂,Λ}` |
+| `correlationΛ_monotone_ambient_subgraph` | `G₁ ≤ G₂ ⇒ ⟨σ^A⟩_{G₁,Λ} ≤ ⟨σ^A⟩_{G₂,Λ}` |
+| `freeEnergyΛ_monotone_ambient_subgraph` | `G₁ ≤ G₂ ⇒ f_{G₁,Λ} ≤ f_{G₂,Λ}` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1824,14 +1824,51 @@ Eventually $|\texttt{correlationAlongExhaustion}~G~\Lambda_\bullet~p~A~n|
 \le 1$, inherited from the finite-volume bound.
 \end{theorem}
 
+\subsection{Ambient subgraph monotonicity on $\Lambda$}
+
+For a fixed finite volume $\Lambda : \texttt{Finset}~V$ and
+ferromagnetic parameters, the finite-volume quantities are monotone
+in the ambient interaction graph.
+
+\begin{lemma}[\texttt{inducedGraph\_mono}]
+$G_1 \le G_2 \Rightarrow G_1.\texttt{induce}~\Lambda \le
+G_2.\texttt{induce}~\Lambda$.
+\end{lemma}
+
+\begin{proof}
+$\texttt{SimpleGraph.induce\_adj}$ reduces adjacency in the induced
+subgraph to ambient adjacency; the ambient inequality then transfers
+pointwise.
+\end{proof}
+
+\begin{theorem}
+The following are monotone in the ambient graph direction:
+\begin{itemize}
+  \item \texttt{partitionFunctionΛ\_monotone\_ambient\_subgraph}:
+    $Z_{G_1,\Lambda} \le Z_{G_2,\Lambda}$
+  \item \texttt{correlationΛ\_monotone\_ambient\_subgraph}:
+    $\langle\sigma^A\rangle_{G_1,\Lambda} \le
+     \langle\sigma^A\rangle_{G_2,\Lambda}$ for any
+    $A : \texttt{Finset}~(\uparrow\!\Lambda)$
+  \item \texttt{freeEnergyΛ\_monotone\_ambient\_subgraph}:
+    $f_{G_1,\Lambda} \le f_{G_2,\Lambda}$
+\end{itemize}
+\end{theorem}
+
+\begin{proof}
+\texttt{inducedGraph\_mono} gives a subgraph relation on
+$(\uparrow\!\Lambda)$; the existing \texttt{*\_monotone\_subgraph}
+theorems (on the Fintype $(\uparrow\!\Lambda)$) then apply directly.
+\end{proof}
+
 \begin{remark}
 Convergence of \texttt{correlationAlongExhaustion} (i.e., $\exists L,
 \texttt{Tendsto} \ldots \texttt{(nhds }L\texttt{)}$) is the natural
 next step, requiring a compatibility argument between
 \texttt{correlationΛ}~on $\Lambda_n$ and $\Lambda_{n+1}$ when
-$\Lambda_n \subseteq \Lambda_{n+1}$.  This generalizes the subgraph
-monotonicity from \texttt{InfiniteVolume.lean} to the
-changing-subtype setting; not yet formalized.
+$\Lambda_n \subseteq \Lambda_{n+1}$.  This is the \emph{volume}
+direction of monotonicity, which requires a configuration
+factorization and is left for a follow-up.
 \end{remark}
 
 \end{document}


### PR DESCRIPTION
## Summary

Follow-up to PR #70. On the ambient lattice framework, add subgraph
monotonicity with respect to the **ambient graph direction** (fixing
Λ): for G₁ ≤ G₂ on V, correlationΛ G₁ ≤ correlationΛ G₂ for
ferromagnetic p.

This is the simpler of the two monotonicity directions in the
ambient framework.  The more substantial **volume direction**
(for Λ₁ ⊆ Λ₂, compare correlationΛ on Λ₁ vs Λ₂) requires a
configuration-factorization argument and is left for a follow-up PR.

## New theorems

### \`IsingModel/AmbientLattice.lean\`
- \`partitionFunctionΛ_monotone_ambient_subgraph\` — G₁ ≤ G₂ ⇒ Z_Λ monotone
- \`correlationΛ_monotone_ambient_subgraph\` — ferromagnetic + G₁ ≤ G₂ ⇒ correlationΛ monotone
- \`freeEnergyΛ_monotone_ambient_subgraph\` — ferromagnetic + G₁ ≤ G₂ ⇒ fΛ monotone

## Proof

Each lemma applies the existing `partitionFunction_monotone_subgraph`
/ `correlation_monotone_subgraph` / `freeEnergy_monotone_subgraph`
(on the Fintype ↑Λ) to the induced subgraphs, observing that
G₁ ≤ G₂ on V implies G₁.induce S ≤ G₂.induce S for any S : Set V.

## Test plan

- [ ] \`lake build\`
- [ ] \`lake exe GKSTest\`
- [ ] Zero \`sorry\` / linter warnings
- [ ] \`copilot -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)