### PR TITLE
feat: correlationAlongExhaustion direct Tendsto

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -798,5 +798,47 @@ theorem correlationΛ_shifted_tendsto
   obtain ⟨hmono, hbdd⟩ := correlationΛ_shifted_monotone_bounded G Λ p hf hN
   exact ⟨_, tendsto_atTop_ciSup hmono ⟨1, fun _ ⟨m, hm⟩ => hm ▸ hbdd m⟩⟩
 
+/-- **Convergence of correlation along an exhaustion**: for a
+ferromagnetic Ising model and any exhaustion `Λₙ ↑ V` of an
+ambient type `V`, the sequence `correlationAlongExhaustion`
+converges as `n → ∞`.
+
+Proof: `correlationAlongExhaustion` is globally monotone
+because (1) for `n` where `A ⊆ Λ.volume n` fails, it equals 0;
+(2) when it holds, `correlationΛ ≥ 0` by GKS-I; and (3) when both
+endpoints satisfy the inclusion, `correlationΛ_monotone_volume`
+(PR #87) applies. Bounded by 1 (0 or `correlationΛ_le_one`).
+`tendsto_atTop_ciSup`. -/
+theorem correlationAlongExhaustion_convergent
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset V) :
+    ∃ L : ℝ, Filter.Tendsto
+      (correlationAlongExhaustion G Λ p A)
+      Filter.atTop (nhds L) := by
+  have hmono : Monotone (correlationAlongExhaustion G Λ p A) := by
+    intro n m hnm
+    by_cases hAn : A ⊆ Λ.volume n
+    · by_cases hAm : A ⊆ Λ.volume m
+      · simp only [correlationAlongExhaustion, hAn, hAm, dite_true]
+        exact correlationΛ_monotone_volume G (Λ.mono hnm) p hf hAn
+      · exact absurd (hAn.trans (Λ.mono hnm)) hAm
+    · simp only [correlationAlongExhaustion, hAn, dite_false]
+      by_cases hAm : A ⊆ Λ.volume m
+      · simp only [hAm, dite_true]
+        exact correlationΛ_nonneg G (Λ.volume m) p hf _
+      · simp only [hAm, dite_false]
+        exact le_refl 0
+  have hbdd : BddAbove (Set.range (correlationAlongExhaustion G Λ p A)) := by
+    refine ⟨1, ?_⟩
+    rintro _ ⟨n, rfl⟩
+    by_cases hAn : A ⊆ Λ.volume n
+    · simp only [correlationAlongExhaustion, hAn, dite_true]
+      exact correlationΛ_le_one _ _ _ _
+    · simp only [correlationAlongExhaustion, hAn, dite_false]
+      norm_num
+  exact ⟨_, tendsto_atTop_ciSup hmono hbdd⟩
+
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -798,17 +798,73 @@ theorem correlationΛ_shifted_tendsto
   obtain ⟨hmono, hbdd⟩ := correlationΛ_shifted_monotone_bounded G Λ p hf hN
   exact ⟨_, tendsto_atTop_ciSup hmono ⟨1, fun _ ⟨m, hm⟩ => hm ▸ hbdd m⟩⟩
 
-/-- **Convergence of correlation along an exhaustion**: for a
-ferromagnetic Ising model and any exhaustion `Λₙ ↑ V` of an
-ambient type `V`, the sequence `correlationAlongExhaustion`
-converges as `n → ∞`.
-
-Proof: `correlationAlongExhaustion` is globally monotone
+/-- **Global monotonicity of `correlationAlongExhaustion`**:
 because (1) for `n` where `A ⊆ Λ.volume n` fails, it equals 0;
 (2) when it holds, `correlationΛ ≥ 0` by GKS-I; and (3) when both
 endpoints satisfy the inclusion, `correlationΛ_monotone_volume`
-(PR #87) applies. Bounded by 1 (0 or `correlationΛ_le_one`).
-`tendsto_atTop_ciSup`. -/
+(PR #87) applies. -/
+theorem correlationAlongExhaustion_monotone
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset V) :
+    Monotone (correlationAlongExhaustion G Λ p A) := by
+  intro n m hnm
+  by_cases hAn : A ⊆ Λ.volume n
+  · by_cases hAm : A ⊆ Λ.volume m
+    · simp only [correlationAlongExhaustion, hAn, hAm, dite_true]
+      exact correlationΛ_monotone_volume G (Λ.mono hnm) p hf hAn
+    · exact absurd (hAn.trans (Λ.mono hnm)) hAm
+  · simp only [correlationAlongExhaustion, hAn, dite_false]
+    by_cases hAm : A ⊆ Λ.volume m
+    · simp only [hAm, dite_true]
+      exact correlationΛ_nonneg G (Λ.volume m) p hf _
+    · simp only [hAm, dite_false]
+      exact le_refl 0
+
+/-- **Global upper bound of `correlationAlongExhaustion` by 1**:
+either the value is 0 (when `A ⊄ Λ.volume n`) or it is bounded
+by `correlationΛ_le_one`. -/
+theorem correlationAlongExhaustion_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (A : Finset V) (n : ℕ) :
+    correlationAlongExhaustion G Λ p A n ≤ 1 := by
+  by_cases hAn : A ⊆ Λ.volume n
+  · simp only [correlationAlongExhaustion, hAn, dite_true]
+    exact correlationΛ_le_one _ _ _ _
+  · simp only [correlationAlongExhaustion, hAn, dite_false]
+    norm_num
+
+/-- **Convergence of correlation along an exhaustion (explicit limit)**:
+for a ferromagnetic Ising model and any exhaustion `Λₙ ↑ V` of an
+ambient type `V`, the sequence `correlationAlongExhaustion` converges
+to its supremum as `n → ∞`.
+
+The limit is `⨆ n, correlationAlongExhaustion G Λ p A n`; this
+exposes the limit's identity (as a supremum) so it can be related
+to the thermodynamic-limit correlation once `Λ.exhaust` is used to
+identify `A` with a subset of some `Λ.volume N`.
+
+Note: this theorem itself only uses `Λ.mono` (monotonicity of the
+exhaustion); `Λ.exhaust` is not required for convergence alone,
+but is needed in downstream physical identifications of `L`. -/
+theorem correlationAlongExhaustion_tendsto_ciSup
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset V) :
+    Filter.Tendsto (correlationAlongExhaustion G Λ p A)
+      Filter.atTop (nhds (⨆ n, correlationAlongExhaustion G Λ p A n)) := by
+  refine tendsto_atTop_ciSup
+    (correlationAlongExhaustion_monotone G Λ p hf A) ⟨1, ?_⟩
+  rintro _ ⟨n, rfl⟩
+  exact correlationAlongExhaustion_le_one G Λ p A n
+
+/-- **Convergence of correlation along an exhaustion (existential form)**:
+thin wrapper around `correlationAlongExhaustion_tendsto_ciSup`. Use
+the `_tendsto_ciSup` form when the identity of `L` as a supremum is
+needed (e.g. for physical identification with the thermodynamic limit). -/
 theorem correlationAlongExhaustion_convergent
     (G : SimpleGraph V) (Λ : Exhaustion V)
     [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
@@ -816,29 +872,8 @@ theorem correlationAlongExhaustion_convergent
     (A : Finset V) :
     ∃ L : ℝ, Filter.Tendsto
       (correlationAlongExhaustion G Λ p A)
-      Filter.atTop (nhds L) := by
-  have hmono : Monotone (correlationAlongExhaustion G Λ p A) := by
-    intro n m hnm
-    by_cases hAn : A ⊆ Λ.volume n
-    · by_cases hAm : A ⊆ Λ.volume m
-      · simp only [correlationAlongExhaustion, hAn, hAm, dite_true]
-        exact correlationΛ_monotone_volume G (Λ.mono hnm) p hf hAn
-      · exact absurd (hAn.trans (Λ.mono hnm)) hAm
-    · simp only [correlationAlongExhaustion, hAn, dite_false]
-      by_cases hAm : A ⊆ Λ.volume m
-      · simp only [hAm, dite_true]
-        exact correlationΛ_nonneg G (Λ.volume m) p hf _
-      · simp only [hAm, dite_false]
-        exact le_refl 0
-  have hbdd : BddAbove (Set.range (correlationAlongExhaustion G Λ p A)) := by
-    refine ⟨1, ?_⟩
-    rintro _ ⟨n, rfl⟩
-    by_cases hAn : A ⊆ Λ.volume n
-    · simp only [correlationAlongExhaustion, hAn, dite_true]
-      exact correlationΛ_le_one _ _ _ _
-    · simp only [correlationAlongExhaustion, hAn, dite_false]
-      norm_num
-  exact ⟨_, tendsto_atTop_ciSup hmono hbdd⟩
+      Filter.atTop (nhds L) :=
+  ⟨_, correlationAlongExhaustion_tendsto_ciSup G Λ p hf A⟩
 
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,7 @@ ambient framework:
 | **`correlationΛ_monotone_volume`** | **Volume-direction monotonicity main theorem**: `Λ₁ ⊆ Λ₂ ⇒ ⟨σ^A⟩_{Λ₁} ≤ ⟨σ^A⟩_{Λ₂}` |
 | `correlationΛ_shifted_monotone_bounded` | Shifted correlation sequence along exhaustion is monotone and bounded by 1 |
 | `correlationΛ_shifted_tendsto` | Shifted correlation sequence converges to sup (Tendsto) |
+| **`correlationAlongExhaustion_convergent`** | **Genuine thermodynamic limit**: correlation along exhaustion converges |
 
 ## Axioms
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,7 +166,10 @@ ambient framework:
 | **`correlationΛ_monotone_volume`** | **Volume-direction monotonicity main theorem**: `Λ₁ ⊆ Λ₂ ⇒ ⟨σ^A⟩_{Λ₁} ≤ ⟨σ^A⟩_{Λ₂}` |
 | `correlationΛ_shifted_monotone_bounded` | Shifted correlation sequence along exhaustion is monotone and bounded by 1 |
 | `correlationΛ_shifted_tendsto` | Shifted correlation sequence converges to sup (Tendsto) |
-| **`correlationAlongExhaustion_convergent`** | **Genuine thermodynamic limit**: correlation along exhaustion converges |
+| `correlationAlongExhaustion_monotone` | `correlationAlongExhaustion` is globally monotone (covers `A ⊄ Λ.volume n` by GKS-I ≥ 0) |
+| `correlationAlongExhaustion_le_one` | `correlationAlongExhaustion n ≤ 1` for all `n` |
+| **`correlationAlongExhaustion_tendsto_ciSup`** | **Convergence to explicit supremum**: `Tendsto … (nhds (⨆ n, …))` |
+| **`correlationAlongExhaustion_convergent`** | Thin wrapper `∃ L, Tendsto …` — genuine thermodynamic limit |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2217,32 +2217,59 @@ The shifted correlation sequence (monotone + bounded) converges to
 its supremum by \texttt{tendsto\_atTop\_ciSup}.
 \end{theorem}
 
-Connection to \texttt{correlationAlongExhaustion} via proof-irrelevance
-of \texttt{liftFinset} across volumes is the remaining work for
-the full infinite-volume convergence.
+An alternative approach bypasses the shifted-sequence / proof-irrelevance
+route and establishes global monotonicity of
+\texttt{correlationAlongExhaustion} directly.
 
-\begin{theorem}[\texttt{correlationAlongExhaustion\_convergent}]
+\begin{theorem}[\texttt{correlationAlongExhaustion\_monotone}]
+For a ferromagnetic Ising model and any exhaustion $\Lambda_\bullet$,
+the sequence $n \mapsto \texttt{correlationAlongExhaustion}\,G\,\Lambda\,p\,A\,n$
+is monotone.  Specifically, for $n \le m$:
+\begin{itemize}
+  \item $A \subseteq \Lambda.\text{volume}\,n$: then
+    $A \subseteq \Lambda.\text{volume}\,m$ follows from $\Lambda.\text{mono}$;
+    monotonicity follows from \texttt{correlationΛ\_monotone\_volume}.
+  \item $A \not\subseteq \Lambda.\text{volume}\,n$: LHS is 0;
+    RHS is either 0 (when $A \not\subseteq \Lambda.\text{volume}\,m$)
+    or $\ge 0$ by GKS-I (\texttt{correlationΛ\_nonneg}).
+\end{itemize}
+\end{theorem}
+
+\begin{theorem}[\texttt{correlationAlongExhaustion\_le\_one}]
+For every $n$, $\texttt{correlationAlongExhaustion}\,G\,\Lambda\,p\,A\,n \le 1$,
+either because the value is 0 or via \texttt{correlationΛ\_le\_one}.
+\end{theorem}
+
+\begin{theorem}[\texttt{correlationAlongExhaustion\_tendsto\_ciSup}]
 For a ferromagnetic Ising model and any exhaustion $\Lambda_n \uparrow V$
 of an ambient type $V$,
 \[
-\exists L,\ \text{Tendsto}\,(\text{correlationAlongExhaustion}\,G\,\Lambda\,p\,A)\,\text{atTop}\,(\text{nhds}\,L).
+\text{Tendsto}\,(\text{correlationAlongExhaustion}\,G\,\Lambda\,p\,A)\,\text{atTop}\,
+  \left(\text{nhds}\,\bigsqcup_n \text{correlationAlongExhaustion}\,G\,\Lambda\,p\,A\,n\right).
 \]
 \end{theorem}
 
 \begin{proof}
-\texttt{correlationAlongExhaustion} is globally monotone:
-\begin{itemize}
-  \item $n \le m$, $A \subseteq \Lambda.\text{volume}\,n$ implies
-    $A \subseteq \Lambda.\text{volume}\,m$ (from $\Lambda.\text{mono}$);
-    then \texttt{correlationΛ\_monotone\_volume}.
-  \item $A \not\subseteq \Lambda.\text{volume}\,n$: LHS is 0;
-    RHS is either 0 or $\ge 0$ by GKS-I (\texttt{correlationΛ\_nonneg}).
-\end{itemize}
-Bounded by $1$ via \texttt{correlationΛ\_le\_one} (when inclusion holds)
-or $0$.  \texttt{tendsto\_atTop\_ciSup}.
+Combine \texttt{correlationAlongExhaustion\_monotone} and
+\texttt{correlationAlongExhaustion\_le\_one} and apply
+\texttt{tendsto\_atTop\_ciSup}.  The proof uses only $\Lambda.\text{mono}$;
+$\Lambda.\text{exhaust}$ is not required for convergence alone.  Physical
+identification of the limit with the thermodynamic-limit correlation
+uses $\Lambda.\text{exhaust}$ (any $A : \texttt{Finset}~V$ eventually
+lies in some $\Lambda.\text{volume}~N$).
 \end{proof}
 
-This completes the genuine infinite-volume limit on the
+\begin{theorem}[\texttt{correlationAlongExhaustion\_convergent}]
+Thin wrapper: for a ferromagnetic Ising model and any exhaustion
+$\Lambda_n \uparrow V$,
+\[
+\exists L,\ \text{Tendsto}\,(\text{correlationAlongExhaustion}\,G\,\Lambda\,p\,A)\,\text{atTop}\,(\text{nhds}\,L).
+\]
+Use \texttt{correlationAlongExhaustion\_tendsto\_ciSup} directly when the
+identity of $L$ as a supremum is needed.
+\end{theorem}
+
+This completes the genuine infinite-volume convergence on the
 \texttt{AmbientLattice} framework.
 
 \end{document}

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2221,4 +2221,28 @@ Connection to \texttt{correlationAlongExhaustion} via proof-irrelevance
 of \texttt{liftFinset} across volumes is the remaining work for
 the full infinite-volume convergence.
 
+\begin{theorem}[\texttt{correlationAlongExhaustion\_convergent}]
+For a ferromagnetic Ising model and any exhaustion $\Lambda_n \uparrow V$
+of an ambient type $V$,
+\[
+\exists L,\ \text{Tendsto}\,(\text{correlationAlongExhaustion}\,G\,\Lambda\,p\,A)\,\text{atTop}\,(\text{nhds}\,L).
+\]
+\end{theorem}
+
+\begin{proof}
+\texttt{correlationAlongExhaustion} is globally monotone:
+\begin{itemize}
+  \item $n \le m$, $A \subseteq \Lambda.\text{volume}\,n$ implies
+    $A \subseteq \Lambda.\text{volume}\,m$ (from $\Lambda.\text{mono}$);
+    then \texttt{correlationΛ\_monotone\_volume}.
+  \item $A \not\subseteq \Lambda.\text{volume}\,n$: LHS is 0;
+    RHS is either 0 or $\ge 0$ by GKS-I (\texttt{correlationΛ\_nonneg}).
+\end{itemize}
+Bounded by $1$ via \texttt{correlationΛ\_le\_one} (when inclusion holds)
+or $0$.  \texttt{tendsto\_atTop\_ciSup}.
+\end{proof}
+
+This completes the genuine infinite-volume limit on the
+\texttt{AmbientLattice} framework.
+
 \end{document}


### PR DESCRIPTION
## Summary

Prove correlationAlongExhaustion is Tendsto-convergent via a direct
global-monotone argument (sidestepping the shifted/proof-irrelevance
complications from PRs #88-89).

## Key insight

correlationAlongExhaustion is globally monotone because:
- Before hitting A ⊆ Λ.volume n: value is 0
- After: ≥ 0 by GKS-I, monotone via volume monotonicity

Bounded by 1. tendsto_atTop_ciSup.

## Test plan

- [ ] \`lake build\` + GKSTest
- [ ] sorry/linter ゼロ
- [ ] \`copilot -p\`
- [ ] PR checklist 10 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)