### PR TITLE
feat: correlationInfinite h-direction monotonicity

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1254,5 +1254,66 @@ theorem correlationInfinite_gks_second
     rw [correlationAlongExhaustion_of_not_subset G Λ p hAn, zero_mul]
     exact correlationAlongExhaustion_nonneg G Λ p hf (A ∆ B) n
 
+/-! ## h-direction monotonicity at infinite volume
+
+Lift `IsingModel.correlation_monotone_h` (finite volume, external
+field direction) to the thermodynamic limit.  For fixed `J ≥ 0`,
+`β > 0`, the map `h ↦ correlationInfinite G Λ ⟨J, h, β⟩ A` is
+monotone on `Set.Ici 0`.
+
+Reference: Glimm–Jaffe, Proposition 4.2.4. -/
+
+/-- **h-direction monotonicity of `correlationΛ`**: for fixed
+`J ≥ 0`, `β > 0`, the correlation on `Λ : Finset V` is monotone in
+the external field `h ∈ Set.Ici 0`. -/
+theorem correlationΛ_monotone_h
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    (A : Finset (↑Λ : Type _)) :
+    MonotoneOn
+      (fun h : ℝ => correlationΛ G Λ ⟨J, h, β⟩ A)
+      (Set.Ici 0) :=
+  IsingModel.correlation_monotone_h (inducedGraph G Λ) J hJ β hβ A
+
+/-- **h-direction monotonicity of `correlationAlongExhaustion`**:
+pointwise on the exhaustion sequence.  For `0 ≤ h₁ ≤ h₂`,
+`correlationAlongExhaustion G Λ ⟨J, h₁, β⟩ A n
+  ≤ correlationAlongExhaustion G Λ ⟨J, h₂, β⟩ A n`
+for every `n`. -/
+theorem correlationAlongExhaustion_monotone_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    (A : Finset V) {h₁ h₂ : ℝ}
+    (hh₁ : 0 ≤ h₁) (hh₁₂ : h₁ ≤ h₂) (n : ℕ) :
+    correlationAlongExhaustion G Λ ⟨J, h₁, β⟩ A n
+      ≤ correlationAlongExhaustion G Λ ⟨J, h₂, β⟩ A n := by
+  by_cases hAn : A ⊆ Λ.volume n
+  · rw [correlationAlongExhaustion_of_subset G Λ ⟨J, h₁, β⟩ hAn,
+        correlationAlongExhaustion_of_subset G Λ ⟨J, h₂, β⟩ hAn]
+    exact correlationΛ_monotone_h G (Λ.volume n) hJ hβ _ hh₁ (hh₁.trans hh₁₂) hh₁₂
+  · rw [correlationAlongExhaustion_of_not_subset G Λ ⟨J, h₁, β⟩ hAn,
+        correlationAlongExhaustion_of_not_subset G Λ ⟨J, h₂, β⟩ hAn]
+
+/-- **h-direction monotonicity of `correlationInfinite`**: for fixed
+`J ≥ 0`, `β > 0`, the thermodynamic-limit correlation is monotone in
+the external field `h ∈ Set.Ici 0`.
+
+Glimm–Jaffe, Proposition 4.2.4 at infinite volume. -/
+theorem correlationInfinite_monotone_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    (A : Finset V) :
+    MonotoneOn
+      (fun h : ℝ => correlationInfinite G Λ ⟨J, h, β⟩ A)
+      (Set.Ici 0) := by
+  intro h₁ hh₁ h₂ _ hh₁₂
+  refine ciSup_le ?_
+  intro n
+  exact (correlationAlongExhaustion_monotone_h G Λ hJ hβ A hh₁ hh₁₂ n).trans
+    (le_ciSup (correlationAlongExhaustion_bddAbove G Λ ⟨J, h₂, β⟩ A) n)
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -188,6 +188,9 @@ ambient framework:
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |
+| `correlationΛ_monotone_h` | `MonotoneOn (h ↦ correlationΛ G Λ ⟨J, h, β⟩ A) (Ici 0)` |
+| `correlationAlongExhaustion_monotone_h` | Pointwise h-monotonicity of the exhaustion sequence |
+| **`correlationInfinite_monotone_h`** | **h-direction monotonicity at infinite volume** (Glimm–Jaffe Prop 4.2.4): `MonotoneOn (h ↦ correlationInfinite G Λ ⟨J, h, β⟩ A) (Ici 0)` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2422,4 +2422,35 @@ LHS $= 0 \le$ RHS (\texttt{correlationAlongExhaustion\_nonneg})
 で点毎不等式が成立. \texttt{le\_of\_tendsto\_of\_tendsto'} で結論.
 \end{proof}
 
+\subsection{h-direction monotonicity at infinite volume}
+
+Glimm--Jaffe Proposition 4.2.4 の無限体積版.
+
+\begin{lemma}[\texttt{correlationΛ\_monotone\_h}]
+$J \ge 0$, $\beta > 0$, $\Lambda \subseteq V$ finite で
+$\texttt{MonotoneOn}\,(h \mapsto \texttt{correlationΛ}\,G\,\Lambda\,\langle J,h,\beta\rangle\,A)\,(\mathrm{Ici}\,0)$.
+\end{lemma}
+
+\begin{proof}
+\texttt{correlation\_monotone\_h} を \texttt{inducedGraph}\,$G\,\Lambda$ に直接適用.
+\end{proof}
+
+\begin{lemma}[\texttt{correlationAlongExhaustion\_monotone\_h}]
+$0 \le h_1 \le h_2$ ならば任意の $n$ で
+$\texttt{correlationAlongExhaustion}\,G\,\Lambda\,\langle J,h_1,\beta\rangle\,A\,n
+  \le \texttt{correlationAlongExhaustion}\,G\,\Lambda\,\langle J,h_2,\beta\rangle\,A\,n$.
+\end{lemma}
+
+\begin{proof}
+$A \subseteq \Lambda.\text{volume}\,n$ で上 Lemma を適用; それ以外は両辺 $0$.
+\end{proof}
+
+\begin{theorem}[\texttt{correlationInfinite\_monotone\_h}]
+$\texttt{MonotoneOn}\,(h \mapsto \texttt{correlationInfinite}\,G\,\Lambda\,\langle J,h,\beta\rangle\,A)\,(\mathrm{Ici}\,0)$.
+\end{theorem}
+
+\begin{proof}
+点毎 $\le$ と \texttt{ciSup\_le}, \texttt{le\_ciSup}.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Lift finite-volume \`correlation_monotone_h\` to the thermodynamic limit:
  \`MonotoneOn (fun h => correlationInfinite G Λ ⟨J, h, β⟩ A) (Set.Ici 0)\`
  for \`0 ≤ J, 0 < β\`.
- Glimm-Jaffe §4.2 Proposition 4.2.4 at infinite volume.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)