### PR TITLE
feat: correlationInfinite ambient-subgraph monotonicity

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1071,5 +1071,49 @@ theorem correlationInfinite_indep_exhaustion
     exact correlationAlongExhaustion_le_correlationInfinite_of_other
       G Λ Λ' p hf A n
 
+/-! ## Ambient-subgraph monotonicity of infinite-volume correlation
+
+Finite-volume monotonicity in the ambient subgraph
+(`correlationΛ_monotone_ambient_subgraph`, PR #58) lifts to the
+thermodynamic-limit correlation: for ferromagnetic Ising on an
+ambient type `V` and exhaustion `Λ`, `G₁ ≤ G₂` implies
+`correlationInfinite G₁ Λ p A ≤ correlationInfinite G₂ Λ p A`. -/
+
+/-- **Ambient-subgraph monotonicity of `correlationAlongExhaustion`**:
+if `G₁ ≤ G₂` then the exhaustion sequence is pointwise monotone in
+the ambient subgraph. -/
+theorem correlationAlongExhaustion_monotone_ambient_subgraph
+    {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G₂ (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset V) (n : ℕ) :
+    correlationAlongExhaustion G₁ Λ p A n
+      ≤ correlationAlongExhaustion G₂ Λ p A n := by
+  by_cases hAn : A ⊆ Λ.volume n
+  · simp only [correlationAlongExhaustion, hAn, dite_true]
+    exact correlationΛ_monotone_ambient_subgraph h (Λ.volume n) p hf _
+  · simp only [correlationAlongExhaustion, hAn, dite_false]
+    exact le_refl 0
+
+/-- **Ambient-subgraph monotonicity of `correlationInfinite`**:
+if `G₁ ≤ G₂` then
+`correlationInfinite G₁ Λ p A ≤ correlationInfinite G₂ Λ p A`.
+
+Proof: pointwise monotonicity of the exhaustion sequence
+(`correlationAlongExhaustion_monotone_ambient_subgraph`) combined
+with `le_ciSup` and `ciSup_le`. -/
+theorem correlationInfinite_monotone_ambient_subgraph
+    {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G₂ (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset V) :
+    correlationInfinite G₁ Λ p A ≤ correlationInfinite G₂ Λ p A := by
+  refine ciSup_le ?_
+  intro n
+  exact (correlationAlongExhaustion_monotone_ambient_subgraph h Λ p hf A n).trans
+    (le_ciSup (correlationAlongExhaustion_bddAbove G₂ Λ p A) n)
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,6 +179,8 @@ ambient framework:
 | **`tendsto_correlationΛ_correlationInfinite`** | **Physical identification** (via `Λ.exhaust`): `correlationΛ G (Λ.volume (m+N)) p (lift A) → correlationInfinite` |
 | `correlationAlongExhaustion_le_correlationInfinite_of_other` | Sandwich: `correlationAlongExhaustion Λ' n ≤ correlationInfinite Λ` via `Λ.exhaust` on `Λ'.volume n` |
 | **`correlationInfinite_indep_exhaustion`** | **Exhaustion-independence**: `correlationInfinite G Λ p A = correlationInfinite G Λ' p A` |
+| `correlationAlongExhaustion_monotone_ambient_subgraph` | `G₁ ≤ G₂` ⇒ pointwise monotonicity of `correlationAlongExhaustion` in ambient subgraph |
+| **`correlationInfinite_monotone_ambient_subgraph`** | **Ambient-subgraph monotonicity at infinite volume**: `G₁ ≤ G₂` ⇒ `correlationInfinite G₁ Λ ≤ correlationInfinite G₂ Λ` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2354,4 +2354,27 @@ $\texttt{correlationInfinite}\,G\,\Lambda\,p\,A
 両向きに \texttt{ciSup\_le} と上の lemma.
 \end{proof}
 
+\subsection{Ambient-subgraph monotonicity at infinite volume}
+
+\begin{lemma}[\texttt{correlationAlongExhaustion\_monotone\_ambient\_subgraph}]
+$G_1 \le G_2$ のとき, 任意の $n$ で
+$\texttt{correlationAlongExhaustion}\,G_1\,\Lambda\,p\,A\,n
+  \le \texttt{correlationAlongExhaustion}\,G_2\,\Lambda\,p\,A\,n$.
+\end{lemma}
+
+\begin{proof}
+$A \subseteq \Lambda.\text{volume}\,n$ のとき
+\texttt{correlationΛ\_monotone\_ambient\_subgraph} 適用; それ以外は両辺 $0$.
+\end{proof}
+
+\begin{theorem}[\texttt{correlationInfinite\_monotone\_ambient\_subgraph}]
+$G_1 \le G_2$ のとき
+$\texttt{correlationInfinite}\,G_1\,\Lambda\,p\,A
+  \le \texttt{correlationInfinite}\,G_2\,\Lambda\,p\,A$.
+\end{theorem}
+
+\begin{proof}
+Lemma + \texttt{le\_ciSup} + \texttt{ciSup\_le}.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Prove \`G₁ ≤ G₂ → correlationInfinite G₁ Λ p A ≤ correlationInfinite G₂ Λ p A\`.
- Lift of finite-volume \`correlationΛ_monotone_ambient_subgraph\` via pointwise monotonicity of the exhaustion sequence and \`ciSup_le\`.
- Follows PR #92 (exhaustion independence) in the Glimm-Jaffe §4.2 infinite-volume series.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot -p\` substantive cross-check
- [ ] Refactor scan (duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)