### PR TITLE
feat: infinite-volume single-site magnetization

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1,5 +1,6 @@
 import IsingModel.InfiniteVolume
 import IsingModel.FreeEnergy
+import IsingModel.Inequalities.GHS
 
 /-!
 # Genuine infinite-volume framework: ambient lattice
@@ -1437,6 +1438,156 @@ theorem correlationInfinite_monotone_J
   intro n
   exact (correlationAlongExhaustion_monotone_J G Λ hh hβ A hJ₁ hJ₁₂ n).trans
     (le_ciSup (correlationAlongExhaustion_bddAbove G Λ ⟨J₂, h, β⟩ A) n)
+
+/-! ## Infinite-volume single-site magnetization
+
+Specialize `correlationInfinite` to single sites `A = {i}` to obtain
+the formal thermodynamic-limit magnetization `magnetizationInfinite`.
+All basic properties follow directly from the general
+`correlationInfinite` API (PR #91–#97).
+
+Reference: Glimm–Jaffe §4.2 (pp. 57ff) / §5.1 (p. 77, $m^* := \lim_{h \to 0^+} M$). -/
+
+/-- **Infinite-volume single-site magnetization**: for a ferromagnetic
+Ising model on an ambient type `V`, exhaustion `Λ`, and site `i : V`,
+`magnetizationInfinite G Λ p i := correlationInfinite G Λ p {i}`.
+
+This is the formal thermodynamic-limit magnetization
+$\langle \sigma_i \rangle_\infty^{\mathrm{FM}}$. -/
+noncomputable def magnetizationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i : V) : ℝ :=
+  correlationInfinite G Λ p {i}
+
+/-- **Nonnegativity of `magnetizationInfinite`** (ferromagnetic):
+`0 ≤ magnetizationInfinite G Λ p i`.  Specialization of
+`correlationInfinite_nonneg` at `A = {i}`. -/
+theorem magnetizationInfinite_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : V) :
+    0 ≤ magnetizationInfinite G Λ p i :=
+  correlationInfinite_nonneg G Λ p hf {i}
+
+/-- **Upper bound**: `magnetizationInfinite G Λ p i ≤ 1`. Specialization
+of `correlationInfinite_le_one`. -/
+theorem magnetizationInfinite_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i : V) :
+    magnetizationInfinite G Λ p i ≤ 1 :=
+  correlationInfinite_le_one G Λ p {i}
+
+/-- **Exhaustion-independence of `magnetizationInfinite`**:
+the value does not depend on the choice of exhaustion.  Specialization
+of `correlationInfinite_indep_exhaustion`. -/
+theorem magnetizationInfinite_indep_exhaustion
+    (G : SimpleGraph V) (Λ Λ' : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G (Λ'.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : V) :
+    magnetizationInfinite G Λ p i = magnetizationInfinite G Λ' p i :=
+  correlationInfinite_indep_exhaustion G Λ Λ' p hf {i}
+
+/-- **J-direction monotonicity of `magnetizationInfinite`** (for
+fixed `h ≥ 0, β > 0`).  Specialization of
+`correlationInfinite_monotone_J`. -/
+theorem magnetizationInfinite_monotone_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β)
+    (i : V) :
+    MonotoneOn
+      (fun J : ℝ => magnetizationInfinite G Λ ⟨J, h, β⟩ i)
+      (Set.Ici 0) :=
+  correlationInfinite_monotone_J G Λ hh hβ {i}
+
+/-- **h-direction monotonicity of `magnetizationInfinite`** (for
+fixed `J ≥ 0, β > 0`).  Specialization of
+`correlationInfinite_monotone_h`. -/
+theorem magnetizationInfinite_monotone_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    (i : V) :
+    MonotoneOn
+      (fun h : ℝ => magnetizationInfinite G Λ ⟨J, h, β⟩ i)
+      (Set.Ici 0) :=
+  correlationInfinite_monotone_h G Λ hJ hβ {i}
+
+/-- **β-direction monotonicity of `magnetizationInfinite`** (for
+fixed `J ≥ 0, h ≥ 0`).  Specialization of
+`correlationInfinite_monotone_beta`. -/
+theorem magnetizationInfinite_monotone_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {h : ℝ} (hh : 0 ≤ h)
+    (i : V) :
+    MonotoneOn
+      (fun β : ℝ => magnetizationInfinite G Λ ⟨J, h, β⟩ i)
+      (Set.Ioi 0) :=
+  correlationInfinite_monotone_beta G Λ hJ hh {i}
+
+/-- **Z₂ symmetry at `h = 0` for `correlationΛ`**: at vanishing external
+field, the correlation on `Λ` of an odd-cardinality set is zero.
+Lift of `IsingModel.correlation_odd_vanish` (GHS.lean). -/
+theorem correlationΛ_odd_vanish_h_zero
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (J β : ℝ) (A : Finset (↑Λ : Type _)) (hodd : Odd A.card) :
+    correlationΛ G Λ ⟨J, 0, β⟩ A = 0 :=
+  IsingModel.correlation_odd_vanish (inducedGraph G Λ) J β A hodd
+
+/-- **Z₂ symmetry at `h = 0` for `correlationAlongExhaustion`**:
+pointwise zero at every `n`.  Either `A ⊄ Λ.volume n` (both branches
+of the dite give `0`) or `A ⊆ Λ.volume n` and the lifted correlation
+vanishes by `correlationΛ_odd_vanish_h_zero`. -/
+theorem correlationAlongExhaustion_h_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (A : Finset V) (hodd : Odd A.card) (n : ℕ) :
+    correlationAlongExhaustion G Λ ⟨J, 0, β⟩ A n = 0 := by
+  by_cases hAn : A ⊆ Λ.volume n
+  · rw [correlationAlongExhaustion_of_subset G Λ ⟨J, 0, β⟩ hAn]
+    refine correlationΛ_odd_vanish_h_zero G (Λ.volume n) J β _ ?_
+    -- liftFinset preserves cardinality (attach.image of an injection)
+    have hinj : Function.Injective
+        (fun (x : { v // v ∈ A }) => (⟨x.val, hAn x.property⟩ : (↑(Λ.volume n) : Type _))) := by
+      intro x y heq
+      apply Subtype.ext
+      exact Subtype.mk.inj heq
+    have hcard : (liftFinset A hAn).card = A.card := by
+      simp only [liftFinset, Finset.card_image_of_injective _ hinj, Finset.card_attach]
+    rw [hcard]
+    exact hodd
+  · exact correlationAlongExhaustion_of_not_subset G Λ ⟨J, 0, β⟩ hAn
+
+/-- **Z₂ symmetry at `h = 0` for `correlationInfinite`**: vanishes
+for odd-cardinality sets.  Supremum of a constantly-zero sequence. -/
+theorem correlationInfinite_h_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (A : Finset V) (hodd : Odd A.card) :
+    correlationInfinite G Λ ⟨J, 0, β⟩ A = 0 := by
+  simp only [correlationInfinite,
+    correlationAlongExhaustion_h_zero G Λ J β A hodd, ciSup_const]
+
+/-- **`magnetizationInfinite` at `h = 0` vanishes**: the Z₂ spin-flip
+symmetry at zero external field forces the single-site thermodynamic
+magnetization to be zero.
+
+This gives the zero-field **symmetric** value, which is distinct from
+the *spontaneous magnetization* $m^* := \lim_{h \to 0^+} M(h)$ studied
+in Glimm–Jaffe §5.1 (p. 77): symmetry breaking is detected by the
+one-sided limit $h \to 0^+$ (or boundary-condition selection), not by
+evaluating at $h = 0$. -/
+theorem magnetizationInfinite_zero_at_h_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i : V) :
+    magnetizationInfinite G Λ ⟨J, 0, β⟩ i = 0 :=
+  correlationInfinite_h_zero G Λ J β {i} (by simp)
 
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -262,7 +262,7 @@ inventory (2026-04-17).
 |---|---|---|---|
 | §5.1 | Pure/mixed phase criteria | **Done (algebraic)** | `mixed_phase_truncated2`, `mixed_phase_pure_iff`, `truncated2_le_one` |
 | §5.2 | Mean field picture | **Done (algebraic)** | `meanFieldEnergy_neg`, `meanField_zero_solution`, `tanh_odd` |
-| §5.3 | Symmetry breaking | **Done (finite)** | `magnetization_zero_at_h_zero`, `susceptibility_nonneg`, derived convergence |
+| §5.3 | Symmetry breaking (Z₂ at `h = 0`) | **Done (finite + infinite)** | Finite: `magnetization_zero_at_h_zero`, `susceptibility_nonneg`; Infinite: `magnetizationInfinite_zero_at_h_zero`, `correlationInfinite_h_zero` |
 | §5.4 | Prop 5.4.1 (Peierls) | **Done** | `peierls_bound` |
 | §5.4 | Prop 5.4.2 (spontaneous magnetization) | **Done (finite +BC)** | Infinite-volume lift: not yet |
 | §5.5 | XY example | Out of scope |

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,9 @@ Formalized in three regimes:
 | `Ambient.correlationInfinite` | `correlationInfinite := ⨆ n, correlationAlongExhaustion G Λ p A n` | `AmbientLattice.lean` | **Genuine ∞-vol (full)**: convergence, Λ-independence, GKS-I/II, J/h/β monotonicity |
 
 Named specializations at `A = {i}`:
-`magnetization_convergent_{J,h,beta,subgraph}`.
+- Finite / Discretized: `magnetization_convergent_{J,h,beta,subgraph}`
+- Genuine ∞-vol: `Ambient.magnetizationInfinite`
+  (nonneg / le_one / indep_exhaustion / monotone_{J,h,beta} inherited from `correlationInfinite`)
 
 ### §4.6: Free energy analyticity and thermodynamic limit
 
@@ -199,6 +201,15 @@ ambient framework:
 | `correlationΛ_monotone_J` | `MonotoneOn (J ↦ correlationΛ G Λ ⟨J, h, β⟩ A) (Ici 0)` |
 | `correlationAlongExhaustion_monotone_J` | Pointwise J-monotonicity of the exhaustion sequence |
 | **`correlationInfinite_monotone_J`** | **J-direction monotonicity at infinite volume** (Glimm–Jaffe Prop 4.2.4): `MonotoneOn (J ↦ correlationInfinite G Λ ⟨J, h, β⟩ A) (Ici 0)` — three-parameter symmetry complete |
+| **`magnetizationInfinite`** | **Infinite-volume single-site magnetization** `:= correlationInfinite G Λ p {i}` |
+| `magnetizationInfinite_nonneg` | `0 ≤ magnetizationInfinite G Λ p i` (ferromagnetic) |
+| `magnetizationInfinite_le_one` | `magnetizationInfinite G Λ p i ≤ 1` |
+| `magnetizationInfinite_indep_exhaustion` | Λ-independence |
+| `magnetizationInfinite_monotone_{J,h,beta}` | three-parameter monotonicity (specializations of correlationInfinite versions) |
+| `correlationΛ_odd_vanish_h_zero` | At `h = 0`, `correlationΛ ⟨J, 0, β⟩ A = 0` for `Odd A.card` (lifted from `correlation_odd_vanish`) |
+| `correlationAlongExhaustion_h_zero` | Pointwise `= 0` at `h = 0` for odd-cardinality `A` |
+| `correlationInfinite_h_zero` | `correlationInfinite ⟨J, 0, β⟩ A = 0` for `Odd A.card` (sup of zero sequence) |
+| **`magnetizationInfinite_zero_at_h_zero`** | **Z₂ symmetry**: `magnetizationInfinite G Λ ⟨J, 0, β⟩ i = 0` at zero external field |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2528,4 +2528,49 @@ $\texttt{MonotoneOn}\,(J \mapsto \texttt{correlationInfinite}\,G\,\Lambda\,\lang
 点毎 $\le$ + \texttt{ciSup\_le}, \texttt{le\_ciSup}.
 \end{proof}
 
+\subsection{Infinite-volume single-site magnetization}
+
+参考: Glimm--Jaffe \S 4.2 (pp.\ 57ff), \S 5.1 (p.\ 77 の $m^* := \lim_{h \to 0^+} M$);
+Friedli--Velenik \S 3.2 Theorem 3.16.
+
+\begin{definition}[\texttt{magnetizationInfinite}]
+\[
+M^{\mathrm{FM}}_{G,\Lambda}(J, h, \beta; i)
+  \;:=\; \texttt{correlationInfinite}\,G\,\Lambda\,\langle J,h,\beta\rangle\,\{i\}.
+\]
+\end{definition}
+
+\begin{theorem}[\texttt{magnetizationInfinite} 基本性質]
+以下すべて $\texttt{correlationInfinite\_*}$ を $A := \{i\}$ に specialize
+して直ちに従う:
+\begin{itemize}
+\item \texttt{magnetizationInfinite\_nonneg} (強磁性),
+\item \texttt{magnetizationInfinite\_le\_one},
+\item \texttt{magnetizationInfinite\_indep\_exhaustion},
+\item \texttt{magnetizationInfinite\_monotone\_\{J,h,beta\}} (3 パラメータ monotonicity).
+\end{itemize}
+\end{theorem}
+
+\subsection*{Z₂ spin-flip symmetry at $h = 0$}
+
+参考: Glimm--Jaffe \S 5.1 p.\ 77 (自発磁化 $m^*$ は $h \to 0^+$ の極限で
+boundary condition に依存 — $h = 0$ 自体ではなく). 有限体積の元は
+\texttt{IsingModel.correlation\_odd\_vanish} (\texttt{Inequalities/GHS.lean}).
+
+\begin{theorem}[\texttt{correlationInfinite\_h\_zero}]
+$h = 0$ かつ $|A|$ が奇数のとき
+$\texttt{correlationInfinite}\,G\,\Lambda\,\langle J,0,\beta\rangle\,A = 0$.
+\end{theorem}
+
+\begin{proof}
+有限体積で \texttt{correlation\_odd\_vanish} を \texttt{inducedGraph} に適用
+(\texttt{correlationΛ\_odd\_vanish\_h\_zero}). 各 $n$ で
+\texttt{correlationAlongExhaustion} は 0 (dite の両分岐共).
+\texttt{ciSup} of zero sequence $= 0$.
+\end{proof}
+
+\begin{theorem}[\texttt{magnetizationInfinite\_zero\_at\_h\_zero}]
+$h = 0$ で $M^{\mathrm{FM}} = 0$ (単サイト $|\{i\}| = 1$ は奇数).
+\end{theorem}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Introduce \`magnetizationInfinite G Λ p i := correlationInfinite G Λ p {i}\` as the formal single-site thermodynamic-limit magnetization.
- Provide 6 specialized properties: nonnegativity (FM), upper bound by 1, Λ-independence, and J/h/β-direction monotonicity.
- All derived directly from PR #91-#97's correlationInfinite API.
- Glimm-Jaffe §4.2 (p. 57ff) / §5.1 (p. 77) / §5.4.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated with page numbers
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)