### PR TITLE
feat: spontaneousCorrelation (general A generalization)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1731,5 +1731,129 @@ theorem tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT
   rw [← hsInf]
   exact htendsto
 
+/-! ## Spontaneous correlation function (general `A`)
+
+Generalize `spontaneousMagnetization` (single-site, `A = {i}`) to an
+arbitrary finite set `A : Finset V`.  Same infimum-form over `h > 0`,
+derived from PR #91–#100's `correlationInfinite` API. -/
+
+/-- **Spontaneous correlation function** (infimum form):
+`spontaneousCorrelation G Λ J β A := ⨅ h : ↥(Set.Ioi 0), correlationInfinite G Λ ⟨J, h, β⟩ A`.
+
+Generalization of `spontaneousMagnetization` to arbitrary `A : Finset V`.
+For $A = \{i\}$, coincides with `spontaneousMagnetization` by definition. -/
+noncomputable def spontaneousCorrelation
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (A : Finset V) : ℝ :=
+  ⨅ h : ↥(Set.Ioi (0 : ℝ)), correlationInfinite G Λ ⟨J, h.val, β⟩ A
+
+/-- **Bounded-below witness** for `spontaneousCorrelation`: the family
+`h ↦ correlationInfinite G Λ ⟨J, h, β⟩ A` over `Set.Ioi 0` is bounded
+below by `0` (ferromagnetic). -/
+private theorem correlationInfinite_bddBelow_on_Ioi
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset V) :
+    BddBelow (Set.range
+      (fun h : ↥(Set.Ioi (0 : ℝ)) =>
+        correlationInfinite G Λ ⟨J, h.val, β⟩ A)) := by
+  refine ⟨0, ?_⟩
+  rintro _ ⟨h, rfl⟩
+  exact correlationInfinite_nonneg G Λ ⟨J, h.val, β⟩
+    ⟨hJ, le_of_lt h.property, hβ⟩ A
+
+/-- **Nonnegativity** (ferromagnetic): $\langle \sigma^A \rangle^* \ge 0$. -/
+theorem spontaneousCorrelation_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset V) :
+    0 ≤ spontaneousCorrelation G Λ J β A := by
+  refine le_ciInf ?_
+  rintro h
+  exact correlationInfinite_nonneg G Λ ⟨J, h.val, β⟩
+    ⟨hJ, le_of_lt h.property, hβ⟩ A
+
+/-- **Upper bound**: $\langle \sigma^A \rangle^* \le 1$. -/
+theorem spontaneousCorrelation_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset V) :
+    spontaneousCorrelation G Λ J β A ≤ 1 := by
+  refine ciInf_le_of_le
+    (correlationInfinite_bddBelow_on_Ioi G Λ hJ hβ A)
+    ⟨1, by norm_num⟩ ?_
+  exact correlationInfinite_le_one G Λ ⟨J, 1, β⟩ A
+
+/-- **Lower bound by `correlationInfinite` at positive `h`**: for any
+`h > 0`, $\langle \sigma^A \rangle^* \le \langle \sigma^A \rangle(h)$. -/
+theorem spontaneousCorrelation_le_correlationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    {h : ℝ} (hh : 0 < h) (A : Finset V) :
+    spontaneousCorrelation G Λ J β A
+      ≤ correlationInfinite G Λ ⟨J, h, β⟩ A :=
+  ciInf_le
+    (correlationInfinite_bddBelow_on_Ioi G Λ hJ hβ A)
+    ⟨h, hh⟩
+
+/-- **Exhaustion-independence**: $\langle \sigma^A \rangle^*$ does not
+depend on the choice of exhaustion. -/
+theorem spontaneousCorrelation_indep_exhaustion
+    (G : SimpleGraph V) (Λ Λ' : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G (Λ'.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset V) :
+    spontaneousCorrelation G Λ J β A
+      = spontaneousCorrelation G Λ' J β A := by
+  unfold spontaneousCorrelation
+  congr 1
+  funext h
+  exact correlationInfinite_indep_exhaustion G Λ Λ' ⟨J, h.val, β⟩
+    ⟨hJ, le_of_lt h.property, hβ⟩ A
+
+/-- **Right-limit Tendsto**: for ferromagnetic Ising, the general-`A`
+`correlationInfinite ⟨J, h, β⟩ A` tends to `spontaneousCorrelation` as
+`h → 0⁺`. Analogous to
+`tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT`. -/
+theorem tendsto_correlationInfinite_spontaneousCorrelation_nhdsGT
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset V) :
+    Filter.Tendsto
+      (fun h : ℝ => correlationInfinite G Λ ⟨J, h, β⟩ A)
+      (nhdsWithin (0 : ℝ) (Set.Ioi 0))
+      (nhds (spontaneousCorrelation G Λ J β A)) := by
+  set f : ℝ → ℝ := fun h => correlationInfinite G Λ ⟨J, h, β⟩ A with hf_def
+  have hmono : MonotoneOn f (Set.Ioi 0) := by
+    have hmono_Ici : MonotoneOn f (Set.Ici 0) :=
+      correlationInfinite_monotone_h G Λ hJ hβ A
+    exact hmono_Ici.mono Set.Ioi_subset_Ici_self
+  have hbdd : BddBelow (f '' Set.Ioi 0) := by
+    refine ⟨0, ?_⟩
+    rintro _ ⟨h, hh, rfl⟩
+    exact correlationInfinite_nonneg G Λ ⟨J, h, β⟩
+      ⟨hJ, le_of_lt hh, hβ⟩ A
+  have htendsto := hmono.tendsto_nhdsGT hbdd
+  have hsInf : sInf (f '' Set.Ioi 0) = spontaneousCorrelation G Λ J β A := by
+    unfold spontaneousCorrelation
+    rw [← sInf_range, ← Set.image_univ]
+    congr 1
+    ext y
+    simp [hf_def, Set.image_univ, Set.mem_image, Set.mem_Ioi, Subtype.exists]
+  rw [← hsInf]
+  exact htendsto
+
+/-- **Agreement at singletons**: `spontaneousCorrelation` on `{i}`
+equals `spontaneousMagnetization` by definition unfolding. -/
+theorem spontaneousCorrelation_singleton_eq_spontaneousMagnetization
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i : V) :
+    spontaneousCorrelation G Λ J β {i}
+      = spontaneousMagnetization G Λ J β i :=
+  rfl
+
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1601,136 +1601,6 @@ equals this infimum.
 Reference: Glimm–Jaffe §5.1 p. 77. Friedli–Velenik §3.10 (self-consistent
 magnetization). -/
 
-/-- **Spontaneous magnetization at infinite volume** (*infimum form*):
-for ferromagnetic Ising on an ambient type `V`, exhaustion `Λ`, and
-fixed `J, β`,
-`spontaneousMagnetization G Λ J β i`
-  `:= ⨅ h : ↥(Set.Ioi 0), magnetizationInfinite G Λ ⟨J, h.val, β⟩ i`.
-
-This is the order parameter $m^*$ distinguishing ordered/disordered
-phases.  Since `magnetizationInfinite` is monotone in `h` on
-`Set.Ici 0` (`magnetizationInfinite_monotone_h`) and bounded in
-`[0, 1]`, this infimum coincides with $\lim_{h \to 0^+} M(h)$ —
-however the explicit `Tendsto` / `nhdsGT 0` statement is not formalized
-here and is deferred to a follow-up PR. -/
-noncomputable def spontaneousMagnetization
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (i : V) : ℝ :=
-  ⨅ h : ↥(Set.Ioi (0 : ℝ)), magnetizationInfinite G Λ ⟨J, h.val, β⟩ i
-
-/-- **Bounded-below witness**: the family
-`h ↦ magnetizationInfinite G Λ ⟨J, h, β⟩ i` over `Set.Ioi 0` is bounded
-below by `0` (ferromagnetic). -/
-private theorem magnetizationInfinite_bddBelow_on_Ioi
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
-    BddBelow (Set.range
-      (fun h : ↥(Set.Ioi (0 : ℝ)) =>
-        magnetizationInfinite G Λ ⟨J, h.val, β⟩ i)) := by
-  refine ⟨0, ?_⟩
-  rintro _ ⟨h, rfl⟩
-  exact magnetizationInfinite_nonneg G Λ ⟨J, h.val, β⟩
-    ⟨hJ, le_of_lt h.property, hβ⟩ i
-
-/-- **Nonnegativity of `spontaneousMagnetization`**: for ferromagnetic
-Ising ($J \ge 0$, $\beta > 0$), $m^* \ge 0$. -/
-theorem spontaneousMagnetization_nonneg
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
-    0 ≤ spontaneousMagnetization G Λ J β i := by
-  refine le_ciInf ?_
-  rintro h
-  exact magnetizationInfinite_nonneg G Λ ⟨J, h.val, β⟩
-    ⟨hJ, le_of_lt h.property, hβ⟩ i
-
-/-- **Upper bound**: $m^* \le 1$. -/
-theorem spontaneousMagnetization_le_one
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
-    spontaneousMagnetization G Λ J β i ≤ 1 := by
-  refine ciInf_le_of_le
-    (magnetizationInfinite_bddBelow_on_Ioi G Λ hJ hβ i)
-    ⟨1, by norm_num⟩ ?_
-  exact magnetizationInfinite_le_one G Λ ⟨J, 1, β⟩ i
-
-/-- **Lower bound for `magnetizationInfinite` at positive `h`**:
-$m^* \le M(h)$ for $h > 0$.  Direct from the definition of `iInf`. -/
-theorem spontaneousMagnetization_le_magnetizationInfinite
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
-    {h : ℝ} (hh : 0 < h) (i : V) :
-    spontaneousMagnetization G Λ J β i
-      ≤ magnetizationInfinite G Λ ⟨J, h, β⟩ i :=
-  ciInf_le
-    (magnetizationInfinite_bddBelow_on_Ioi G Λ hJ hβ i)
-    ⟨h, hh⟩
-
-/-- **Exhaustion-independence of `spontaneousMagnetization`**:
-the value does not depend on the choice of exhaustion.  For every
-`h : Set.Ioi 0`, we build `Ferromagnetic ⟨J, h.val, β⟩` from `hJ`,
-`h.property`, and `hβ`, apply
-`magnetizationInfinite_indep_exhaustion` pointwise, then conclude by
-extensional agreement of the iInf-ed function. -/
-theorem spontaneousMagnetization_indep_exhaustion
-    (G : SimpleGraph V) (Λ Λ' : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    [∀ n, Fintype (inducedGraph G (Λ'.volume n)).edgeSet]
-    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
-    spontaneousMagnetization G Λ J β i
-      = spontaneousMagnetization G Λ' J β i := by
-  unfold spontaneousMagnetization
-  congr 1
-  funext h
-  exact magnetizationInfinite_indep_exhaustion G Λ Λ' ⟨J, h.val, β⟩
-    ⟨hJ, le_of_lt h.property, hβ⟩ i
-
-/-- **Right-limit Tendsto**: for ferromagnetic Ising, the
-`magnetizationInfinite` function tends to `spontaneousMagnetization`
-as `h → 0⁺`.
-
-Combines:
-- `magnetizationInfinite_monotone_h` (PR #95), restricted to `Set.Ioi 0`.
-- Bounded-below-by-0 (ferromagnetic).
-- `MonotoneOn.tendsto_nhdsGT` (Mathlib).
-- Conversion between `sInf (f '' Ioi 0)` and the subtype-indexed iInf
-  via `sInf_image` / `iInf_subtype`. -/
-theorem tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
-    Filter.Tendsto
-      (fun h : ℝ => magnetizationInfinite G Λ ⟨J, h, β⟩ i)
-      (nhdsWithin (0 : ℝ) (Set.Ioi 0))
-      (nhds (spontaneousMagnetization G Λ J β i)) := by
-  set f : ℝ → ℝ := fun h => magnetizationInfinite G Λ ⟨J, h, β⟩ i with hf_def
-  -- Step 1: MonotoneOn f (Ioi 0)
-  have hmono : MonotoneOn f (Set.Ioi 0) := by
-    have hmono_Ici : MonotoneOn f (Set.Ici 0) :=
-      magnetizationInfinite_monotone_h G Λ hJ hβ i
-    exact hmono_Ici.mono Set.Ioi_subset_Ici_self
-  -- Step 2: BddBelow (f '' Ioi 0)
-  have hbdd : BddBelow (f '' Set.Ioi 0) := by
-    refine ⟨0, ?_⟩
-    rintro _ ⟨h, hh, rfl⟩
-    exact magnetizationInfinite_nonneg G Λ ⟨J, h, β⟩
-      ⟨hJ, le_of_lt hh, hβ⟩ i
-  -- Step 3: Apply MonotoneOn.tendsto_nhdsGT
-  have htendsto := hmono.tendsto_nhdsGT hbdd
-  -- Step 4: Identify sInf (f '' Ioi 0) with spontaneousMagnetization
-  have hsInf : sInf (f '' Set.Ioi 0) = spontaneousMagnetization G Λ J β i := by
-    unfold spontaneousMagnetization
-    rw [← sInf_range, ← Set.image_univ]
-    congr 1
-    ext y
-    simp [hf_def, Set.image_univ, Set.mem_image, Set.mem_Ioi, Subtype.exists]
-  rw [← hsInf]
-  exact htendsto
-
 /-! ## Spontaneous correlation function (general `A`)
 
 Generalize `spontaneousMagnetization` (single-site, `A = {i}`) to an
@@ -1845,8 +1715,32 @@ theorem tendsto_correlationInfinite_spontaneousCorrelation_nhdsGT
   rw [← hsInf]
   exact htendsto
 
+/-! ## Spontaneous magnetization (single-site specialization)
+
+`spontaneousMagnetization` is the single-site case `A = {i}` of
+`spontaneousCorrelation`.  All basic properties are one-line
+specializations.
+
+Reference: Glimm–Jaffe §5.1 p. 77 (the order parameter $m^*$
+distinguishing ordered/disordered phases). -/
+
+/-- **Spontaneous magnetization at infinite volume** (*infimum form*):
+for ferromagnetic Ising on an ambient type `V`, exhaustion `Λ`, and
+fixed `J, β`,
+`spontaneousMagnetization G Λ J β i := spontaneousCorrelation G Λ J β {i}`.
+
+This is the order parameter $m^*$.  Since `magnetizationInfinite` is
+monotone in `h` on `Set.Ici 0` and bounded in `[0, 1]`, this infimum
+coincides with $\lim_{h \to 0^+} M(h)$
+(`tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT`). -/
+noncomputable def spontaneousMagnetization
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i : V) : ℝ :=
+  spontaneousCorrelation G Λ J β {i}
+
 /-- **Agreement at singletons**: `spontaneousCorrelation` on `{i}`
-equals `spontaneousMagnetization` by definition unfolding. -/
+equals `spontaneousMagnetization`. Holds by definition. -/
 theorem spontaneousCorrelation_singleton_eq_spontaneousMagnetization
     (G : SimpleGraph V) (Λ : Exhaustion V)
     [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
@@ -1854,6 +1748,65 @@ theorem spontaneousCorrelation_singleton_eq_spontaneousMagnetization
     spontaneousCorrelation G Λ J β {i}
       = spontaneousMagnetization G Λ J β i :=
   rfl
+
+/-- **Nonnegativity of `spontaneousMagnetization`** (ferromagnetic):
+$m^* \ge 0$.  Specialization of `spontaneousCorrelation_nonneg` at
+`A = {i}`. -/
+theorem spontaneousMagnetization_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
+    0 ≤ spontaneousMagnetization G Λ J β i :=
+  spontaneousCorrelation_nonneg G Λ hJ hβ {i}
+
+/-- **Upper bound**: $m^* \le 1$.  Specialization of
+`spontaneousCorrelation_le_one` at `A = {i}`. -/
+theorem spontaneousMagnetization_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
+    spontaneousMagnetization G Λ J β i ≤ 1 :=
+  spontaneousCorrelation_le_one G Λ hJ hβ {i}
+
+/-- **Lower bound for `magnetizationInfinite` at positive `h`**:
+$m^* \le M(h)$ for $h > 0$. Specialization of
+`spontaneousCorrelation_le_correlationInfinite` at `A = {i}` (noting
+`magnetizationInfinite = correlationInfinite ... {i}`). -/
+theorem spontaneousMagnetization_le_magnetizationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    {h : ℝ} (hh : 0 < h) (i : V) :
+    spontaneousMagnetization G Λ J β i
+      ≤ magnetizationInfinite G Λ ⟨J, h, β⟩ i :=
+  spontaneousCorrelation_le_correlationInfinite G Λ hJ hβ hh {i}
+
+/-- **Exhaustion-independence of `spontaneousMagnetization`**:
+the value does not depend on the choice of exhaustion.  Specialization
+of `spontaneousCorrelation_indep_exhaustion` at `A = {i}`. -/
+theorem spontaneousMagnetization_indep_exhaustion
+    (G : SimpleGraph V) (Λ Λ' : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G (Λ'.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
+    spontaneousMagnetization G Λ J β i
+      = spontaneousMagnetization G Λ' J β i :=
+  spontaneousCorrelation_indep_exhaustion G Λ Λ' hJ hβ {i}
+
+/-- **Right-limit Tendsto**: for ferromagnetic Ising,
+`magnetizationInfinite` tends to `spontaneousMagnetization` as
+`h → 0⁺`.  Specialization of
+`tendsto_correlationInfinite_spontaneousCorrelation_nhdsGT` at
+`A = {i}` (noting `magnetizationInfinite = correlationInfinite ... {i}`). -/
+theorem tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
+    Filter.Tendsto
+      (fun h : ℝ => magnetizationInfinite G Λ ⟨J, h, β⟩ i)
+      (nhdsWithin (0 : ℝ) (Set.Ioi 0))
+      (nhds (spontaneousMagnetization G Λ J β i)) :=
+  tendsto_correlationInfinite_spontaneousCorrelation_nhdsGT G Λ hJ hβ {i}
 
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -216,6 +216,13 @@ ambient framework:
 | `spontaneousMagnetization_le_magnetizationInfinite` | `m* ≤ M(h)` for any `h > 0` (infimum characterization) |
 | `spontaneousMagnetization_indep_exhaustion` | `m*` does not depend on the choice of exhaustion |
 | **`tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT`** | **Right-limit**: `Tendsto M(h) (𝓝[>] 0) (𝓝 m*)` — realizes `m*` as the physical right limit of `magnetizationInfinite` |
+| **`spontaneousCorrelation`** | **General-A spontaneous correlation** `:= ⨅ h : Set.Ioi 0, correlationInfinite ⟨J, h, β⟩ A` — generalization of `spontaneousMagnetization` |
+| `spontaneousCorrelation_nonneg` | `0 ≤ ⟨σ^A⟩*` (ferromagnetic) |
+| `spontaneousCorrelation_le_one` | `⟨σ^A⟩* ≤ 1` |
+| `spontaneousCorrelation_le_correlationInfinite` | `⟨σ^A⟩* ≤ ⟨σ^A⟩(h)` for `h > 0` |
+| `spontaneousCorrelation_indep_exhaustion` | Λ-independence |
+| `tendsto_correlationInfinite_spontaneousCorrelation_nhdsGT` | Right-limit Tendsto: `⟨σ^A⟩(h) → ⟨σ^A⟩*` as `h → 0+` |
+| `spontaneousCorrelation_singleton_eq_spontaneousMagnetization` | `spontaneousCorrelation ... {i} = spontaneousMagnetization ... i` (definitional) |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2573,50 +2573,16 @@ $\texttt{correlationInfinite}\,G\,\Lambda\,\langle J,0,\beta\rangle\,A = 0$.
 $h = 0$ で $M^{\mathrm{FM}} = 0$ (単サイト $|\{i\}| = 1$ は奇数).
 \end{theorem}
 
-\subsection{Spontaneous magnetization at infinite volume}
-
-参考: Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987), \S 5.1 p.\ 77:
-$m^*(J, \beta) := \lim_{h \to 0^+} M(J, h, \beta)$.
-Friedli--Velenik \S 3.10 (self-consistent magnetization).
-
-\begin{definition}[\texttt{spontaneousMagnetization}]
-\[
-m^*(G, \Lambda; J, \beta; i)
-  \;:=\; \inf_{h > 0} \texttt{magnetizationInfinite}\,G\,\Lambda\,\langle J,h,\beta\rangle\,i.
-\]
-\end{definition}
-
-\begin{theorem}[\texttt{spontaneousMagnetization}の基本性質]
-強磁性下で:
-\begin{itemize}
-\item \texttt{\_nonneg}: $m^* \ge 0$,
-\item \texttt{\_le\_one}: $m^* \le 1$,
-\item \texttt{\_le\_magnetizationInfinite}: $h > 0$ で $m^* \le M(h)$,
-\item \texttt{\_indep\_exhaustion}: $m^*$ は $\Lambda$ の選び方に非依存.
-\end{itemize}
-$\texttt{magnetizationInfinite}$ は $h$ に対して monotone on $\mathrm{Ici}\,0$
-(PR \#95) かつ $0 \le \cdot \le 1$ なので, $\inf_{h > 0}$ は well-defined.
-\end{theorem}
-
-\begin{theorem}[\texttt{tendsto\_magnetizationInfinite\_spontaneousMagnetization\_nhdsGT}]
-強磁性系 ($J \ge 0, \beta > 0$) で
-\[
-\text{Tendsto}\,\bigl(h \mapsto M(h)\bigr)\,
-  (\mathcal{N}[>]\,0)\,(\mathcal{N}\,m^*).
-\]
-すなわち $m^* = \lim_{h \to 0^+} M(h)$ が形式化される.
-\end{theorem}
-
-\begin{proof}
-\texttt{MonotoneOn.tendsto\_nhdsGT} (Mathlib) で
-$\text{Tendsto}\,M\,(\mathcal{N}[>]\,0)\,(\mathcal{N}\,(\inf(M''\mathrm{Ioi}\,0)))$.
-$\inf(M''\mathrm{Ioi}\,0) = m^*$ を $\texttt{sInf\_image}$/$\texttt{iInf\_subtype}$ で結びつける.
-\end{proof}
-
 \subsection{Spontaneous correlation function (general \texorpdfstring{$A$}{A})}
 
-参考: Glimm--Jaffe \S 4.2 p.\ 57ff, \S 5.1 p.\ 77.
-PR \#99+\#100 を一般 $A : \texttt{Finset}\,V$ に汎化.
+参考: Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987),
+\S 4.2 p.\ 57ff, \S 5.1 p.\ 77:
+$m^*(J, \beta) := \lim_{h \to 0^+} M(J, h, \beta)$.
+Friedli--Velenik \S 3.10.
+
+無限体積相関関数 $\langle \sigma^A \rangle$ の $h \to 0^+$ 極限を
+**一般 $A : \texttt{Finset}\,V$** に対して定義し, 基本性質を揃える.
+単サイト $A = \{i\}$ の場合が自発磁化 $m^*$ (Glimm--Jaffe §5.1 p.\ 77).
 
 \begin{definition}[\texttt{spontaneousCorrelation}]
 \[
@@ -2634,10 +2600,32 @@ PR \#99+\#100 を一般 $A : \texttt{Finset}\,V$ に汎化.
 \texttt{tendsto\_\ldots\_nhdsGT}.
 \end{theorem}
 
+\subsection*{Spontaneous magnetization (single-site specialization)}
+
+自発磁化 $m^*$ は \texttt{spontaneousCorrelation} の $A = \{i\}$ 特殊化:
+
+\begin{definition}[\texttt{spontaneousMagnetization}]
+\[
+\texttt{spontaneousMagnetization}\,G\,\Lambda\,J\,\beta\,i
+  \;:=\; \texttt{spontaneousCorrelation}\,G\,\Lambda\,J\,\beta\,\{i\}.
+\]
+\end{definition}
+
 \begin{theorem}[\texttt{spontaneousCorrelation\_singleton\_eq\_spontaneousMagnetization}]
-$\texttt{spontaneousCorrelation}\,G\,\Lambda\,J\,\beta\,\{i\}
-  = \texttt{spontaneousMagnetization}\,G\,\Lambda\,J\,\beta\,i$
-(定義展開で rfl).
+上記定義より \texttt{rfl} で等価.
+\end{theorem}
+
+\begin{theorem}[\texttt{spontaneousMagnetization}の基本性質]
+全て \texttt{spontaneousCorrelation\_*} の $A := \{i\}$ specialization
+(1-line specialization):
+\begin{itemize}
+\item \texttt{\_nonneg}: $m^* \ge 0$,
+\item \texttt{\_le\_one}: $m^* \le 1$,
+\item \texttt{\_le\_magnetizationInfinite}: $h > 0$ で $m^* \le M(h)$,
+\item \texttt{\_indep\_exhaustion}: $\Lambda$ 非依存,
+\item \texttt{tendsto\_magnetizationInfinite\_spontaneousMagnetization\_nhdsGT}:
+      $m^* = \lim_{h \to 0^+} M(h)$.
+\end{itemize}
 \end{theorem}
 
 \end{document}

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2613,4 +2613,31 @@ $\text{Tendsto}\,M\,(\mathcal{N}[>]\,0)\,(\mathcal{N}\,(\inf(M''\mathrm{Ioi}\,0)
 $\inf(M''\mathrm{Ioi}\,0) = m^*$ を $\texttt{sInf\_image}$/$\texttt{iInf\_subtype}$ で結びつける.
 \end{proof}
 
+\subsection{Spontaneous correlation function (general \texorpdfstring{$A$}{A})}
+
+参考: Glimm--Jaffe \S 4.2 p.\ 57ff, \S 5.1 p.\ 77.
+PR \#99+\#100 を一般 $A : \texttt{Finset}\,V$ に汎化.
+
+\begin{definition}[\texttt{spontaneousCorrelation}]
+\[
+\langle \sigma^A \rangle^*_{G, \Lambda}(J, \beta)
+  \;:=\; \inf_{h > 0} \texttt{correlationInfinite}\,G\,\Lambda\,\langle J,h,\beta\rangle\,A.
+\]
+\end{definition}
+
+\begin{theorem}[\texttt{spontaneousCorrelation}の基本性質]
+強磁性下で 5 properties (全て \texttt{correlationInfinite\_*} の specialize):
+\texttt{\_nonneg},
+\texttt{\_le\_one},
+\texttt{\_le\_correlationInfinite},
+\texttt{\_indep\_exhaustion},
+\texttt{tendsto\_\ldots\_nhdsGT}.
+\end{theorem}
+
+\begin{theorem}[\texttt{spontaneousCorrelation\_singleton\_eq\_spontaneousMagnetization}]
+$\texttt{spontaneousCorrelation}\,G\,\Lambda\,J\,\beta\,\{i\}
+  = \texttt{spontaneousMagnetization}\,G\,\Lambda\,J\,\beta\,i$
+(定義展開で rfl).
+\end{theorem}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Generalize PR #99+#100's spontaneousMagnetization (single-site) to arbitrary \`A : Finset V\`:
  \`spontaneousCorrelation G Λ J β A := ⨅ h : ↥(Set.Ioi 0), correlationInfinite G Λ ⟨J, h, β⟩ A\`
- Provide 5 specialized properties (nonneg, le_one, le_correlationInfinite, indep_exhaustion, tendsto_nhdsGT) mirroring the magnetization versions.
- Agreement theorem: \`spontaneousCorrelation ... {i} = spontaneousMagnetization ... i\`.
- Glimm-Jaffe §4.2 p. 57ff / §5.1 p. 77.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated (page numbers)
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)