### PR TITLE
feat: full partition and numerator factoring

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -614,5 +614,56 @@ theorem configEquivSubtypeProd_symm_apply_compl
   simp [configEquivSubtypeProd, Equiv.piEquivPiSubtypeProd,
     Λ₁subtypeEquiv, v.property]
 
+/-! ## Partition function factoring via config-equiv
+
+Using Boltzmann factoring (PR #81) and config-equiv helpers
+(PRs #82-84), express `partitionFunction extendGraph` as a product
+of `partitionFunction inducedGraph Λ₁` and a complement factor. -/
+
+/-- The complement factor used in the partition function factoring:
+`F := ∑ σ₂ : (complement → Spin), exp(β·h · Σ_{v : C} sign(σ₂ v))`. -/
+noncomputable def complementFactor
+    {Λ₁ Λ₂ : Finset V} (_h12 : Λ₁ ⊆ Λ₂)
+    (p : IsingParams ℝ) : ℝ :=
+  ∑ σ₂ : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁} → Spin,
+    Real.exp (p.β * p.h *
+      ∑ v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁}, Spin.sign ℝ (σ₂ v))
+
+/-- **Partition function factoring**:
+`Z_{extendGraphFromΛ₁} = Z_{inducedGraph Λ₁} · complementFactor`. -/
+theorem partitionFunction_extendGraph_factor
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet]
+    (p : IsingParams ℝ) :
+    partitionFunction (extendGraphFromΛ₁ G Λ₁ Λ₂) p
+      = partitionFunction (inducedGraph G Λ₁) p * complementFactor h12 p := by
+  unfold partitionFunction complementFactor
+  -- Reindex via configEquivSubtypeProd
+  rw [← Fintype.sum_equiv (configEquivSubtypeProd h12).symm _
+    (fun σ => boltzmannWeight (extendGraphFromΛ₁ G Λ₁ Λ₂) p σ)
+    (fun x => rfl)]
+  rw [Fintype.sum_prod_type]
+  -- Rewrite summand using Boltzmann factoring and restrict identities
+  have hsum : ∀ (σ₁ : (↑Λ₁ : Type _) → Spin)
+      (σ₂ : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁} → Spin),
+      boltzmannWeight (extendGraphFromΛ₁ G Λ₁ Λ₂) p
+        ((configEquivSubtypeProd h12).symm (σ₁, σ₂))
+      = boltzmannWeight (inducedGraph G Λ₁) p σ₁
+        * Real.exp (p.β * p.h *
+            ∑ v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁}, Spin.sign ℝ (σ₂ v)) := by
+    intro σ₁ σ₂
+    rw [boltzmannWeight_extendGraph_factor G h12 p,
+      restrictConfig_configEquivSubtypeProd_symm]
+    have hsign : ∑ v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁},
+          Spin.sign ℝ ((configEquivSubtypeProd h12).symm (σ₁, σ₂) v.val)
+        = ∑ v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁}, Spin.sign ℝ (σ₂ v) := by
+      apply Finset.sum_congr rfl
+      intro v _
+      rw [configEquivSubtypeProd_symm_apply_compl]
+    rw [hsign]
+  simp_rw [hsum]
+  rw [← Finset.sum_mul_sum]
+
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -653,15 +653,9 @@ theorem partitionFunction_extendGraph_factor
         * Real.exp (p.β * p.h *
             ∑ v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁}, Spin.sign ℝ (σ₂ v)) := by
     intro σ₁ σ₂
-    rw [boltzmannWeight_extendGraph_factor G h12 p,
-      restrictConfig_configEquivSubtypeProd_symm]
-    have hsign : ∑ v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁},
-          Spin.sign ℝ ((configEquivSubtypeProd h12).symm (σ₁, σ₂) v.val)
-        = ∑ v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁}, Spin.sign ℝ (σ₂ v) := by
-      apply Finset.sum_congr rfl
-      intro v _
-      rw [configEquivSubtypeProd_symm_apply_compl]
-    rw [hsign]
+    simp_rw [boltzmannWeight_extendGraph_factor G h12 p,
+      restrictConfig_configEquivSubtypeProd_symm,
+      configEquivSubtypeProd_symm_apply_compl]
   simp_rw [hsum]
   rw [← Finset.sum_mul_sum]
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,6 +159,8 @@ ambient framework:
 | `spinProduct_lift_eq` | Spin product on ↑Λ₂-lift = spin product on ↑Λ₁-lift under restrictConfig |
 | `restrictConfig_configEquivSubtypeProd_symm` | `restrictConfig (equivSymm (σ₁, σ₂)) = σ₁` (content-bearing config factoring identity) |
 | `configEquivSubtypeProd_symm_apply_compl` | On complement: `(equivSymm (σ₁, σ₂)) v.val = σ₂ v` |
+| `complementFactor` | `F := Σ σ₂, exp(β·h · Σ sign σ₂)` — complement factor for partition function |
+| `partitionFunction_extendGraph_factor` | `Z_extend = Z_induceΛ₁ · F` (partition function factoring) |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2124,4 +2124,26 @@ On the complement subtype $v \in \{x : \uparrow\!\Lambda_2 \mid x.\text{val} \no
 selects the complement branch.
 \end{proof}
 
+\subsection{Partition function factoring}
+
+\begin{theorem}[\texttt{partitionFunction\_extendGraph\_factor}]
+\[
+Z_{\texttt{extendGraphFromΛ₁}\,G\,\Lambda_1\,\Lambda_2,\,p}
+  = Z_{\texttt{inducedGraph}\,G\,\Lambda_1,\,p} \cdot F,
+\]
+where $F := \sum_{\sigma_2 : C \to \texttt{Spin}}
+  \exp\bigl(\beta h \sum_v \texttt{Spin.sign}\,\mathbb{R}\,(\sigma_2\,v)\bigr)$
+is the \texttt{complementFactor}.
+\end{theorem}
+
+\begin{proof}
+\texttt{Fintype.sum\_equiv} with $(\texttt{configEquivSubtypeProd}\,h_{12}).\texttt{symm}$
+to reindex into a pair sum.  \texttt{Fintype.sum\_prod\_type} splits
+into nested sums.  Each summand is rewritten via
+\texttt{boltzmannWeight\_extendGraph\_factor},
+\texttt{restrictConfig\_configEquivSubtypeProd\_symm}, and
+\texttt{configEquivSubtypeProd\_symm\_apply\_compl}.  Finally
+\texttt{Finset.sum\_mul\_sum} combines into the product.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Combine all config-equiv helpers from PRs #81-84 to factor both Z
and numerator on extendGraphFromΛ₁.

## Planned

- partitionFunction_extendGraph_factor: Z_ext = Z_Λ₁ · F
- numerator_extendGraph_factor: num_ext(A_2) = num_Λ₁(A_1) · F

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist 10 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)