### PR TITLE
feat: full site sum split

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -444,8 +444,7 @@ final step (PR #78). -/
 subtype `{x : ↑Λ₂ // x.val ∈ Λ₁}` of a function evaluated at `σ v.val`
 equals the sum over `↑Λ₁` of the same function with `restrictConfig`.
 
-This is the core ingredient for site-sum splitting (the full splitting
-along the `Λ₁ / complement` partition is completed in PR #79). -/
+This is the core ingredient for site-sum splitting. -/
 theorem sum_Λ₁_subtype_eq {K : Type*} [Field K]
     {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
     (σ : (↑Λ₂ : Type _) → Spin) :
@@ -456,6 +455,30 @@ theorem sum_Λ₁_subtype_eq {K : Type*} [Field K]
     (fun v : (↑Λ₁ : Type _) => Spin.sign K (restrictConfig h12 σ v))
     (fun x => ?_)
   simp [restrictConfig, subtypeIncl, Λ₁subtypeEquiv]
+
+/-- **Site-sum partition** on `↑Λ₂` along the `Λ₁/complement` partition.
+Specialized form of `Fintype.sum_subtype_add_sum_subtype` for the
+Ising model site-sum. -/
+theorem siteSum_partition {K : Type*} [Field K]
+    (Λ₁ Λ₂ : Finset V) (σ : (↑Λ₂ : Type _) → Spin) :
+    ∑ v : (↑Λ₂ : Type _), Spin.sign K (σ v)
+      = (∑ v : {x : (↑Λ₂ : Type _) // x.val ∈ Λ₁}, Spin.sign K (σ v.val))
+        + ∑ v : {x : (↑Λ₂ : Type _) // ¬ (x.val ∈ Λ₁)}, Spin.sign K (σ v.val) := by
+  classical
+  exact (Fintype.sum_subtype_add_sum_subtype
+    (fun x : (↑Λ₂ : Type _) => x.val ∈ Λ₁)
+    (fun v => Spin.sign K (σ v))).symm
+
+/-- **Site-sum splitting** on `↑Λ₂` along the `Λ₁/complement` partition,
+with the Λ₁-part expressed via `restrictConfig` on `↑Λ₁`.
+Combines `siteSum_partition` with `sum_Λ₁_subtype_eq`. -/
+theorem siteSum_split {K : Type*} [Field K]
+    {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    (σ : (↑Λ₂ : Type _) → Spin) :
+    ∑ v : (↑Λ₂ : Type _), Spin.sign K (σ v)
+      = (∑ v : (↑Λ₁ : Type _), Spin.sign K (restrictConfig h12 σ v))
+        + ∑ v : {x : (↑Λ₂ : Type _) // ¬ (x.val ∈ Λ₁)}, Spin.sign K (σ v.val) := by
+  rw [siteSum_partition Λ₁ Λ₂ σ, sum_Λ₁_subtype_eq h12 σ]
 
 omit [DecidableEq V] in
 /-- Edge-sum equality for the extendGraph via the Sym2.map-based

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -445,7 +445,7 @@ subtype `{x : ↑Λ₂ // x.val ∈ Λ₁}` of a function evaluated at `σ v.val
 equals the sum over `↑Λ₁` of the same function with `restrictConfig`.
 
 This is the core ingredient for site-sum splitting. -/
-theorem sum_Λ₁_subtype_eq {K : Type*} [Field K]
+theorem sum_Λ₁_subtype_eq {K : Type*} [CommRing K]
     {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
     (σ : (↑Λ₂ : Type _) → Spin) :
     ∑ v : {x : (↑Λ₂ : Type _) // x.val ∈ Λ₁}, Spin.sign K (σ v.val)
@@ -459,7 +459,7 @@ theorem sum_Λ₁_subtype_eq {K : Type*} [Field K]
 /-- **Site-sum partition** on `↑Λ₂` along the `Λ₁/complement` partition.
 Specialized form of `Fintype.sum_subtype_add_sum_subtype` for the
 Ising model site-sum. -/
-theorem siteSum_partition {K : Type*} [Field K]
+theorem siteSum_partition {K : Type*} [CommRing K]
     (Λ₁ Λ₂ : Finset V) (σ : (↑Λ₂ : Type _) → Spin) :
     ∑ v : (↑Λ₂ : Type _), Spin.sign K (σ v)
       = (∑ v : {x : (↑Λ₂ : Type _) // x.val ∈ Λ₁}, Spin.sign K (σ v.val))
@@ -472,7 +472,7 @@ theorem siteSum_partition {K : Type*} [Field K]
 /-- **Site-sum splitting** on `↑Λ₂` along the `Λ₁/complement` partition,
 with the Λ₁-part expressed via `restrictConfig` on `↑Λ₁`.
 Combines `siteSum_partition` with `sum_Λ₁_subtype_eq`. -/
-theorem siteSum_split {K : Type*} [Field K]
+theorem siteSum_split {K : Type*} [CommRing K]
     {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
     (σ : (↑Λ₂ : Type _) → Spin) :
     ∑ v : (↑Λ₂ : Type _), Spin.sign K (σ v)

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,6 +151,8 @@ ambient framework:
 | `exists_induce_edge_of_extendGraph` | extendGraph edge ← unique induce edge |
 | `extendGraph_edgeSum_eq` | `Σ edgeSpin σ` over extendGraph = `Σ edgeSpin (restrictConfig σ)` over G.induce Λ₁ |
 | `sum_Λ₁_subtype_eq` | Reindex `Σ f(σ ↑v)` from `{x // x.val ∈ Λ₁}` to `↑Λ₁` with `restrictConfig` |
+| `siteSum_partition` | Specialized `Fintype.sum_subtype_add_sum_subtype` for `sign (σ v)` |
+| `siteSum_split` | Full split: site sum = Λ₁-part (restrictConfig) + complement-part |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2020,4 +2020,27 @@ pointwise equality follows by unfolding \texttt{restrictConfig}
 $= \sigma \circ \texttt{subtypeIncl}$.
 \end{proof}
 
+\begin{theorem}[\texttt{siteSum\_partition}]
+Specialized \texttt{Fintype.sum\_subtype\_add\_sum\_subtype}:
+\[
+\sum_{v : \uparrow\!\Lambda_2} \texttt{Spin.sign}\,K\,(\sigma\,v)
+  = \Bigl(\sum_{v : \{x \mid x.\text{val} \in \Lambda_1\}} \texttt{Spin.sign}\,K\,(\sigma\,v.\text{val})\Bigr)
+    + \sum_{v : \{x \mid \neg (x.\text{val} \in \Lambda_1)\}} \texttt{Spin.sign}\,K\,(\sigma\,v.\text{val}).
+\]
+\end{theorem}
+
+\begin{theorem}[\texttt{siteSum\_split}]
+Full splitting, with the $\Lambda_1$-part expressed via
+\texttt{restrictConfig}:
+\[
+\sum_{v : \uparrow\!\Lambda_2} \texttt{Spin.sign}\,K\,(\sigma\,v)
+  = \Bigl(\sum_{v : \uparrow\!\Lambda_1} \texttt{Spin.sign}\,K\,(\texttt{restrictConfig}\,h_{12}\,\sigma\,v)\Bigr)
+    + \sum_{v : \{x \mid \neg (x.\text{val} \in \Lambda_1)\}} \texttt{Spin.sign}\,K\,(\sigma\,v.\text{val}).
+\]
+\end{theorem}
+
+\begin{proof}
+\texttt{siteSum\_partition} + \texttt{sum\_Λ₁\_subtype\_eq}.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Complete the site-sum splitting started in PR #78. Combine
\`sum_Λ₁_subtype_eq\` with \`Fintype.sum_subtype_add_sum_subtype\`.

## Planned

- \`siteSum_split\`: full form splitting ∑ v : ↑Λ₂, sign (σ v)
  into Λ₁-part (via restrictConfig) + complement-part.

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)