### PR TITLE
feat: Boltzmann factoring on extendGraphFromΛ₁

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -380,14 +380,17 @@ equality for the Boltzmann-weight factoring. -/
 
 omit [DecidableEq V] in
 /-- Pointwise edge-spin preservation:
-`edgeSpin σ (Sym2.map (subtypeIncl h12) e) = edgeSpin (restrictConfig h12 σ) e`. -/
-theorem edgeSpin_subtypeIncl {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+`edgeSpin σ (Sym2.map (subtypeIncl h12) e) = edgeSpin (restrictConfig h12 σ) e`.
+
+Generic in the coefficient field `K`; the `ℝ`-specialization arises
+automatically when instantiated for the Ising Boltzmann weight. -/
+theorem edgeSpin_subtypeIncl {K : Type*} [Field K]
+    {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
     (σ : (↑Λ₂ : Type _) → Spin) (e : Sym2 (↑Λ₁ : Type _)) :
-    edgeSpin (K := ℝ) σ (Sym2.map (subtypeIncl h12) e)
-      = edgeSpin (K := ℝ) (restrictConfig h12 σ) e := by
+    edgeSpin (K := K) σ (Sym2.map (subtypeIncl h12) e)
+      = edgeSpin (K := K) (restrictConfig h12 σ) e := by
   refine Sym2.ind (fun u v => ?_) e
-  simp only [Sym2.map_mk, edgeSpin, Sym2.lift_mk, restrictConfig,
-    Function.comp_apply]
+  simp [edgeSpin, restrictConfig, subtypeIncl]
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -369,5 +369,25 @@ theorem configEquivSubtypeProd_fst {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ�
   simp [configEquivSubtypeProd, restrictConfig, subtypeIncl,
     Equiv.piEquivPiSubtypeProd, Λ₁subtypeEquiv]
 
+/-! ## Edge-spin preservation under `Sym2.map subtypeIncl`
+
+For an edge `e : Sym2 (↑Λ₁)`, its image under `Sym2.map (subtypeIncl h12)`
+is an edge on `↑Λ₂` with the same endpoint values.  Hence the
+`edgeSpin` values coincide (with `restrictConfig` on the `↑Λ₁` side).
+
+This is the pointwise identity underlying the eventual edge-sum
+equality for the Boltzmann-weight factoring. -/
+
+omit [DecidableEq V] in
+/-- Pointwise edge-spin preservation:
+`edgeSpin σ (Sym2.map (subtypeIncl h12) e) = edgeSpin (restrictConfig h12 σ) e`. -/
+theorem edgeSpin_subtypeIncl {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    (σ : (↑Λ₂ : Type _) → Spin) (e : Sym2 (↑Λ₁ : Type _)) :
+    edgeSpin (K := ℝ) σ (Sym2.map (subtypeIncl h12) e)
+      = edgeSpin (K := ℝ) (restrictConfig h12 σ) e := by
+  refine Sym2.ind (fun u v => ?_) e
+  simp only [Sym2.map_mk, edgeSpin, Sym2.lift_mk, restrictConfig,
+    Function.comp_apply]
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,6 +146,7 @@ ambient framework:
 | `Λ₁subtypeEquiv` | `{x : ↑Λ₂ // x.val ∈ Λ₁} ≃ ↑Λ₁` |
 | `configEquivSubtypeProd` | `(↑Λ₂ → Spin) ≃ (↑Λ₁ → Spin) × ({x // x.val ∉ Λ₁} → Spin)` |
 | `configEquivSubtypeProd_fst` | First projection = `restrictConfig` |
+| `edgeSpin_subtypeIncl` | `edgeSpin σ (Sym2.map subtypeIncl e) = edgeSpin (restrictConfig σ) e` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1955,4 +1955,20 @@ The first projection of \texttt{configEquivSubtypeProd} is
 \texttt{restrictConfig}.
 \end{theorem}
 
+\begin{theorem}[\texttt{edgeSpin\_subtypeIncl}]
+Pointwise edge-spin preservation under the subtype inclusion lift:
+for $e : \texttt{Sym2}\,(\uparrow\!\Lambda_1)$,
+\[
+\texttt{edgeSpin}\,\sigma\,(\texttt{Sym2.map}\,(\texttt{subtypeIncl}\,h_{12})\,e)
+  = \texttt{edgeSpin}\,(\texttt{restrictConfig}\,h_{12}\,\sigma)\,e.
+\]
+(Generic in the coefficient field~$K$.)
+\end{theorem}
+
+\begin{proof}
+\texttt{Sym2.ind} reduces to the concrete-pair case, then \texttt{simp}
+unfolds \texttt{edgeSpin}, \texttt{restrictConfig}, and \texttt{subtypeIncl}
+to the trivial pointwise identity.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Boltzmann weight factoring for the extended graph on ↑Λ₂,
complementing the configuration Equiv from PR #74.

## Planned results (\`IsingModel/AmbientLattice.lean\`)

- \`extendGraph_edgeSum_eq\` — edge-sum equality via \`Sym2.map subtypeIncl\`.
- \`extendGraph_siteSum_split\` — site sum splits into \`↑Λ₁\` and complement.
- \`boltzmannWeight_extendGraph_factor\` — Boltzmann weight factors as
  \`w_{G.induce Λ₁}(restrictConfig σ) · ∏_{v ∈ complement} exp(βh sign σ_v)\`.

## Test plan

- [ ] \`lake build\`
- [ ] \`lake exe GKSTest\`
- [ ] Zero \`sorry\` / linter warnings
- [ ] \`copilot -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)