### PR TITLE
feat: spontaneousMagnetization as right-limit Tendsto

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1689,5 +1689,47 @@ theorem spontaneousMagnetization_indep_exhaustion
   exact magnetizationInfinite_indep_exhaustion G Λ Λ' ⟨J, h.val, β⟩
     ⟨hJ, le_of_lt h.property, hβ⟩ i
 
+/-- **Right-limit Tendsto**: for ferromagnetic Ising, the
+`magnetizationInfinite` function tends to `spontaneousMagnetization`
+as `h → 0⁺`.
+
+Combines:
+- `magnetizationInfinite_monotone_h` (PR #95), restricted to `Set.Ioi 0`.
+- Bounded-below-by-0 (ferromagnetic).
+- `MonotoneOn.tendsto_nhdsGT` (Mathlib).
+- Conversion between `sInf (f '' Ioi 0)` and the subtype-indexed iInf
+  via `sInf_image` / `iInf_subtype`. -/
+theorem tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
+    Filter.Tendsto
+      (fun h : ℝ => magnetizationInfinite G Λ ⟨J, h, β⟩ i)
+      (nhdsWithin (0 : ℝ) (Set.Ioi 0))
+      (nhds (spontaneousMagnetization G Λ J β i)) := by
+  set f : ℝ → ℝ := fun h => magnetizationInfinite G Λ ⟨J, h, β⟩ i with hf_def
+  -- Step 1: MonotoneOn f (Ioi 0)
+  have hmono : MonotoneOn f (Set.Ioi 0) := by
+    have hmono_Ici : MonotoneOn f (Set.Ici 0) :=
+      magnetizationInfinite_monotone_h G Λ hJ hβ i
+    exact hmono_Ici.mono Set.Ioi_subset_Ici_self
+  -- Step 2: BddBelow (f '' Ioi 0)
+  have hbdd : BddBelow (f '' Set.Ioi 0) := by
+    refine ⟨0, ?_⟩
+    rintro _ ⟨h, hh, rfl⟩
+    exact magnetizationInfinite_nonneg G Λ ⟨J, h, β⟩
+      ⟨hJ, le_of_lt hh, hβ⟩ i
+  -- Step 3: Apply MonotoneOn.tendsto_nhdsGT
+  have htendsto := hmono.tendsto_nhdsGT hbdd
+  -- Step 4: Identify sInf (f '' Ioi 0) with spontaneousMagnetization
+  have hsInf : sInf (f '' Set.Ioi 0) = spontaneousMagnetization G Λ J β i := by
+    unfold spontaneousMagnetization
+    rw [← sInf_range, ← Set.image_univ]
+    congr 1
+    ext y
+    simp [hf_def, Set.image_univ, Set.mem_image, Set.mem_Ioi, Subtype.exists]
+  rw [← hsInf]
+  exact htendsto
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -215,6 +215,7 @@ ambient framework:
 | `spontaneousMagnetization_le_one` | `m* ≤ 1` |
 | `spontaneousMagnetization_le_magnetizationInfinite` | `m* ≤ M(h)` for any `h > 0` (infimum characterization) |
 | `spontaneousMagnetization_indep_exhaustion` | `m*` does not depend on the choice of exhaustion |
+| **`tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT`** | **Right-limit**: `Tendsto M(h) (𝓝[>] 0) (𝓝 m*)` — realizes `m*` as the physical right limit of `magnetizationInfinite` |
 
 ## Axioms
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -267,7 +267,7 @@ inventory (2026-04-17).
 | Section | Result | Status | Notes |
 |---|---|---|---|
 | §5.1 | Pure/mixed phase criteria | **Done (algebraic)** | `mixed_phase_truncated2`, `mixed_phase_pure_iff`, `truncated2_le_one` |
-| §5.1 | Spontaneous magnetization `m*` (p. 77) | **Done (infimum form)** | `spontaneousMagnetization` + nonneg/≤1/≤M(h). Tendsto (nhdsGT 0) form: follow-up |
+| §5.1 | Spontaneous magnetization `m*` (p. 77) | **Done (complete)** | `spontaneousMagnetization` (infimum form) + `tendsto_…_nhdsGT` (right-limit `m* = lim_{h→0+} M(h)`) + nonneg/≤1/≤M(h)/indep_exhaustion |
 | §5.2 | Mean field picture | **Done (algebraic)** | `meanFieldEnergy_neg`, `meanField_zero_solution`, `tanh_odd` |
 | §5.3 | Symmetry breaking (Z₂ at `h = 0`) | **Done (finite + infinite)** | Finite: `magnetization_zero_at_h_zero`, `susceptibility_nonneg`; Infinite: `magnetizationInfinite_zero_at_h_zero`, `correlationInfinite_h_zero` |
 | §5.4 | Prop 5.4.1 (Peierls) | **Done** | `peierls_bound` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2598,4 +2598,19 @@ $\texttt{magnetizationInfinite}$ は $h$ に対して monotone on $\mathrm{Ici}\
 (PR \#95) かつ $0 \le \cdot \le 1$ なので, $\inf_{h > 0}$ は well-defined.
 \end{theorem}
 
+\begin{theorem}[\texttt{tendsto\_magnetizationInfinite\_spontaneousMagnetization\_nhdsGT}]
+強磁性系 ($J \ge 0, \beta > 0$) で
+\[
+\text{Tendsto}\,\bigl(h \mapsto M(h)\bigr)\,
+  (\mathcal{N}[>]\,0)\,(\mathcal{N}\,m^*).
+\]
+すなわち $m^* = \lim_{h \to 0^+} M(h)$ が形式化される.
+\end{theorem}
+
+\begin{proof}
+\texttt{MonotoneOn.tendsto\_nhdsGT} (Mathlib) で
+$\text{Tendsto}\,M\,(\mathcal{N}[>]\,0)\,(\mathcal{N}\,(\inf(M''\mathrm{Ioi}\,0)))$.
+$\inf(M''\mathrm{Ioi}\,0) = m^*$ を $\texttt{sInf\_image}$/$\texttt{iInf\_subtype}$ で結びつける.
+\end{proof}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Prove \`Tendsto (fun h => magnetizationInfinite G Λ ⟨J, h, β⟩ i) (𝓝[>] 0) (𝓝 (spontaneousMagnetization ...))\`.
- Follow-up to PR #99: complete the identification of the infimum-form \`spontaneousMagnetization\` with the actual right limit $\lim_{h \to 0^+} M(h)$.
- Uses \`MonotoneOn.tendsto_nhdsGT\` (Mathlib/Topology/Order/Monotone.lean).
- Glimm-Jaffe §5.1 p. 77.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated with page numbers
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)