### PR TITLE
feat: partition function + numerator factoring for correlation equality

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -584,5 +584,24 @@ theorem spinProduct_lift_eq
       (fun _ _ _ _ heq => subtypeIncl_injective h12 heq)]
   rfl
 
+/-! ## Restriction of the config-equiv inverse
+
+If `(σ₁, σ₂) : (↑Λ₁ → Spin) × (complement → Spin)` and
+`σ := (configEquivSubtypeProd h12).symm (σ₁, σ₂)`, then
+`restrictConfig h12 σ = σ₁`.  This is the content-bearing identity
+that lets us split Boltzmann sums through the configuration
+decomposition. -/
+
+/-- The `restrictConfig` of the configEquiv-inverse of a pair recovers
+the first component. -/
+theorem restrictConfig_configEquivSubtypeProd_symm
+    {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    (σ₁ : (↑Λ₁ : Type _) → Spin)
+    (σ₂ : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁} → Spin) :
+    restrictConfig h12 ((configEquivSubtypeProd h12).symm (σ₁, σ₂)) = σ₁ := by
+  ext v
+  simp [restrictConfig, subtypeIncl, configEquivSubtypeProd,
+    Equiv.piEquivPiSubtypeProd, Λ₁subtypeEquiv, v.property]
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,7 @@ ambient framework:
 | `boltzmannWeight_extendGraph_factor` | Boltzmann weight on extendGraph = weight on G.induce Λ₁ · exp(βh · complement sign sum) |
 | `liftFinset_eq_image_subtypeIncl` | `liftFinset A (hA.trans h12) = (liftFinset A hA).image (subtypeIncl h12)` |
 | `spinProduct_lift_eq` | Spin product on ↑Λ₂-lift = spin product on ↑Λ₁-lift under restrictConfig |
+| `restrictConfig_configEquivSubtypeProd_symm` | `restrictConfig (equivSymm (σ₁, σ₂)) = σ₁` (content-bearing config factoring identity) |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2096,4 +2096,19 @@ lemma, apply \texttt{Finset.prod\_image} using
 definitional ($\sigma \circ \texttt{subtypeIncl} = \texttt{restrictConfig}\,\sigma$).
 \end{proof}
 
+\begin{theorem}[\texttt{restrictConfig\_configEquivSubtypeProd\_symm}]
+For $(\sigma_1, \sigma_2) \in (\uparrow\!\Lambda_1 \to \texttt{Spin})
+\times (C \to \texttt{Spin})$,
+\[
+\texttt{restrictConfig}\,h_{12}\,\bigl((\texttt{configEquivSubtypeProd}\,h_{12}).\texttt{symm}\,(\sigma_1, \sigma_2)\bigr) = \sigma_1.
+\]
+\end{theorem}
+
+\begin{proof}
+\texttt{ext v}, \texttt{simp} with \texttt{configEquivSubtypeProd},
+\texttt{Λ₁subtypeEquiv}, \texttt{piEquivPiSubtypeProd},
+\texttt{subtypeIncl}, and $v.\texttt{property}$
+(which selects the $\uparrow\!\Lambda_1$ branch).
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Factor Z and numerator on extendGraph via configEquivSubtypeProd
(PR #74) + Boltzmann factoring (PR #81) + spinProduct lift (PR #82).

## Planned

- \`partitionFunctionΛ_extendGraph_factor\`
- \`numerator_extendGraph_factor\`

These establish that both partition function and numerator factor
as (inducedGraph Λ₁ counterpart) · (common complement factor).

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist 10 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)