### PR TITLE
feat: site sum splitting on ↑Λ₂

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -440,6 +440,23 @@ The site-sum splitting follows from `Fintype.sum_equiv` on
 `configEquivSubtypeProd`, reducing the Boltzmann factoring to its
 final step (PR #78). -/
 
+/-- **Reindex helper for site sums**: for `Λ₁ ⊆ Λ₂`, the sum over the
+subtype `{x : ↑Λ₂ // x.val ∈ Λ₁}` of a function evaluated at `σ v.val`
+equals the sum over `↑Λ₁` of the same function with `restrictConfig`.
+
+This is the core ingredient for site-sum splitting (the full splitting
+along the `Λ₁ / complement` partition is completed in PR #79). -/
+theorem sum_Λ₁_subtype_eq {K : Type*} [Field K]
+    {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    (σ : (↑Λ₂ : Type _) → Spin) :
+    ∑ v : {x : (↑Λ₂ : Type _) // x.val ∈ Λ₁}, Spin.sign K (σ v.val)
+      = ∑ v : (↑Λ₁ : Type _), Spin.sign K (restrictConfig h12 σ v) := by
+  refine Fintype.sum_equiv (Λ₁subtypeEquiv h12)
+    (fun x : {y : (↑Λ₂ : Type _) // y.val ∈ Λ₁} => Spin.sign K (σ x.val))
+    (fun v : (↑Λ₁ : Type _) => Spin.sign K (restrictConfig h12 σ v))
+    (fun x => ?_)
+  simp [restrictConfig, subtypeIncl, Λ₁subtypeEquiv]
+
 omit [DecidableEq V] in
 /-- Edge-sum equality for the extendGraph via the Sym2.map-based
 bijection.  Generic in the coefficient field `K`. -/

--- a/docs/index.md
+++ b/docs/index.md
@@ -150,6 +150,7 @@ ambient framework:
 | `mem_extendGraph_edgeSet_of_mem_induce` | Induce edge → extendGraph edge (under Sym2.map) |
 | `exists_induce_edge_of_extendGraph` | extendGraph edge ← unique induce edge |
 | `extendGraph_edgeSum_eq` | `Σ edgeSpin σ` over extendGraph = `Σ edgeSpin (restrictConfig σ)` over G.induce Λ₁ |
+| `sum_Λ₁_subtype_eq` | Reindex `Σ f(σ ↑v)` from `{x // x.val ∈ Λ₁}` to `↑Λ₁` with `restrictConfig` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2004,4 +2004,20 @@ surjectivity via \texttt{exists\_induce\_edge\_of\_extendGraph},
 pointwise equality via \texttt{edgeSpin\_subtypeIncl}.
 \end{proof}
 
+\begin{theorem}[\texttt{sum\_Λ₁\_subtype\_eq}]
+Site-sum reindex helper: for $\Lambda_1 \subseteq \Lambda_2$,
+\[
+\sum_{v : \{x : \uparrow\!\Lambda_2 \mid x.\text{val} \in \Lambda_1\}}
+  \texttt{Spin.sign}\,K\,(\sigma\,v.\text{val})
+= \sum_{v : \uparrow\!\Lambda_1}
+  \texttt{Spin.sign}\,K\,(\texttt{restrictConfig}\,h_{12}\,\sigma\,v).
+\]
+\end{theorem}
+
+\begin{proof}
+\texttt{Fintype.sum\_equiv} applied to \texttt{Λ₁subtypeEquiv};
+pointwise equality follows by unfolding \texttt{restrictConfig}
+$= \sigma \circ \texttt{subtypeIncl}$.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Split the site sum on ↑Λ₂ into Λ₁-part and complement-part.
Final prep step before Boltzmann factoring (PR #79).

## Planned

- \`siteSum_split\`: ∑ v : ↑Λ₂, sign (σ v) = ∑ v : ↑Λ₁, sign (restrictConfig σ v) + ∑ v : complement, sign (σ v)

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)