### PR TITLE
feat: edge-set bijection + edge sum equality for extendGraphFromΛ₁

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -392,5 +392,45 @@ theorem edgeSpin_subtypeIncl {K : Type*} [Field K]
   refine Sym2.ind (fun u v => ?_) e
   simp [edgeSpin, restrictConfig, subtypeIncl]
 
+/-! ## Edge-set transfer between `G.induce Λ₁` and `extendGraphFromΛ₁`
+
+`Sym2.map (subtypeIncl h12)` gives an injection from
+`Sym2 (↑Λ₁)` to `Sym2 (↑Λ₂)` that restricts to a bijection between
+the edge sets of `G.induce Λ₁` and `extendGraphFromΛ₁ G Λ₁ Λ₂`.
+
+Combined with `Finset.sum_bij` (or `sum_map`) and
+`edgeSpin_subtypeIncl`, this yields the edge-sum equality underlying
+the Boltzmann factoring. -/
+
+omit [DecidableEq V] in
+/-- The image of an induced-graph edge under `Sym2.map (subtypeIncl h12)`
+is an edge of `extendGraphFromΛ₁`. -/
+theorem mem_extendGraph_edgeSet_of_mem_induce
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    {e : Sym2 (↑Λ₁ : Type _)} (he : e ∈ (G.induce (↑Λ₁ : Set V)).edgeSet) :
+    Sym2.map (subtypeIncl h12) e ∈ (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet := by
+  refine Sym2.ind (fun u v he => ?_) e he
+  rw [Sym2.map_mk, SimpleGraph.mem_edgeSet]
+  rw [SimpleGraph.mem_edgeSet] at he
+  exact ⟨u.property, v.property, he⟩
+
+omit [DecidableEq V] in
+/-- Conversely, every `extendGraphFromΛ₁` edge comes from a unique
+induced-graph edge via `Sym2.map (subtypeIncl h12)`. -/
+theorem exists_induce_edge_of_extendGraph
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    {e : Sym2 (↑Λ₂ : Type _)}
+    (he : e ∈ (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet) :
+    ∃ e' : Sym2 (↑Λ₁ : Type _),
+      e' ∈ (G.induce (↑Λ₁ : Set V)).edgeSet ∧ Sym2.map (subtypeIncl h12) e' = e := by
+  refine Sym2.ind (fun u v he => ?_) e he
+  rw [SimpleGraph.mem_edgeSet] at he
+  obtain ⟨hu, hv, hadj⟩ := he
+  refine ⟨s(⟨u.val, hu⟩, ⟨v.val, hv⟩), ?_, ?_⟩
+  · rw [SimpleGraph.mem_edgeSet]
+    exact hadj
+  · rw [Sym2.map_mk]
+    rfl
+
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -407,7 +407,7 @@ omit [DecidableEq V] in
 is an edge of `extendGraphFromΛ₁`. -/
 theorem mem_extendGraph_edgeSet_of_mem_induce
     (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
-    {e : Sym2 (↑Λ₁ : Type _)} (he : e ∈ (G.induce (↑Λ₁ : Set V)).edgeSet) :
+    {e : Sym2 (↑Λ₁ : Type _)} (he : e ∈ (inducedGraph G Λ₁).edgeSet) :
     Sym2.map (subtypeIncl h12) e ∈ (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet := by
   refine Sym2.ind (fun u v he => ?_) e he
   rw [Sym2.map_mk, SimpleGraph.mem_edgeSet]
@@ -422,7 +422,7 @@ theorem exists_induce_edge_of_extendGraph
     {e : Sym2 (↑Λ₂ : Type _)}
     (he : e ∈ (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet) :
     ∃ e' : Sym2 (↑Λ₁ : Type _),
-      e' ∈ (G.induce (↑Λ₁ : Set V)).edgeSet ∧ Sym2.map (subtypeIncl h12) e' = e := by
+      e' ∈ (inducedGraph G Λ₁).edgeSet ∧ Sym2.map (subtypeIncl h12) e' = e := by
   refine Sym2.ind (fun u v he => ?_) e he
   rw [SimpleGraph.mem_edgeSet] at he
   obtain ⟨hu, hv, hadj⟩ := he

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,6 +147,8 @@ ambient framework:
 | `configEquivSubtypeProd` | `(↑Λ₂ → Spin) ≃ (↑Λ₁ → Spin) × ({x // x.val ∉ Λ₁} → Spin)` |
 | `configEquivSubtypeProd_fst` | First projection = `restrictConfig` |
 | `edgeSpin_subtypeIncl` | `edgeSpin σ (Sym2.map subtypeIncl e) = edgeSpin (restrictConfig σ) e` |
+| `mem_extendGraph_edgeSet_of_mem_induce` | Induce edge → extendGraph edge (under Sym2.map) |
+| `exists_induce_edge_of_extendGraph` | extendGraph edge ← unique induce edge |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1971,4 +1971,17 @@ unfolds \texttt{edgeSpin}, \texttt{restrictConfig}, and \texttt{subtypeIncl}
 to the trivial pointwise identity.
 \end{proof}
 
+\begin{theorem}[\texttt{mem\_extendGraph\_edgeSet\_of\_mem\_induce}]
+If $e \in (G.\texttt{induce}\,\Lambda_1).\texttt{edgeSet}$, then
+$\texttt{Sym2.map}\,(\texttt{subtypeIncl}\,h_{12})\,e \in (\texttt{extendGraphFromΛ₁}\,G\,\Lambda_1\,\Lambda_2).\texttt{edgeSet}$.
+\end{theorem}
+
+\begin{theorem}[\texttt{exists\_induce\_edge\_of\_extendGraph}]
+Every $e \in (\texttt{extendGraphFromΛ₁}\,G\,\Lambda_1\,\Lambda_2).\texttt{edgeSet}$ is the
+image of a unique $e' \in (G.\texttt{induce}\,\Lambda_1).\texttt{edgeSet}$ under
+$\texttt{Sym2.map}\,(\texttt{subtypeIncl}\,h_{12})$.
+\end{theorem}
+
+These two together with \texttt{Sym2.map.injective}\,(\texttt{subtypeIncl\_injective}) give a bijection between the edge sets.
+
 \end{document}


### PR DESCRIPTION
## Summary

Edge-set level equality and edge sum transfer for the Boltzmann
factoring argument on extendGraphFromΛ₁ (for volume-direction
monotonicity). Uses Sym2.map (subtypeIncl h12) as the bijection
between edgeFinsets.

## Planned (\`IsingModel/AmbientLattice.lean\`)

- \`extendGraph_edgeFinset_eq\`: Finset equality
- \`extendGraph_edgeSum_eq\`: edge sum equality (via Finset.sum_map +
  edgeSpin_subtypeIncl from PR #75)

## Test plan

- [ ] \`lake build\`
- [ ] \`lake exe GKSTest\`
- [ ] Zero \`sorry\` / linter warnings
- [ ] \`copilot -p\`
- [ ] PR checklist 10 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)