### PR TITLE
feat: spontaneous* J/β-direction monotonicity

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2406,7 +2406,13 @@ theorem spontaneousCorrelation_monotone_J
 
 /-- **β-direction monotonicity of `spontaneousCorrelation`**: for
 fixed `J ≥ 0`, the map `β ↦ spontaneousCorrelation G Λ J β A` is
-monotone on `Set.Ioi 0`. -/
+monotone on `Set.Ioi 0`.
+
+Companion to `spontaneousCorrelation_monotone_J`.  Since
+`correlationInfinite_monotone_beta` gives pointwise monotonicity in
+`β` for each `h ∈ Ioi 0` (with the remaining parameters bounded
+below by `0`), the iInf over `h > 0` is also monotone in `β`.
+Proof via `ciInf_mono` + `correlationInfinite_bddBelow_on_Ioi`. -/
 theorem spontaneousCorrelation_monotone_beta
     (G : SimpleGraph V) (Λ : Exhaustion V)
     [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2374,5 +2374,75 @@ theorem truncated4Infinite_indep_exhaustion
       correlationInfinite_indep_exhaustion G Λ Λ' p hf {i, l},
       correlationInfinite_indep_exhaustion G Λ Λ' p hf {j, k}]
 
+/-! ## Parameter monotonicity of `spontaneous*`
+
+Combine the parameter-direction monotonicity of `correlationInfinite`
+(PR #95–#97) with the infimum definition of `spontaneousCorrelation`
+to obtain monotonicity of the spontaneous correlation function in
+`J` and `β`.  The `h`-direction is already collapsed by the infimum
+over `h > 0`, so only `J` and `β` remain as free parameters. -/
+
+/-- **J-direction monotonicity of `spontaneousCorrelation`**: for
+fixed `β > 0`, $\langle \sigma^A \rangle^*(J, \beta)$ is monotone in
+$J \in \mathrm{Ici}\,0$.
+
+Since `correlationInfinite_monotone_J` gives pointwise monotonicity
+for each `h ∈ Ioi 0`, the iInf over `h > 0` is also monotone in `J`.
+Proof via `ciInf_mono` + `correlationInfinite_bddBelow_on_Ioi`. -/
+theorem spontaneousCorrelation_monotone_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β : ℝ} (hβ : 0 < β) (A : Finset V) :
+    MonotoneOn
+      (fun J : ℝ => spontaneousCorrelation G Λ J β A)
+      (Set.Ici 0) := by
+  intro J₁ hJ₁ J₂ _ hJ₁₂
+  unfold spontaneousCorrelation
+  refine ciInf_mono
+    (correlationInfinite_bddBelow_on_Ioi G Λ hJ₁ hβ A) ?_
+  intro h
+  exact correlationInfinite_monotone_J G Λ h.property.le hβ A
+    hJ₁ (hJ₁.trans hJ₁₂) hJ₁₂
+
+/-- **β-direction monotonicity of `spontaneousCorrelation`**: for
+fixed `J ≥ 0`, the map `β ↦ spontaneousCorrelation G Λ J β A` is
+monotone on `Set.Ioi 0`. -/
+theorem spontaneousCorrelation_monotone_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) (A : Finset V) :
+    MonotoneOn
+      (fun β : ℝ => spontaneousCorrelation G Λ J β A)
+      (Set.Ioi 0) := by
+  intro β₁ hβ₁ β₂ _ hβ₁₂
+  unfold spontaneousCorrelation
+  refine ciInf_mono
+    (correlationInfinite_bddBelow_on_Ioi G Λ hJ hβ₁ A) ?_
+  intro h
+  exact correlationInfinite_monotone_beta G Λ hJ h.property.le A
+    hβ₁ (lt_of_lt_of_le hβ₁ hβ₁₂) hβ₁₂
+
+/-- **J-direction monotonicity of `spontaneousMagnetization`**:
+specialization of `spontaneousCorrelation_monotone_J` at `A = {i}`. -/
+theorem spontaneousMagnetization_monotone_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β : ℝ} (hβ : 0 < β) (i : V) :
+    MonotoneOn
+      (fun J : ℝ => spontaneousMagnetization G Λ J β i)
+      (Set.Ici 0) :=
+  spontaneousCorrelation_monotone_J G Λ hβ {i}
+
+/-- **β-direction monotonicity of `spontaneousMagnetization`**:
+specialization of `spontaneousCorrelation_monotone_beta` at `A = {i}`. -/
+theorem spontaneousMagnetization_monotone_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) (i : V) :
+    MonotoneOn
+      (fun β : ℝ => spontaneousMagnetization G Λ J β i)
+      (Set.Ioi 0) :=
+  spontaneousCorrelation_monotone_beta G Λ hJ {i}
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -236,6 +236,9 @@ ambient framework:
 | **`truncated4Infinite`** | **Truncated 4-point correlation** `U_4(i,j,k,l) := ⟨σ^{i,j,k,l}⟩_∞ - ⟨σ^{i,j}⟩_∞⟨σ^{k,l}⟩_∞ - ⟨σ^{i,k}⟩_∞⟨σ^{j,l}⟩_∞ - ⟨σ^{i,l}⟩_∞⟨σ^{j,k}⟩_∞` |
 | **`truncated4Infinite_nonpos_h_zero`** | **Lebowitz/U_4 ≤ 0 at infinite volume** (Glimm–Jaffe §4.3 Cor 4.3.3 pp. 68ff): `h = 0` + pairwise distinct ⇒ `U_4 ≤ 0` |
 | `truncated4Infinite_indep_exhaustion` | Λ-independence |
+| `spontaneousCorrelation_monotone_J` | `MonotoneOn (J ↦ spontaneousCorrelation G Λ J β A) (Ici 0)` |
+| `spontaneousCorrelation_monotone_beta` | `MonotoneOn (β ↦ spontaneousCorrelation G Λ J β A) (Ioi 0)` |
+| `spontaneousMagnetization_monotone_{J,beta}` | Singleton specializations |
 
 ## Axioms
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -238,7 +238,8 @@ ambient framework:
 | `truncated4Infinite_indep_exhaustion` | Λ-independence |
 | `spontaneousCorrelation_monotone_J` | `MonotoneOn (J ↦ spontaneousCorrelation G Λ J β A) (Ici 0)` |
 | `spontaneousCorrelation_monotone_beta` | `MonotoneOn (β ↦ spontaneousCorrelation G Λ J β A) (Ioi 0)` |
-| `spontaneousMagnetization_monotone_{J,beta}` | Singleton specializations |
+| `spontaneousMagnetization_monotone_J` | Singleton specialization at `A = {i}` |
+| `spontaneousMagnetization_monotone_beta` | Singleton specialization at `A = {i}` |
 
 ## Axioms
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2734,8 +2734,12 @@ $J \ge 0$ 固定で
 $\texttt{MonotoneOn}\,(\beta \mapsto \langle \sigma^A \rangle^*)\,(\mathrm{Ioi}\,0)$.
 \end{theorem}
 
-\begin{theorem}[\texttt{spontaneousMagnetization\_monotone\_\{J,beta\}}]
-単サイト specialization.
+\begin{theorem}[\texttt{spontaneousMagnetization\_monotone\_J}]
+単サイト $A = \{i\}$ specialization of \texttt{spontaneousCorrelation\_monotone\_J}.
+\end{theorem}
+
+\begin{theorem}[\texttt{spontaneousMagnetization\_monotone\_beta}]
+単サイト $A = \{i\}$ specialization of \texttt{spontaneousCorrelation\_monotone\_beta}.
 \end{theorem}
 
 \end{document}

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2718,4 +2718,24 @@ $\texttt{truncated4AlongExhaustion} \to \texttt{truncated4Infinite}$.
 $\Lambda$ 非依存 (7 箇所).
 \end{theorem}
 
+\subsection{Parameter monotonicity of spontaneous*}
+
+参考: Glimm--Jaffe \S 5.1 p.\ 77.
+PR \#95-\#97 (correlationInfinite J/h/$\beta$) + PR \#99/\#101 (spontaneous).
+
+\begin{theorem}[\texttt{spontaneousCorrelation\_monotone\_J}]
+$\beta > 0$ 固定で
+$\texttt{MonotoneOn}\,(J \mapsto \langle \sigma^A \rangle^*)\,(\mathrm{Ici}\,0)$.
+各 $h > 0$ で $\texttt{correlationInfinite\_monotone\_J}$, \texttt{ciInf\_mono}.
+\end{theorem}
+
+\begin{theorem}[\texttt{spontaneousCorrelation\_monotone\_beta}]
+$J \ge 0$ 固定で
+$\texttt{MonotoneOn}\,(\beta \mapsto \langle \sigma^A \rangle^*)\,(\mathrm{Ioi}\,0)$.
+\end{theorem}
+
+\begin{theorem}[\texttt{spontaneousMagnetization\_monotone\_\{J,beta\}}]
+単サイト specialization.
+\end{theorem}
+
 \end{document}


### PR DESCRIPTION
## Summary

- Prove J/β-direction monotonicity for spontaneousCorrelation and spontaneousMagnetization.
- Follows from correlationInfinite_monotone_{J,beta} (PR #95-#97) applied pointwise + ciInf_mono.
- Completes the physical order-parameter monotonicity picture.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)