### PR TITLE
feat: correlationInfinite J-direction monotonicity

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1377,5 +1377,66 @@ theorem correlationInfinite_monotone_beta
   exact (correlationAlongExhaustion_monotone_beta G Λ hJ hh A hβ₁ hβ₁₂ n).trans
     (le_ciSup (correlationAlongExhaustion_bddAbove G Λ ⟨J, h, β₂⟩ A) n)
 
+/-! ## J-direction monotonicity at infinite volume
+
+Lift `IsingModel.correlation_monotone_J` (coupling-constant
+direction) to the thermodynamic limit.  For fixed `h ≥ 0`, `β > 0`,
+the map `J ↦ correlationInfinite G Λ ⟨J, h, β⟩ A` is monotone on
+`Set.Ici 0`.
+
+Reference: Glimm–Jaffe, Proposition 4.2.4, p. 58 (J-direction). -/
+
+/-- **J-direction monotonicity of `correlationΛ`**: for fixed
+`h ≥ 0`, `β > 0`, the correlation on `Λ : Finset V` is monotone in
+the coupling constant `J ∈ Set.Ici 0`. -/
+theorem correlationΛ_monotone_J
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β)
+    (A : Finset (↑Λ : Type _)) :
+    MonotoneOn
+      (fun J : ℝ => correlationΛ G Λ ⟨J, h, β⟩ A)
+      (Set.Ici 0) :=
+  IsingModel.correlation_monotone_J (inducedGraph G Λ) h hh β hβ A
+
+/-- **J-direction monotonicity of `correlationAlongExhaustion`**:
+pointwise on the exhaustion sequence.  For `0 ≤ J₁ ≤ J₂`,
+`correlationAlongExhaustion G Λ ⟨J₁, h, β⟩ A n
+  ≤ correlationAlongExhaustion G Λ ⟨J₂, h, β⟩ A n`
+for every `n`. -/
+theorem correlationAlongExhaustion_monotone_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β)
+    (A : Finset V) {J₁ J₂ : ℝ}
+    (hJ₁ : 0 ≤ J₁) (hJ₁₂ : J₁ ≤ J₂) (n : ℕ) :
+    correlationAlongExhaustion G Λ ⟨J₁, h, β⟩ A n
+      ≤ correlationAlongExhaustion G Λ ⟨J₂, h, β⟩ A n := by
+  by_cases hAn : A ⊆ Λ.volume n
+  · rw [correlationAlongExhaustion_of_subset G Λ ⟨J₁, h, β⟩ hAn,
+        correlationAlongExhaustion_of_subset G Λ ⟨J₂, h, β⟩ hAn]
+    exact correlationΛ_monotone_J G (Λ.volume n) hh hβ _ hJ₁ (hJ₁.trans hJ₁₂) hJ₁₂
+  · rw [correlationAlongExhaustion_of_not_subset G Λ ⟨J₁, h, β⟩ hAn,
+        correlationAlongExhaustion_of_not_subset G Λ ⟨J₂, h, β⟩ hAn]
+
+/-- **J-direction monotonicity of `correlationInfinite`**: for fixed
+`h ≥ 0`, `β > 0`, the thermodynamic-limit correlation is monotone in
+the coupling constant `J ∈ Set.Ici 0`.
+
+Glimm–Jaffe, Proposition 4.2.4 at infinite volume (J-direction). -/
+theorem correlationInfinite_monotone_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β)
+    (A : Finset V) :
+    MonotoneOn
+      (fun J : ℝ => correlationInfinite G Λ ⟨J, h, β⟩ A)
+      (Set.Ici 0) := by
+  intro J₁ hJ₁ J₂ _ hJ₁₂
+  refine ciSup_le ?_
+  intro n
+  exact (correlationAlongExhaustion_monotone_J G Λ hh hβ A hJ₁ hJ₁₂ n).trans
+    (le_ciSup (correlationAlongExhaustion_bddAbove G Λ ⟨J₂, h, β⟩ A) n)
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,11 +40,13 @@ specifies which of the three above apply.
 | **GKS-I** (Thm 4.1.1) | `⟨σ^A⟩ ≥ 0` for ferromagnetic `p` | `Inequalities/GKS.lean` | Finite |
 | **GKS-II** (Thm 4.1.1) | `⟨σ^A σ^B⟩ ≥ ⟨σ^A⟩⟨σ^B⟩` | `Inequalities/GKS.lean` | Finite |
 | **FKG** (§4.4) | `⟨fg⟩ ≥ ⟨f⟩⟨g⟩` for `f, g` monotone | `Inequalities/FKG.lean` | Finite |
-| **Boundedness** (Prop 4.2.2) | `|⟨σ^A⟩| ≤ 1` | `InfiniteVolume.lean` | Finite |
-| **J-monotonicity** (Prop 4.2.1) | `⟨σ^A⟩` monotone in `J ≥ 0` | `InfiniteVolume.lean` | Finite |
-| **h-monotonicity** (Prop 4.2.4) | `⟨σ^A⟩` monotone in `h ≥ 0` | `InfiniteVolume.lean` | Finite |
-| **β-monotonicity** | `⟨σ^A⟩` monotone in `β > 0` | `InfiniteVolume.lean` | Finite |
-| **Subgraph monotonicity** | `G₁ ≤ G₂ ⇒ ⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` | `InfiniteVolume.lean` | Discretized Λ↑ |
+| **Boundedness** (Prop 4.2.2) | `|⟨σ^A⟩| ≤ 1` | `InfiniteVolume.lean` / `AmbientLattice.lean` | Finite + genuine ∞-vol |
+| **J-monotonicity** (Prop 4.2.1) | `⟨σ^A⟩` monotone in `J ≥ 0` | `InfiniteVolume.lean` / `AmbientLattice.lean` | Finite + genuine ∞-vol |
+| **h-monotonicity** (Prop 4.2.4) | `⟨σ^A⟩` monotone in `h ≥ 0` | `InfiniteVolume.lean` / `AmbientLattice.lean` | Finite + genuine ∞-vol |
+| **β-monotonicity** | `⟨σ^A⟩` monotone in `β > 0` | `InfiniteVolume.lean` / `AmbientLattice.lean` | Finite + genuine ∞-vol |
+| **Subgraph monotonicity** | `G₁ ≤ G₂ ⇒ ⟨σ^A⟩_{G₁} ≤ ⟨σ^A⟩_{G₂}` | `InfiniteVolume.lean` / `AmbientLattice.lean` | Finite + Discretized Λ↑ + genuine ∞-vol |
+| **GKS-II at ∞-vol** (Thm 4.2.3) | `⟨σ^A⟩ · ⟨σ^B⟩ ≤ ⟨σ^{A∆B}⟩` | `AmbientLattice.lean` | Genuine ∞-vol (ferromagnetic) |
+| **Exhaustion-independence** | `correlationInfinite G Λ = correlationInfinite G Λ'` | `AmbientLattice.lean` | Genuine ∞-vol |
 | **Lee–Yang circle theorem** (§4.5) | Ising partition polynomial nonvanishing on polydisk | `LeeYang.lean` | Finite |
 | **Lee–Yang (graph form)** | Z ≠ 0 on polydisk for ferromagnetic graph | `FreeEnergy.lean` | Finite |
 | **φ⁴ Lebowitz** (Cor 4.3.2) | `lebowitz_third/four/inductive` | `Inequalities/GHS.lean` | Finite, axiom |
@@ -63,7 +65,7 @@ Formalized in three regimes:
 | `correlation_convergent_h` | `⟨σ^A⟩_{(J,n,β)}` converges as `h = n → ∞` | `InfiniteVolume.lean` | Finite |
 | `correlation_convergent_beta` | `⟨σ^A⟩_{(J,h,n+1)}` converges as `β = n+1 → ∞` | `InfiniteVolume.lean` | Finite |
 | `correlation_convergent_subgraph` | `⟨σ^A⟩_{Gₙ}` converges for `Gₙ ↑` | `InfiniteVolume.lean` | Discretized Λ↑ |
-| `Ambient.correlationAlongExhaustion` | correlation along an exhaustion `Λₙ ↑ V` | `AmbientLattice.lean` | Genuine ∞-vol (framework) |
+| `Ambient.correlationInfinite` | `correlationInfinite := ⨆ n, correlationAlongExhaustion G Λ p A n` | `AmbientLattice.lean` | **Genuine ∞-vol (full)**: convergence, Λ-independence, GKS-I/II, J/h/β monotonicity |
 
 Named specializations at `A = {i}`:
 `magnetization_convergent_{J,h,beta,subgraph}`.
@@ -229,10 +231,10 @@ inventory (2026-04-17).
 | Section | Result | Status | Notes |
 |---|---|---|---|
 | §4.1 | Thm 4.1.1 GKS-I/II | **Done** | `gks_first`, `gks_second` |
-| §4.2 | Prop 4.2.1 (J-monotonicity) | **Done** | Finite |
-| §4.2 | Prop 4.2.2 (boundedness) | **Done** | Finite |
-| §4.2 | **Thm 4.2.3 (thermodynamic limit)** | **Done (discretized)** | Fixed finite ambient + subgraph |
-| §4.2 | Prop 4.2.4 (h-monotonicity) | **Done** | Finite |
+| §4.2 | Prop 4.2.1 (J-monotonicity) | **Done (finite + infinite)** | Finite: `correlation_monotone_J`; Infinite: `correlationInfinite_monotone_J` |
+| §4.2 | Prop 4.2.2 (boundedness) | **Done (finite + infinite)** | Finite: `abs_correlation_le_one`; Infinite: `correlationInfinite_le_one` |
+| §4.2 | **Thm 4.2.3 (thermodynamic limit)** | **Done (genuine ∞-vol)** | `correlationInfinite_gks_second` (GKS-II), `correlationInfinite_indep_exhaustion`, ambient-subgraph monotonicity |
+| §4.2 | Prop 4.2.4 (h-monotonicity) | **Done (finite + infinite)** | Three parameters: `correlationInfinite_monotone_{J,h,beta}` |
 | §4.3 | Thm 4.3.1 (φ⁴) | **Done (axiom)** | `phi4_single_site_nonneg` |
 | §4.3 | Cor 4.3.2 (Lebowitz) | **Done (axiom)** | 3 axioms |
 | §4.3 | Cor 4.3.3, 4.3.4, 4.3.5 | **Done** | Uses axioms |

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,6 +194,9 @@ ambient framework:
 | `correlationΛ_monotone_beta` | `MonotoneOn (β ↦ correlationΛ G Λ ⟨J, h, β⟩ A) (Ioi 0)` |
 | `correlationAlongExhaustion_monotone_beta` | Pointwise β-monotonicity of the exhaustion sequence |
 | **`correlationInfinite_monotone_beta`** | **β-direction monotonicity at infinite volume** (Glimm–Jaffe Prop 4.2.4): `MonotoneOn (β ↦ correlationInfinite G Λ ⟨J, h, β⟩ A) (Ioi 0)` |
+| `correlationΛ_monotone_J` | `MonotoneOn (J ↦ correlationΛ G Λ ⟨J, h, β⟩ A) (Ici 0)` |
+| `correlationAlongExhaustion_monotone_J` | Pointwise J-monotonicity of the exhaustion sequence |
+| **`correlationInfinite_monotone_J`** | **J-direction monotonicity at infinite volume** (Glimm–Jaffe Prop 4.2.4): `MonotoneOn (J ↦ correlationInfinite G Λ ⟨J, h, β⟩ A) (Ici 0)` — three-parameter symmetry complete |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2497,4 +2497,35 @@ $\texttt{MonotoneOn}\,(\beta \mapsto \texttt{correlationInfinite}\,G\,\Lambda\,\
 点毎 $\le$ + \texttt{ciSup\_le}, \texttt{le\_ciSup}.
 \end{proof}
 
+\subsection{J-direction monotonicity at infinite volume}
+
+Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987), \S 4.2
+Proposition 4.2.4 (Exercise), p.\ 58 の J-方向無限体積版.
+三パラメータ (J, h, $\beta$) monotonicity の対称性完成.
+
+\begin{lemma}[\texttt{correlationΛ\_monotone\_J}]
+$h \ge 0, \beta > 0$ で
+$\texttt{MonotoneOn}\,(J \mapsto \texttt{correlationΛ}\,G\,\Lambda\,\langle J,h,\beta\rangle\,A)\,(\mathrm{Ici}\,0)$.
+\end{lemma}
+
+\begin{proof}
+\texttt{correlation\_monotone\_J} を \texttt{inducedGraph}\,$G\,\Lambda$ に適用.
+\end{proof}
+
+\begin{lemma}[\texttt{correlationAlongExhaustion\_monotone\_J}]
+$0 \le J_1 \le J_2$ で任意の $n$ に pointwise monotone.
+\end{lemma}
+
+\begin{proof}
+case split + correlationΛ\_monotone\_J; それ以外は両辺 $0$.
+\end{proof}
+
+\begin{theorem}[\texttt{correlationInfinite\_monotone\_J}]
+$\texttt{MonotoneOn}\,(J \mapsto \texttt{correlationInfinite}\,G\,\Lambda\,\langle J,h,\beta\rangle\,A)\,(\mathrm{Ici}\,0)$.
+\end{theorem}
+
+\begin{proof}
+点毎 $\le$ + \texttt{ciSup\_le}, \texttt{le\_ciSup}.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Lift finite-volume \`correlation_monotone_J\` to the thermodynamic limit:
  \`MonotoneOn (fun J => correlationInfinite G Λ ⟨J, h, β⟩ A) (Set.Ici 0)\`
  for \`0 ≤ h, 0 < β\`.
- Glimm-Jaffe §4.2 Proposition 4.2.4, p. 58 — J-direction companion to PR #95 (h) and PR #96 (β), completing the three-parameter symmetry.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated (with page numbers)
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)