### PR TITLE
feat: correlationΛ_monotone_volume main theorem

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -730,23 +730,20 @@ factoring) with `extendGraphFromΛ₁_le_induce` + `correlation_monotone_subgrap
 (subgraph monotonicity on `↑Λ₂`), we obtain the main volume-direction
 monotonicity theorem. -/
 
-set_option linter.unusedFintypeInType false in
 /-- **Volume-direction monotonicity** (main theorem of the ambient
 framework): for ferromagnetic `p`, `A ⊆ Λ₁ ⊆ Λ₂ : Finset V`,
-`correlationΛ G Λ₁ p (liftFinset A hA) ≤ correlationΛ G Λ₂ p (liftFinset A (hA.trans h12))`.
-
-The `Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet` instance is used
-internally by `correlationΛ_extendGraph_eq` but does not appear in
-the theorem statement. -/
+`⟨σ^A⟩_{G, Λ₁} ≤ ⟨σ^A⟩_{G, Λ₂}`. -/
 theorem correlationΛ_monotone_volume
     (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
     [Fintype (inducedGraph G Λ₁).edgeSet]
     [Fintype (inducedGraph G Λ₂).edgeSet]
-    [Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p)
     {A : Finset V} (hA : A ⊆ Λ₁) :
     correlationΛ G Λ₁ p (liftFinset A hA)
       ≤ correlationΛ G Λ₂ p (liftFinset A (hA.trans h12)) := by
+  classical
+  haveI : Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet :=
+    Fintype.ofFinite _
   unfold correlationΛ
   rw [← correlationΛ_extendGraph_eq G h12 p hA]
   exact correlation_monotone_subgraph

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -723,5 +723,34 @@ theorem correlationΛ_extendGraph_eq
   rw [gibbsExpectation_eq_div, gibbsExpectation_eq_div, hZfac, hnfac]
   field_simp
 
+/-! ## Volume-direction monotonicity main theorem
+
+Combining `correlationΛ_extendGraph_eq` (correlation equality via config
+factoring) with `extendGraphFromΛ₁_le_induce` + `correlation_monotone_subgraph`
+(subgraph monotonicity on `↑Λ₂`), we obtain the main volume-direction
+monotonicity theorem. -/
+
+set_option linter.unusedFintypeInType false in
+/-- **Volume-direction monotonicity** (main theorem of the ambient
+framework): for ferromagnetic `p`, `A ⊆ Λ₁ ⊆ Λ₂ : Finset V`,
+`correlationΛ G Λ₁ p (liftFinset A hA) ≤ correlationΛ G Λ₂ p (liftFinset A (hA.trans h12))`.
+
+The `Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet` instance is used
+internally by `correlationΛ_extendGraph_eq` but does not appear in
+the theorem statement. -/
+theorem correlationΛ_monotone_volume
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h12 : Λ₁ ⊆ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (extendGraphFromΛ₁ G Λ₁ Λ₂).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    {A : Finset V} (hA : A ⊆ Λ₁) :
+    correlationΛ G Λ₁ p (liftFinset A hA)
+      ≤ correlationΛ G Λ₂ p (liftFinset A (hA.trans h12)) := by
+  unfold correlationΛ
+  rw [← correlationΛ_extendGraph_eq G h12 p hA]
+  exact correlation_monotone_subgraph
+    (extendGraphFromΛ₁_le_induce G Λ₁ Λ₂) p hf _
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,6 +163,7 @@ ambient framework:
 | `partitionFunction_extendGraph_factor` | `Z_extend = Z_induceΛ₁ · F` (partition function factoring) |
 | `numerator_extendGraph_factor` | `num_extend(lift A) = num_induceΛ₁(lift A) · F` |
 | `correlationΛ_extendGraph_eq` | **Correlation equality**: `⟨σ^A⟩_extend = ⟨σ^A⟩_induceΛ₁` (F cancels) |
+| **`correlationΛ_monotone_volume`** | **Volume-direction monotonicity main theorem**: `Λ₁ ⊆ Λ₂ ⇒ ⟨σ^A⟩_{Λ₁} ≤ ⟨σ^A⟩_{Λ₂}` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2170,4 +2170,28 @@ Express both correlations as $\texttt{numerator} / Z$ via
 and cancel the common complement factor $F$ using \texttt{field\_simp}.
 \end{proof}
 
+\subsection{Volume-direction monotonicity main theorem}
+
+\begin{theorem}[\texttt{correlationΛ\_monotone\_volume}]
+For ferromagnetic $p$ and $A \subseteq \Lambda_1 \subseteq \Lambda_2 : \text{Finset}\,V$,
+\[
+\langle\sigma^A\rangle_{G, \Lambda_1} \le \langle\sigma^A\rangle_{G, \Lambda_2}.
+\]
+\end{theorem}
+
+\begin{proof}
+\begin{align*}
+\langle\sigma^A\rangle_{G, \Lambda_1}
+&= \langle\sigma^{A_1}\rangle_{\texttt{inducedGraph}\,G\,\Lambda_1} && \text{(def)}\\
+&= \langle\sigma^{A_2}\rangle_{\texttt{extendGraphFromΛ₁}\,G\,\Lambda_1\,\Lambda_2}
+   && \text{(\texttt{correlationΛ\_extendGraph\_eq})}\\
+&\le \langle\sigma^{A_2}\rangle_{\texttt{inducedGraph}\,G\,\Lambda_2}
+   && \text{(\texttt{correlation\_monotone\_subgraph} + \texttt{extendGraphFromΛ₁\_le\_induce})}\\
+&= \langle\sigma^A\rangle_{G, \Lambda_2}. && \text{(def)}
+\end{align*}
+\end{proof}
+
+This completes the volume-direction monotonicity on the genuine
+infinite-volume (\texttt{AmbientLattice}) framework.
+
 \end{document}


### PR DESCRIPTION
## Summary

Final step of the volume-direction monotonicity series (#71-87):
prove correlationΛ_monotone_volume on the AmbientLattice framework.

## Theorem

For A ⊆ Λ₁ ⊆ Λ₂ : Finset V and ferromagnetic p,
`correlationΛ G Λ₁ p (lift A to Λ₁) ≤ correlationΛ G Λ₂ p (lift A to Λ₂)`.

## Proof

Combine:
- correlationΛ_extendGraph_eq (PR #86): correlation equality via config factoring
- extendGraphFromΛ₁_le_induce (PR #72): extend graph is a subgraph of Λ₂'s induce
- correlation_monotone_subgraph (PR #64): subgraph-direction monotonicity

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist 10 items (run BEFORE commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)