### PR TITLE
feat: full partition/numerator factoring + correlation equality

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -603,5 +603,16 @@ theorem restrictConfig_configEquivSubtypeProd_symm
   simp [restrictConfig, subtypeIncl, configEquivSubtypeProd,
     Equiv.piEquivPiSubtypeProd, Λ₁subtypeEquiv, v.property]
 
+/-- On the complement subtype, the configEquiv-inverse applied to a pair
+gives the second component. -/
+theorem configEquivSubtypeProd_symm_apply_compl
+    {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    (σ₁ : (↑Λ₁ : Type _) → Spin)
+    (σ₂ : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁} → Spin)
+    (v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁}) :
+    (configEquivSubtypeProd h12).symm (σ₁, σ₂) v.val = σ₂ v := by
+  simp [configEquivSubtypeProd, Equiv.piEquivPiSubtypeProd,
+    Λ₁subtypeEquiv, v.property]
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,7 @@ ambient framework:
 | `liftFinset_eq_image_subtypeIncl` | `liftFinset A (hA.trans h12) = (liftFinset A hA).image (subtypeIncl h12)` |
 | `spinProduct_lift_eq` | Spin product on ↑Λ₂-lift = spin product on ↑Λ₁-lift under restrictConfig |
 | `restrictConfig_configEquivSubtypeProd_symm` | `restrictConfig (equivSymm (σ₁, σ₂)) = σ₁` (content-bearing config factoring identity) |
+| `configEquivSubtypeProd_symm_apply_compl` | On complement: `(equivSymm (σ₁, σ₂)) v.val = σ₂ v` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2111,4 +2111,17 @@ For $(\sigma_1, \sigma_2) \in (\uparrow\!\Lambda_1 \to \texttt{Spin})
 (which selects the $\uparrow\!\Lambda_1$ branch).
 \end{proof}
 
+\begin{theorem}[\texttt{configEquivSubtypeProd\_symm\_apply\_compl}]
+On the complement subtype $v \in \{x : \uparrow\!\Lambda_2 \mid x.\text{val} \notin \Lambda_1\}$,
+\[
+(\texttt{configEquivSubtypeProd}\,h_{12}).\texttt{symm}\,(\sigma_1, \sigma_2)\,v.\text{val}
+ = \sigma_2\,v.
+\]
+\end{theorem}
+
+\begin{proof}
+\texttt{simp} with the same unfoldings, now $v.\texttt{property}$
+selects the complement branch.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Combine the building blocks from PRs #81-83 to obtain the full
partition/numerator factoring and the correlation equality.

## Planned

- partitionFunctionΛ_extendGraph_factor: Z = Z_Λ₁ · F
- numerator_extendGraph_factor: num = num_Λ₁ · F
- correlationΛ_extendGraph_eq: correlations are equal (F cancels)

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)