### PR TITLE
feat: correlationInfinite β-direction monotonicity

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1315,5 +1315,67 @@ theorem correlationInfinite_monotone_h
   exact (correlationAlongExhaustion_monotone_h G Λ hJ hβ A hh₁ hh₁₂ n).trans
     (le_ciSup (correlationAlongExhaustion_bddAbove G Λ ⟨J, h₂, β⟩ A) n)
 
+/-! ## β-direction monotonicity at infinite volume
+
+Lift `IsingModel.correlation_monotone_beta` (inverse-temperature
+direction) to the thermodynamic limit.  For fixed `J ≥ 0`, `h ≥ 0`,
+the map `β ↦ correlationInfinite G Λ ⟨J, h, β⟩ A` is monotone on
+`Set.Ioi 0`.
+
+Reference: Glimm–Jaffe, Proposition 4.2.4 (β-direction). -/
+
+/-- **β-direction monotonicity of `correlationΛ`**: for fixed
+`J ≥ 0`, `h ≥ 0`, the correlation on `Λ : Finset V` is monotone in
+the inverse temperature `β ∈ Set.Ioi 0`. -/
+theorem correlationΛ_monotone_beta
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {h : ℝ} (hh : 0 ≤ h)
+    (A : Finset (↑Λ : Type _)) :
+    MonotoneOn
+      (fun β : ℝ => correlationΛ G Λ ⟨J, h, β⟩ A)
+      (Set.Ioi 0) :=
+  IsingModel.correlation_monotone_beta (inducedGraph G Λ) J hJ h hh A
+
+/-- **β-direction monotonicity of `correlationAlongExhaustion`**:
+pointwise on the exhaustion sequence.  For `0 < β₁ ≤ β₂`,
+`correlationAlongExhaustion G Λ ⟨J, h, β₁⟩ A n
+  ≤ correlationAlongExhaustion G Λ ⟨J, h, β₂⟩ A n`
+for every `n`. -/
+theorem correlationAlongExhaustion_monotone_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {h : ℝ} (hh : 0 ≤ h)
+    (A : Finset V) {β₁ β₂ : ℝ}
+    (hβ₁ : 0 < β₁) (hβ₁₂ : β₁ ≤ β₂) (n : ℕ) :
+    correlationAlongExhaustion G Λ ⟨J, h, β₁⟩ A n
+      ≤ correlationAlongExhaustion G Λ ⟨J, h, β₂⟩ A n := by
+  by_cases hAn : A ⊆ Λ.volume n
+  · rw [correlationAlongExhaustion_of_subset G Λ ⟨J, h, β₁⟩ hAn,
+        correlationAlongExhaustion_of_subset G Λ ⟨J, h, β₂⟩ hAn]
+    exact correlationΛ_monotone_beta G (Λ.volume n) hJ hh _ hβ₁
+      (lt_of_lt_of_le hβ₁ hβ₁₂) hβ₁₂
+  · rw [correlationAlongExhaustion_of_not_subset G Λ ⟨J, h, β₁⟩ hAn,
+        correlationAlongExhaustion_of_not_subset G Λ ⟨J, h, β₂⟩ hAn]
+
+/-- **β-direction monotonicity of `correlationInfinite`**: for fixed
+`J ≥ 0`, `h ≥ 0`, the thermodynamic-limit correlation is monotone in
+the inverse temperature `β ∈ Set.Ioi 0`.
+
+Glimm–Jaffe, Proposition 4.2.4 at infinite volume (β-direction). -/
+theorem correlationInfinite_monotone_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {h : ℝ} (hh : 0 ≤ h)
+    (A : Finset V) :
+    MonotoneOn
+      (fun β : ℝ => correlationInfinite G Λ ⟨J, h, β⟩ A)
+      (Set.Ioi 0) := by
+  intro β₁ hβ₁ β₂ _ hβ₁₂
+  refine ciSup_le ?_
+  intro n
+  exact (correlationAlongExhaustion_monotone_beta G Λ hJ hh A hβ₁ hβ₁₂ n).trans
+    (le_ciSup (correlationAlongExhaustion_bddAbove G Λ ⟨J, h, β₂⟩ A) n)
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -191,6 +191,9 @@ ambient framework:
 | `correlationΛ_monotone_h` | `MonotoneOn (h ↦ correlationΛ G Λ ⟨J, h, β⟩ A) (Ici 0)` |
 | `correlationAlongExhaustion_monotone_h` | Pointwise h-monotonicity of the exhaustion sequence |
 | **`correlationInfinite_monotone_h`** | **h-direction monotonicity at infinite volume** (Glimm–Jaffe Prop 4.2.4): `MonotoneOn (h ↦ correlationInfinite G Λ ⟨J, h, β⟩ A) (Ici 0)` |
+| `correlationΛ_monotone_beta` | `MonotoneOn (β ↦ correlationΛ G Λ ⟨J, h, β⟩ A) (Ioi 0)` |
+| `correlationAlongExhaustion_monotone_beta` | Pointwise β-monotonicity of the exhaustion sequence |
+| **`correlationInfinite_monotone_beta`** | **β-direction monotonicity at infinite volume** (Glimm–Jaffe Prop 4.2.4): `MonotoneOn (β ↦ correlationInfinite G Λ ⟨J, h, β⟩ A) (Ioi 0)` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2274,6 +2274,10 @@ This completes the genuine infinite-volume convergence on the
 
 \subsection{Infinite-volume correlation function}
 
+参考: Glimm--Jaffe \textit{Quantum Physics} 2nd ed.\ (1987),
+\S 4.2 Theorem 4.2.3, pp.\ 58--59 (ferromagnetic Ising の熱力学極限相関).
+Friedli--Velenik \S 3.2.
+
 \begin{definition}[\texttt{correlationInfinite}]
 \[
 \langle \sigma^A \rangle_V^{\mathrm{FM}} \;:=\;
@@ -2327,6 +2331,9 @@ $\exists N, \exists h_N$ で上と同じ結論が得られる.
 
 \subsection{Exhaustion-independence}
 
+参考: Glimm--Jaffe \S 4.2, pp.\ 58--59 (無限体積極限は exhaustion の
+選び方に依存しない). Friedli--Velenik \S 3.2 (Infinite-volume Gibbs states).
+
 \begin{lemma}[\texttt{correlationAlongExhaustion\_le\_correlationInfinite\_of\_other}]
 2 つの exhaustion $\Lambda, \Lambda'$ に対し任意の $n$ で
 \[
@@ -2356,6 +2363,9 @@ $\texttt{correlationInfinite}\,G\,\Lambda\,p\,A
 
 \subsection{Ambient-subgraph monotonicity at infinite volume}
 
+参考: Glimm--Jaffe \S 4.2, pp.\ 58--59 (熱力学極限は有限体積の
+monotonicity を保持する). Friedli--Velenik \S 3.6.
+
 \begin{lemma}[\texttt{correlationAlongExhaustion\_monotone\_ambient\_subgraph}]
 $G_1 \le G_2$ のとき, 任意の $n$ で
 $\texttt{correlationAlongExhaustion}\,G_1\,\Lambda\,p\,A\,n
@@ -2379,8 +2389,11 @@ Lemma + \texttt{le\_ciSup} + \texttt{ciSup\_le}.
 
 \subsection{GKS-II at infinite volume}
 
-Glimm--Jaffe \S 4.2 Theorem 4.2.3: the second Griffiths inequality
-holds in the thermodynamic limit.
+Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987),
+\S 4.2 Theorem 4.2.3, pp.\ 58--59: the second Griffiths inequality
+holds in the thermodynamic limit. 有限体積版は Friedli--Velenik
+\textit{Statistical Mechanics of Lattice Systems}, Theorem 3.49
+(eq.~3.55), pp.\ 127--128.
 
 \begin{lemma}[\texttt{liftFinset\_symmDiff}]
 $A, B \subseteq \Lambda$ のとき
@@ -2424,7 +2437,8 @@ LHS $= 0 \le$ RHS (\texttt{correlationAlongExhaustion\_nonneg})
 
 \subsection{h-direction monotonicity at infinite volume}
 
-Glimm--Jaffe Proposition 4.2.4 の無限体積版.
+Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987), \S 4.2
+Proposition 4.2.4 (Exercise), p.\ 58 の h-方向無限体積版.
 
 \begin{lemma}[\texttt{correlationΛ\_monotone\_h}]
 $J \ge 0$, $\beta > 0$, $\Lambda \subseteq V$ finite で
@@ -2455,7 +2469,8 @@ $\texttt{MonotoneOn}\,(h \mapsto \texttt{correlationInfinite}\,G\,\Lambda\,\lang
 
 \subsection{β-direction monotonicity at infinite volume}
 
-Glimm--Jaffe Proposition 4.2.4 の β-方向.
+Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987), \S 4.2
+Proposition 4.2.4 (Exercise), p.\ 58 の β-方向無限体積版.
 
 \begin{lemma}[\texttt{correlationΛ\_monotone\_beta}]
 $J \ge 0, h \ge 0$ で

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2453,4 +2453,33 @@ $\texttt{MonotoneOn}\,(h \mapsto \texttt{correlationInfinite}\,G\,\Lambda\,\lang
 点毎 $\le$ と \texttt{ciSup\_le}, \texttt{le\_ciSup}.
 \end{proof}
 
+\subsection{β-direction monotonicity at infinite volume}
+
+Glimm--Jaffe Proposition 4.2.4 の β-方向.
+
+\begin{lemma}[\texttt{correlationΛ\_monotone\_beta}]
+$J \ge 0, h \ge 0$ で
+$\texttt{MonotoneOn}\,(\beta \mapsto \texttt{correlationΛ}\,G\,\Lambda\,\langle J,h,\beta\rangle\,A)\,(\mathrm{Ioi}\,0)$.
+\end{lemma}
+
+\begin{proof}
+\texttt{correlation\_monotone\_beta} を \texttt{inducedGraph}\,$G\,\Lambda$ に適用.
+\end{proof}
+
+\begin{lemma}[\texttt{correlationAlongExhaustion\_monotone\_beta}]
+$0 < \beta_1 \le \beta_2$ で任意の $n$ で pointwise monotone.
+\end{lemma}
+
+\begin{proof}
+case split + correlationΛ\_monotone\_beta; それ以外は両辺 $0$.
+\end{proof}
+
+\begin{theorem}[\texttt{correlationInfinite\_monotone\_beta}]
+$\texttt{MonotoneOn}\,(\beta \mapsto \texttt{correlationInfinite}\,G\,\Lambda\,\langle J,h,\beta\rangle\,A)\,(\mathrm{Ioi}\,0)$.
+\end{theorem}
+
+\begin{proof}
+点毎 $\le$ + \texttt{ciSup\_le}, \texttt{le\_ciSup}.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Lift finite-volume \`correlation_monotone_beta\` to the thermodynamic limit:
  \`MonotoneOn (fun β => correlationInfinite G Λ ⟨J, h, β⟩ A) (Set.Ioi 0)\`
  for \`0 ≤ J, 0 ≤ h\`.
- Glimm-Jaffe §4.2 Proposition 4.2.4 at infinite volume, β-direction companion to PR #95.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)