### PR TITLE
feat: infinite-volume truncated 2-point correlation

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1808,5 +1808,101 @@ theorem tendsto_magnetizationInfinite_spontaneousMagnetization_nhdsGT
       (nhds (spontaneousMagnetization G Λ J β i)) :=
   tendsto_correlationInfinite_spontaneousCorrelation_nhdsGT G Λ hJ hβ {i}
 
+/-! ## Truncated 2-point correlation at infinite volume
+
+Specialize `correlationInfinite_gks_second` (PR #94) to the
+two-point case, obtaining the truncated 2-point correlation function
+$U_2(i, j) := \langle \sigma_i \sigma_j \rangle_\infty
+  - \langle \sigma_i \rangle_\infty \langle \sigma_j \rangle_\infty$
+and the nonnegativity $U_2 \ge 0$ for $i \ne j$.
+
+Reference: Glimm–Jaffe §4.2 p. 57ff, Friedli–Velenik §3.6.3. -/
+
+/-- **Truncated 2-point correlation at infinite volume**:
+$U_2(i, j) := \langle \sigma_i \sigma_j \rangle_\infty
+  - \langle \sigma_i \rangle_\infty \langle \sigma_j \rangle_\infty$. -/
+noncomputable def truncated2Infinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i j : V) : ℝ :=
+  correlationInfinite G Λ p {i, j}
+    - correlationInfinite G Λ p {i} * correlationInfinite G Λ p {j}
+
+/-- **Symmetry in the two arguments**: $U_2(i, j) = U_2(j, i)$. -/
+theorem truncated2Infinite_symm
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i j : V) :
+    truncated2Infinite G Λ p i j = truncated2Infinite G Λ p j i := by
+  unfold truncated2Infinite
+  rw [Finset.pair_comm, mul_comm]
+
+/-- **Nonnegativity for distinct sites**: $U_2(i, j) \ge 0$ for
+$i \ne j$.  Direct corollary of `correlationInfinite_gks_second`:
+$\{i, j\} = \{i\} \,\triangle\, \{j\}$ when $i \ne j$. -/
+theorem truncated2Infinite_nonneg_of_ne
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    {i j : V} (hij : i ≠ j) :
+    0 ≤ truncated2Infinite G Λ p i j := by
+  unfold truncated2Infinite
+  have hset : ({i, j} : Finset V) = ({i} : Finset V) ∆ ({j} : Finset V) := by
+    ext x
+    simp only [Finset.mem_symmDiff, Finset.mem_insert, Finset.mem_singleton]
+    constructor
+    · rintro (rfl | rfl)
+      · exact Or.inl ⟨rfl, hij⟩
+      · exact Or.inr ⟨rfl, hij.symm⟩
+    · rintro (⟨rfl, _⟩ | ⟨rfl, _⟩)
+      · exact Or.inl rfl
+      · exact Or.inr rfl
+  rw [hset]
+  linarith [correlationInfinite_gks_second G Λ p hf {i} {j}]
+
+/-- **Nonnegativity for coincident sites**: $U_2(i, i) \ge 0$.
+On the diagonal `{i, i} = {i}` so $U_2(i, i) = M(i) - M(i)^2
+  = M(i)(1 - M(i)) \ge 0$ since $M(i) \in [0, 1]$. -/
+theorem truncated2Infinite_nonneg_of_eq
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : V) :
+    0 ≤ truncated2Infinite G Λ p i i := by
+  unfold truncated2Infinite
+  have hset : ({i, i} : Finset V) = {i} := by simp
+  rw [hset]
+  have h0 : 0 ≤ correlationInfinite G Λ p {i} :=
+    correlationInfinite_nonneg G Λ p hf {i}
+  have h1 : correlationInfinite G Λ p {i} ≤ 1 :=
+    correlationInfinite_le_one G Λ p {i}
+  nlinarith
+
+/-- **Nonnegativity of `truncated2Infinite`** (general): $U_2(i, j) \ge 0$
+for all `i, j : V`, combining the `_of_ne` and `_of_eq` cases. -/
+theorem truncated2Infinite_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
+    0 ≤ truncated2Infinite G Λ p i j := by
+  by_cases hij : i = j
+  · subst hij
+    exact truncated2Infinite_nonneg_of_eq G Λ p hf i
+  · exact truncated2Infinite_nonneg_of_ne G Λ p hf hij
+
+/-- **Exhaustion-independence of `truncated2Infinite`**: the value
+does not depend on the choice of exhaustion.  Follows from
+`correlationInfinite_indep_exhaustion` applied to each of the three
+`correlationInfinite` occurrences in the definition. -/
+theorem truncated2Infinite_indep_exhaustion
+    (G : SimpleGraph V) (Λ Λ' : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G (Λ'.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
+    truncated2Infinite G Λ p i j = truncated2Infinite G Λ' p i j := by
+  unfold truncated2Infinite
+  rw [correlationInfinite_indep_exhaustion G Λ Λ' p hf {i, j},
+      correlationInfinite_indep_exhaustion G Λ Λ' p hf {i},
+      correlationInfinite_indep_exhaustion G Λ Λ' p hf {j}]
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -223,6 +223,12 @@ ambient framework:
 | `spontaneousCorrelation_indep_exhaustion` | Λ-independence |
 | `tendsto_correlationInfinite_spontaneousCorrelation_nhdsGT` | Right-limit Tendsto: `⟨σ^A⟩(h) → ⟨σ^A⟩*` as `h → 0+` |
 | `spontaneousCorrelation_singleton_eq_spontaneousMagnetization` | `spontaneousCorrelation ... {i} = spontaneousMagnetization ... i` (definitional) |
+| **`truncated2Infinite`** | **Truncated 2-point correlation** `U_2(i,j) := ⟨σᵢσⱼ⟩_∞ - ⟨σᵢ⟩_∞⟨σⱼ⟩_∞` |
+| `truncated2Infinite_symm` | `U_2(i,j) = U_2(j,i)` |
+| `truncated2Infinite_nonneg_of_ne` | `i ≠ j ⇒ 0 ≤ U_2(i,j)` (direct GKS-II corollary) |
+| `truncated2Infinite_nonneg_of_eq` | `0 ≤ U_2(i,i) = M(i)(1-M(i))` |
+| **`truncated2Infinite_nonneg`** | **General nonneg**: `0 ≤ U_2(i,j)` for all `i, j` |
+| `truncated2Infinite_indep_exhaustion` | Λ-independence |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2628,4 +2628,31 @@ Friedli--Velenik \S 3.10.
 \end{itemize}
 \end{theorem}
 
+\subsection{Truncated 2-point correlation at infinite volume}
+
+参考: Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987),
+\S 4.2 p.\ 57ff (GKS-II); Friedli--Velenik \S 3.6.3.
+
+PR \#94 の \texttt{correlationInfinite\_gks\_second} を 2 点ケースに specialize.
+
+\begin{definition}[\texttt{truncated2Infinite}]
+\[
+U_2(G, \Lambda; p; i, j)
+  \;:=\; \langle \sigma_i \sigma_j \rangle_\infty
+    - \langle \sigma_i \rangle_\infty \langle \sigma_j \rangle_\infty.
+\]
+\end{definition}
+
+\begin{theorem}[\texttt{truncated2Infinite}の基本性質]
+\begin{itemize}
+\item \texttt{\_symm}: $U_2(i, j) = U_2(j, i)$ (\texttt{Finset.pair\_comm}).
+\item \texttt{\_nonneg\_of\_ne}: $i \ne j \Rightarrow U_2 \ge 0$
+      (\texttt{correlationInfinite\_gks\_second} 経由, $\{i,j\} = \{i\} \triangle \{j\}$).
+\item \texttt{\_nonneg\_of\_eq}: $U_2(i, i) = M(i)(1 - M(i)) \ge 0$
+      ($\{i, i\} = \{i\}$, $M \in [0, 1]$).
+\item \texttt{\_nonneg}: 任意の $i, j$ で $0 \le U_2(i, j)$ (上 2 つの統合).
+\item \texttt{\_indep\_exhaustion}: $\Lambda$ 非依存.
+\end{itemize}
+\end{theorem}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Introduce \`truncated2Infinite G Λ p i j := correlationInfinite {i,j} - correlationInfinite {i} * correlationInfinite {j}\` as the formal thermodynamic-limit truncated 2-point correlation $U_2$.
- Properties:
  - \`truncated2Infinite_symm\` (Finset.pair_comm + real mul comm)
  - \`truncated2Infinite_nonneg_of_ne\` (direct GKS-II corollary via {i,j} = {i} ∆ {j} for i ≠ j)
  - \`truncated2Infinite_indep_exhaustion\`
- Glimm-Jaffe §4.2 p. 57ff, Friedli-Velenik §3.6.3.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated with page numbers
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)