### PR TITLE
feat: numerator factoring + correlation equality

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -659,5 +659,69 @@ theorem partitionFunction_extendGraph_factor
   simp_rw [hsum]
   rw [← Finset.sum_mul_sum]
 
+/-- **Numerator factoring**: for `A ⊆ Λ₁`, the numerator for the
+lifted spin product on `extendGraphFromΛ₁` equals the numerator on
+`inducedGraph G Λ₁` times the complement factor. -/
+theorem numerator_extendGraph_factor
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet]
+    (p : IsingParams ℝ)
+    {A : Finset V} (hA : A ⊆ Λ₁) :
+    numerator (extendGraphFromΛ₁ G Λ₁ Λ₂) p
+        (spinProduct (liftFinset A (hA.trans h12)))
+      = numerator (inducedGraph G Λ₁) p
+          (spinProduct (liftFinset A hA))
+        * complementFactor h12 p := by
+  unfold numerator complementFactor
+  rw [← Fintype.sum_equiv (configEquivSubtypeProd h12).symm _
+    (fun σ => spinProduct (liftFinset A (hA.trans h12)) σ *
+      boltzmannWeight (extendGraphFromΛ₁ G Λ₁ Λ₂) p σ)
+    (fun x => rfl)]
+  rw [Fintype.sum_prod_type]
+  have hsum : ∀ (σ₁ : (↑Λ₁ : Type _) → Spin)
+      (σ₂ : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁} → Spin),
+      spinProduct (liftFinset A (hA.trans h12))
+          ((configEquivSubtypeProd h12).symm (σ₁, σ₂))
+        * boltzmannWeight (extendGraphFromΛ₁ G Λ₁ Λ₂) p
+            ((configEquivSubtypeProd h12).symm (σ₁, σ₂))
+      = spinProduct (liftFinset A hA) σ₁
+          * boltzmannWeight (inducedGraph G Λ₁) p σ₁
+        * Real.exp (p.β * p.h *
+            ∑ v : {x : (↑Λ₂ : Type _) // x.val ∉ Λ₁}, Spin.sign ℝ (σ₂ v)) := by
+    intro σ₁ σ₂
+    simp_rw [spinProduct_lift_eq h12 hA,
+      boltzmannWeight_extendGraph_factor G h12 p,
+      restrictConfig_configEquivSubtypeProd_symm,
+      configEquivSubtypeProd_symm_apply_compl]
+    ring
+  simp_rw [hsum]
+  rw [← Finset.sum_mul_sum]
+
+/-- **Correlation equality**: the correlation on `extendGraphFromΛ₁`
+equals the correlation on `inducedGraph G Λ₁`, when `A ⊆ Λ₁`.
+
+Proof: the complement factor in `numerator_extendGraph_factor` and
+`partitionFunction_extendGraph_factor` is identical, so it cancels
+in the ratio `correlation = numerator / partitionFunction`. -/
+theorem correlationΛ_extendGraph_eq
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet]
+    (p : IsingParams ℝ)
+    {A : Finset V} (hA : A ⊆ Λ₁) :
+    correlation (extendGraphFromΛ₁ G Λ₁ Λ₂) p (liftFinset A (hA.trans h12))
+      = correlation (inducedGraph G Λ₁) p (liftFinset A hA) := by
+  have hZ : (0 : ℝ) < partitionFunction (inducedGraph G Λ₁) p :=
+    partitionFunction_pos _ _
+  have hF : (0 : ℝ) < complementFactor h12 p := by
+    unfold complementFactor
+    exact Finset.sum_pos (fun _ _ => Real.exp_pos _) Finset.univ_nonempty
+  have hZfac := partitionFunction_extendGraph_factor G h12 p
+  have hnfac := numerator_extendGraph_factor G h12 p hA
+  unfold correlation
+  rw [gibbsExpectation_eq_div, gibbsExpectation_eq_div, hZfac, hnfac]
+  field_simp
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,6 +161,8 @@ ambient framework:
 | `configEquivSubtypeProd_symm_apply_compl` | On complement: `(equivSymm (σ₁, σ₂)) v.val = σ₂ v` |
 | `complementFactor` | `F := Σ σ₂, exp(β·h · Σ sign σ₂)` — complement factor for partition function |
 | `partitionFunction_extendGraph_factor` | `Z_extend = Z_induceΛ₁ · F` (partition function factoring) |
+| `numerator_extendGraph_factor` | `num_extend(lift A) = num_induceΛ₁(lift A) · F` |
+| `correlationΛ_extendGraph_eq` | **Correlation equality**: `⟨σ^A⟩_extend = ⟨σ^A⟩_induceΛ₁` (F cancels) |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2146,4 +2146,28 @@ into nested sums.  Each summand is rewritten via
 \texttt{Finset.sum\_mul\_sum} combines into the product.
 \end{proof}
 
+\begin{theorem}[\texttt{numerator\_extendGraph\_factor}]
+For $A \subseteq \Lambda_1$,
+$\texttt{numerator}_{G_1^\text{ext}}(\texttt{spinProduct}\,(\texttt{liftFinset}\,A\,\ldots))
+= \texttt{numerator}_{\texttt{inducedGraph}\,G\,\Lambda_1}(\texttt{spinProduct}\,(\texttt{liftFinset}\,A\,h_A)) \cdot F$.
+\end{theorem}
+
+\begin{proof}
+Same pattern as partition function factoring, with
+\texttt{spinProduct\_lift\_eq} additionally applied to rewrite the
+spinProduct through \texttt{restrictConfig}.
+\end{proof}
+
+\begin{theorem}[\texttt{correlationΛ\_extendGraph\_eq}]
+For $A \subseteq \Lambda_1$,
+$\langle\sigma^{A_2}\rangle_{G_1^\text{ext}}
+ = \langle\sigma^{A_1}\rangle_{\texttt{inducedGraph}\,G\,\Lambda_1}$.
+\end{theorem}
+
+\begin{proof}
+Express both correlations as $\texttt{numerator} / Z$ via
+\texttt{gibbsExpectation\_eq\_div}, apply the two factoring theorems,
+and cancel the common complement factor $F$ using \texttt{field\_simp}.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

Numerator factoring (mirror of PR #85 partition factoring) plus
the correlation equality that the extendGraph and inducedGraph Λ₁
correlations coincide when A ⊆ Λ₁.

## Planned

- numerator_extendGraph_factor
- correlationΛ_extendGraph_eq

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)