### PR TITLE
feat: Boltzmann weight factoring on extendGraphFromΛ₁

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -525,5 +525,24 @@ theorem hamiltonian_extendGraph_factor
   rw [extendGraph_edgeSum_eq G h12 σ, siteSum_split h12 σ]
   ring
 
+/-- Boltzmann weight factoring on `extendGraphFromΛ₁`: the weight on the
+extended graph equals the weight on `inducedGraph G Λ₁` (with
+`restrictConfig`) multiplied by an exponential factor over the
+complement sites. -/
+theorem boltzmannWeight_extendGraph_factor
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet]
+    (p : IsingParams ℝ) (σ : (↑Λ₂ : Type _) → Spin) :
+    boltzmannWeight (extendGraphFromΛ₁ G Λ₁ Λ₂) p σ
+      = boltzmannWeight (inducedGraph G Λ₁) p (restrictConfig h12 σ)
+        * Real.exp (p.β * p.h *
+            ∑ v : {x : (↑Λ₂ : Type _) // ¬ (x.val ∈ Λ₁)},
+              Spin.sign ℝ (σ v.val)) := by
+  simp only [boltzmannWeight]
+  rw [hamiltonian_extendGraph_factor G h12 p σ, ← Real.exp_add]
+  congr 1
+  ring
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,6 +154,7 @@ ambient framework:
 | `siteSum_partition` | Specialized `Fintype.sum_subtype_add_sum_subtype` for `sign (σ v)` |
 | `siteSum_split` | Full split: site sum = Λ₁-part (restrictConfig) + complement-part |
 | `hamiltonian_extendGraph_factor` | Hamiltonian on extendGraph = Hamiltonian on G.induce Λ₁ (restrictConfig) + complement site term |
+| `boltzmannWeight_extendGraph_factor` | Boltzmann weight on extendGraph = weight on G.induce Λ₁ · exp(βh · complement sign sum) |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2059,4 +2059,19 @@ Unfold \texttt{hamiltonian}, \texttt{interactionEnergy},
 \texttt{siteSum\_split}. \texttt{ring} closes.
 \end{proof}
 
+\begin{theorem}[\texttt{boltzmannWeight\_extendGraph\_factor}]
+The Boltzmann weight on \texttt{extendGraphFromΛ₁} factors as:
+\[
+w_{G_1^\text{ext},\,p}(\sigma)
+  = w_{\texttt{inducedGraph}\,G\,\Lambda_1,\,p}(\texttt{restrictConfig}\,h_{12}\,\sigma)
+    \cdot \exp\Bigl(\beta h \sum_{v : C} \texttt{Spin.sign}\,\mathbb{R}\,(\sigma\,v.\text{val})\Bigr).
+\]
+\end{theorem}
+
+\begin{proof}
+Unfold \texttt{boltzmannWeight}, apply
+\texttt{hamiltonian\_extendGraph\_factor}, and use
+\texttt{Real.exp\_add}. \texttt{ring} closes the exponent algebra.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Boltzmann weight factoring via exp of Hamiltonian decomposition (PR #80).

## Planned

- \`boltzmannWeight_extendGraph_factor\`: w_extendGraph(σ) = w_induceΛ₁(restrictConfig σ) · complement factor

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist 10 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)