### PR TITLE
feat: correlation equality on extendGraphFromΛ₁

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -544,5 +544,45 @@ theorem boltzmannWeight_extendGraph_factor
   congr 1
   ring
 
+/-! ## Spin product lift equality
+
+For `A ⊆ Λ₁ ⊆ Λ₂`, the spin product of the `↑Λ₂`-lifted `A` evaluated
+at a `↑Λ₂`-configuration equals the spin product of the `↑Λ₁`-lifted
+`A` evaluated at the restricted configuration.
+
+This is a key lemma for the correlation equality: the observable
+`σ^A` transported through the `↑Λ₁ ↪ ↑Λ₂` embedding agrees with
+the lifted one. -/
+
+/-- The `↑Λ₂`-lift of `A ⊆ Λ₁` equals the image of the `↑Λ₁`-lift
+under `subtypeIncl h12`. -/
+theorem liftFinset_eq_image_subtypeIncl
+    {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    {A : Finset V} (hA : A ⊆ Λ₁) :
+    liftFinset A (hA.trans h12)
+      = (liftFinset A hA).image (subtypeIncl h12) := by
+  ext x
+  simp only [liftFinset, Finset.mem_image, Finset.mem_attach,
+    subtypeIncl, true_and]
+  constructor
+  · rintro ⟨⟨v, hv⟩, rfl⟩
+    exact ⟨⟨v, hA hv⟩, ⟨⟨v, hv⟩, rfl⟩, rfl⟩
+  · rintro ⟨y, ⟨⟨v, hv⟩, rfl⟩, rfl⟩
+    exact ⟨⟨v, hv⟩, rfl⟩
+
+/-- **Spin product lift equality**: for `A ⊆ Λ₁ ⊆ Λ₂`,
+`spinProduct (liftFinset A (hA.trans h12)) σ
+  = spinProduct (liftFinset A hA) (restrictConfig h12 σ)`. -/
+theorem spinProduct_lift_eq
+    {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    {A : Finset V} (hA : A ⊆ Λ₁) (σ : (↑Λ₂ : Type _) → Spin) :
+    spinProduct (liftFinset A (hA.trans h12)) σ
+      = spinProduct (liftFinset A hA) (restrictConfig h12 σ) := by
+  unfold spinProduct
+  rw [liftFinset_eq_image_subtypeIncl h12 hA,
+    Finset.prod_image
+      (fun _ _ _ _ heq => subtypeIncl_injective h12 heq)]
+  rfl
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,6 +155,8 @@ ambient framework:
 | `siteSum_split` | Full split: site sum = Λ₁-part (restrictConfig) + complement-part |
 | `hamiltonian_extendGraph_factor` | Hamiltonian on extendGraph = Hamiltonian on G.induce Λ₁ (restrictConfig) + complement site term |
 | `boltzmannWeight_extendGraph_factor` | Boltzmann weight on extendGraph = weight on G.induce Λ₁ · exp(βh · complement sign sum) |
+| `liftFinset_eq_image_subtypeIncl` | `liftFinset A (hA.trans h12) = (liftFinset A hA).image (subtypeIncl h12)` |
+| `spinProduct_lift_eq` | Spin product on ↑Λ₂-lift = spin product on ↑Λ₁-lift under restrictConfig |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2074,4 +2074,26 @@ Unfold \texttt{boltzmannWeight}, apply
 \texttt{Real.exp\_add}. \texttt{ring} closes the exponent algebra.
 \end{proof}
 
+\begin{lemma}[\texttt{liftFinset\_eq\_image\_subtypeIncl}]
+For $A \subseteq \Lambda_1 \subseteq \Lambda_2$,
+$\texttt{liftFinset}\,A\,(h_A \circ h_{12})
+ = (\texttt{liftFinset}\,A\,h_A).\texttt{image}\,(\texttt{subtypeIncl}\,h_{12})$.
+\end{lemma}
+
+\begin{theorem}[\texttt{spinProduct\_lift\_eq}]
+For $A \subseteq \Lambda_1 \subseteq \Lambda_2$,
+$\sigma : \uparrow\!\Lambda_2 \to \texttt{Spin}$:
+\[
+\texttt{spinProduct}\,(\texttt{liftFinset}\,A\,(h_A \circ h_{12}))\,\sigma
+  = \texttt{spinProduct}\,(\texttt{liftFinset}\,A\,h_A)\,(\texttt{restrictConfig}\,h_{12}\,\sigma).
+\]
+\end{theorem}
+
+\begin{proof}
+Unfold \texttt{spinProduct}, rewrite the Finset via the preceding
+lemma, apply \texttt{Finset.prod\_image} using
+\texttt{subtypeIncl\_injective}. The remaining equality is
+definitional ($\sigma \circ \texttt{subtypeIncl} = \texttt{restrictConfig}\,\sigma$).
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Prove the correlation equality: extendGraph correlation on ↑Λ₂
equals inducedGraph Λ₁ correlation on ↑Λ₁, when the observable is
lifted from A ⊆ Λ₁.

## Planned

- partition function factoring (Z_extendGraph = Z_induceΛ₁ · complement factor)
- numerator factoring (same complement factor appears)
- \`correlationΛ_extendGraph_eq\`: complement factors cancel in ratio

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist 10 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)