### PR TITLE
feat: infinite-volume correlation function

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -907,8 +907,8 @@ theorem tendsto_correlationAlongExhaustion_correlationInfinite
       Filter.atTop (nhds (correlationInfinite G Λ p A)) :=
   correlationAlongExhaustion_tendsto_ciSup G Λ p hf A
 
-/-- **Upper bound**: `correlationInfinite ≤ 1`. Follows from
-`correlationAlongExhaustion_le_one` applied to the supremum. -/
+/-- **Upper bound**: `correlationInfinite ≤ 1`. Pointwise bound from
+`correlationAlongExhaustion_le_one` + `ciSup_le`. -/
 theorem correlationInfinite_le_one
     (G : SimpleGraph V) (Λ : Exhaustion V)
     [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -875,5 +875,118 @@ theorem correlationAlongExhaustion_convergent
       Filter.atTop (nhds L) :=
   ⟨_, correlationAlongExhaustion_tendsto_ciSup G Λ p hf A⟩
 
+/-! ## Infinite-volume correlation function
+
+The supremum exposed by `correlationAlongExhaustion_tendsto_ciSup`
+is, by GKS-I and `Λ.exhaust`, the thermodynamic-limit correlation
+for ferromagnetic Ising models on an ambient `V`.  We package it as
+a `noncomputable def` and record its basic properties. -/
+
+/-- **Infinite-volume correlation function**: for a ferromagnetic
+Ising model on an ambient type `V` with an exhaustion `Λ` and a
+finite `A : Finset V`,
+`correlationInfinite G Λ p A := ⨆ n, correlationAlongExhaustion G Λ p A n`.
+This is the thermodynamic-limit correlation identified via
+`Λ.exhaust` (any finite `A` lies in some `Λ.volume N`). -/
+noncomputable def correlationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (A : Finset V) : ℝ :=
+  ⨆ n, correlationAlongExhaustion G Λ p A n
+
+/-- **Tendsto to infinite-volume correlation** (primary form):
+`correlationAlongExhaustion` converges to `correlationInfinite`.
+Restatement of `correlationAlongExhaustion_tendsto_ciSup` in terms
+of the canonical `correlationInfinite` name. -/
+theorem tendsto_correlationAlongExhaustion_correlationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset V) :
+    Filter.Tendsto (correlationAlongExhaustion G Λ p A)
+      Filter.atTop (nhds (correlationInfinite G Λ p A)) :=
+  correlationAlongExhaustion_tendsto_ciSup G Λ p hf A
+
+/-- **Upper bound**: `correlationInfinite ≤ 1`. Follows from
+`correlationAlongExhaustion_le_one` applied to the supremum. -/
+theorem correlationInfinite_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (A : Finset V) :
+    correlationInfinite G Λ p A ≤ 1 := by
+  refine ciSup_le ?_
+  intro n
+  exact correlationAlongExhaustion_le_one G Λ p A n
+
+/-- **Nonnegativity** (ferromagnetic): `correlationInfinite ≥ 0`.
+Uses `Λ.exhaust`: pick `N` with `A ⊆ Λ.volume N`; then
+`correlationAlongExhaustion G Λ p A N ≥ 0` by GKS-I, and this is
+a lower bound for the supremum (so the supremum is also `≥ 0`). -/
+theorem correlationInfinite_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset V) :
+    0 ≤ correlationInfinite G Λ p A := by
+  obtain ⟨N, hN⟩ := Λ.exhaust A
+  have hA : A ⊆ Λ.volume N := hN N le_rfl
+  have hval : 0 ≤ correlationAlongExhaustion G Λ p A N := by
+    simp only [correlationAlongExhaustion, hA, dite_true]
+    exact correlationΛ_nonneg G (Λ.volume N) p hf _
+  have hbdd : BddAbove (Set.range (correlationAlongExhaustion G Λ p A)) := by
+    refine ⟨1, ?_⟩
+    rintro _ ⟨n, rfl⟩
+    exact correlationAlongExhaustion_le_one G Λ p A n
+  exact hval.trans (le_ciSup hbdd N)
+
+/-- **Tendsto of the lifted `correlationΛ` sequence (explicit form)**:
+given an explicit `N` and a hypothesis `hN : ∀ n ≥ N, A ⊆ Λ.volume n`,
+the sequence `m ↦ correlationΛ G (Λ.volume (m+N)) p (liftFinset A …)`
+converges to `correlationInfinite G Λ p A`.
+
+The shifted sequence coincides with `correlationAlongExhaustion` on
+indices `≥ N` (both branches of the dite agree since `A ⊆ Λ.volume (m+N)`),
+and the base sequence's limit is `correlationInfinite` by
+`tendsto_correlationAlongExhaustion_correlationInfinite`. -/
+theorem tendsto_correlationΛ_correlationInfinite_of_subset
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    {A : Finset V} {N : ℕ}
+    (hN : ∀ n ≥ N, A ⊆ Λ.volume n) :
+    Filter.Tendsto
+      (fun m : ℕ => correlationΛ G (Λ.volume (m + N)) p
+        (liftFinset A (hN (m + N) (Nat.le_add_left N m))))
+      Filter.atTop (nhds (correlationInfinite G Λ p A)) := by
+  have hbase := tendsto_correlationAlongExhaustion_correlationInfinite G Λ p hf A
+  have hshift :
+      Filter.Tendsto (fun m : ℕ => correlationAlongExhaustion G Λ p A (m + N))
+        Filter.atTop (nhds (correlationInfinite G Λ p A)) :=
+    hbase.comp (Filter.tendsto_add_atTop_nat N)
+  refine hshift.congr ?_
+  intro m
+  have hA : A ⊆ Λ.volume (m + N) := hN (m + N) (Nat.le_add_left N m)
+  simp only [correlationAlongExhaustion, hA, dite_true]
+
+/-- **Tendsto of the lifted `correlationΛ` sequence (corollary)**:
+using `Λ.exhaust` to produce an `N` with `A ⊆ Λ.volume n` for `n ≥ N`,
+the sequence `m ↦ correlationΛ G (Λ.volume (m+N)) p (liftFinset A …)`
+converges to `correlationInfinite G Λ p A`.
+
+This is the physical statement: as the volume grows, the finite-volume
+correlation converges to the thermodynamic-limit correlation. -/
+theorem tendsto_correlationΛ_correlationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset V) :
+    ∃ N : ℕ, ∃ hN : ∀ n ≥ N, A ⊆ Λ.volume n,
+      Filter.Tendsto
+        (fun m : ℕ => correlationΛ G (Λ.volume (m + N)) p
+          (liftFinset A (hN (m + N) (Nat.le_add_left N m))))
+        Filter.atTop (nhds (correlationInfinite G Λ p A)) := by
+  obtain ⟨N, hN⟩ := Λ.exhaust A
+  exact ⟨N, hN, tendsto_correlationΛ_correlationInfinite_of_subset G Λ p hf hN⟩
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -170,6 +170,12 @@ ambient framework:
 | `correlationAlongExhaustion_le_one` | `correlationAlongExhaustion n ≤ 1` for all `n` |
 | **`correlationAlongExhaustion_tendsto_ciSup`** | **Convergence to explicit supremum**: `Tendsto … (nhds (⨆ n, …))` |
 | **`correlationAlongExhaustion_convergent`** | Thin wrapper `∃ L, Tendsto …` — genuine thermodynamic limit |
+| **`correlationInfinite`** | **Infinite-volume correlation** `:= ⨆ n, correlationAlongExhaustion …` |
+| `tendsto_correlationAlongExhaustion_correlationInfinite` | `correlationAlongExhaustion → correlationInfinite` (Tendsto) |
+| `correlationInfinite_le_one` | `correlationInfinite ≤ 1` |
+| `correlationInfinite_nonneg` | `0 ≤ correlationInfinite` (uses `Λ.exhaust` + GKS-I) |
+| `tendsto_correlationΛ_correlationInfinite_of_subset` | Explicit-hypothesis form: given `∀ n ≥ N, A ⊆ Λ.volume n`, `correlationΛ (Λ.volume (m+N)) …` → `correlationInfinite` |
+| **`tendsto_correlationΛ_correlationInfinite`** | **Physical identification** (via `Λ.exhaust`): `correlationΛ G (Λ.volume (m+N)) p (lift A) → correlationInfinite` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2272,4 +2272,57 @@ identity of $L$ as a supremum is needed.
 This completes the genuine infinite-volume convergence on the
 \texttt{AmbientLattice} framework.
 
+\subsection{Infinite-volume correlation function}
+
+\begin{definition}[\texttt{correlationInfinite}]
+\[
+\langle \sigma^A \rangle_V^{\mathrm{FM}} \;:=\;
+  \bigsqcup_{n \in \mathbb{N}} \texttt{correlationAlongExhaustion}\,G\,\Lambda\,p\,A\,n.
+\]
+\end{definition}
+
+\begin{theorem}[\texttt{tendsto\_correlationAlongExhaustion\_correlationInfinite}]
+$\text{Tendsto}\,\texttt{correlationAlongExhaustion}\,\text{atTop}\,
+  (\text{nhds}\,\langle \sigma^A \rangle_V^{\mathrm{FM}})$.
+\end{theorem}
+
+\begin{theorem}[\texttt{correlationInfinite\_le\_one}]
+$\langle \sigma^A \rangle_V^{\mathrm{FM}} \le 1$.
+\end{theorem}
+
+\begin{proof}
+\texttt{correlationAlongExhaustion\_le\_one} から sup の上界が 1.
+\end{proof}
+
+\begin{theorem}[\texttt{correlationInfinite\_nonneg}]
+強磁性下で $\langle \sigma^A \rangle_V^{\mathrm{FM}} \ge 0$.
+\end{theorem}
+
+\begin{proof}
+$\Lambda.\text{exhaust}$ で $A \subseteq \Lambda.\text{volume}\,N$
+を取り, GKS-I で $\texttt{correlationAlongExhaustion}\,N \ge 0$.
+単調増加列の sup も $\ge 0$.
+\end{proof}
+
+\begin{theorem}[\texttt{tendsto\_correlationΛ\_correlationInfinite\_of\_subset}]
+明示的 $N$ と $h_N : \forall n \ge N,\ A \subseteq \Lambda.\text{volume}\,n$
+を与えたとき,
+\[
+\text{Tendsto}\,\bigl(m \mapsto \texttt{correlationΛ}~G~\Lambda(m+N)~p~
+  (\texttt{liftFinset}~A~\ldots)\bigr)\,\text{atTop}\,
+  (\text{nhds}\,\langle \sigma^A \rangle_V^{\mathrm{FM}}).
+\]
+\end{theorem}
+
+\begin{proof}
+\texttt{tendsto\_add\_atTop\_nat} で \texttt{correlationAlongExhaustion}
+の shift 版が極限と一致. $n \ge N$ で \texttt{correlationAlongExhaustion}
+は dite の分岐を展開し \texttt{correlationΛ} に一致 (\texttt{Tendsto.congr}).
+\end{proof}
+
+\begin{theorem}[\texttt{tendsto\_correlationΛ\_correlationInfinite}]
+$\Lambda.\text{exhaust}$ を使った系:
+$\exists N, \exists h_N$ で上と同じ結論が得られる.
+\end{theorem}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Introduce `correlationInfinite` as `⨆ n, correlationAlongExhaustion G Λ p A n`, the formal thermodynamic-limit correlation function.
- Provide basic properties: nonnegativity (under `Ferromagnetic`), upper bound by 1, Tendsto of `correlationAlongExhaustion`, and Tendsto of the lifted `correlationΛ` sequence.
- Follow-up to PR #90 (`correlationAlongExhaustion_tendsto_ciSup` exposed `⨆`; this PR identifies the sup as the physical infinite-volume correlation using `Λ.exhaust`).

## Test plan

- [ ] `lake build` succeeds, zero linter warnings
- [ ] New `def` and theorems have doc comments (incl. private)
- [ ] `docs/index.md` + `tex/proof-guide.tex` updated
- [ ] `copilot -p` cross-check (substantive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)