### PR TITLE
feat: h=0 specializations for truncated2Infinite

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1904,6 +1904,31 @@ theorem truncated2Infinite_indep_exhaustion
       correlationInfinite_indep_exhaustion G Λ Λ' p hf {i},
       correlationInfinite_indep_exhaustion G Λ Λ' p hf {j}]
 
+/-- **`truncated2Infinite` at `h = 0`**: since
+$\langle \sigma_i \rangle_\infty = \langle \sigma_j \rangle_\infty = 0$
+at $h = 0$ (singletons have odd cardinality 1, so
+`correlationInfinite_h_zero` applies), the truncated 2-point function
+reduces to the raw 2-point correlation:
+$U_2(i, j; \langle J, 0, \beta \rangle) = \langle \sigma_i \sigma_j \rangle_\infty$.
+
+Holds for all `i, j : V` (no distinctness needed): if `i = j`, both
+sides equal `correlationInfinite G Λ ⟨J, 0, β⟩ {i}` which is `0` by
+the same Z₂ argument.  Useful as a closed-form expression for the
+truncated correlation at zero external field (connects to
+susceptibility/fluctuation analysis). -/
+theorem truncated2Infinite_h_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i j : V) :
+    truncated2Infinite G Λ ⟨J, 0, β⟩ i j
+      = correlationInfinite G Λ ⟨J, 0, β⟩ {i, j} := by
+  unfold truncated2Infinite
+  have h_i : Odd ({i} : Finset V).card := by simp
+  have h_j : Odd ({j} : Finset V).card := by simp
+  rw [correlationInfinite_h_zero G Λ J β _ h_i,
+      correlationInfinite_h_zero G Λ J β _ h_j]
+  ring
+
 /-! ## Truncated 3-point correlation + GHS at infinite volume
 
 Lift the finite-volume GHS inequality (`ghs_inequality`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -229,6 +229,7 @@ ambient framework:
 | `truncated2Infinite_nonneg_of_eq` | `0 ≤ U_2(i,i) = M(i)(1-M(i))` |
 | **`truncated2Infinite_nonneg`** | **General nonneg**: `0 ≤ U_2(i,j)` for all `i, j` |
 | `truncated2Infinite_indep_exhaustion` | Λ-independence |
+| `truncated2Infinite_h_zero` | `h = 0` ⇒ `U_2 = ⟨σᵢσⱼ⟩_∞` (general; Z₂ collapses singletons) |
 | **`truncated3Infinite`** | **Truncated 3-point correlation** `U_3(i,j,k) := ⟨σ^{i,j,k}⟩_∞ - ⟨σ_i⟩_∞⟨σ^{j,k}⟩_∞ - ⟨σ_j⟩_∞⟨σ^{i,k}⟩_∞ - ⟨σ_k⟩_∞⟨σ^{i,j}⟩_∞ + 2⟨σ_i⟩_∞⟨σ_j⟩_∞⟨σ_k⟩_∞` |
 | **`truncated3Infinite_nonpos`** | **GHS at infinite volume** (Glimm–Jaffe §4.3 Cor 4.3.4 pp. 68ff): pairwise distinct ⇒ `U_3 ≤ 0` |
 | `truncated3Infinite_h_zero_of_distinct` | `h = 0` + distinct ⇒ `U_3 = 0` (Z₂ symmetry consequence) |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2652,6 +2652,8 @@ U_2(G, \Lambda; p; i, j)
       ($\{i, i\} = \{i\}$, $M \in [0, 1]$).
 \item \texttt{\_nonneg}: 任意の $i, j$ で $0 \le U_2(i, j)$ (上 2 つの統合).
 \item \texttt{\_indep\_exhaustion}: $\Lambda$ 非依存.
+\item \texttt{\_h\_zero}: $h = 0$ で $U_2 = \langle \sigma_i \sigma_j \rangle_\infty$
+      (任意 $i, j$; singletons vanish by Z₂, $\texttt{correlationInfinite\_h\_zero}$).
 \end{itemize}
 \end{theorem}
 


### PR DESCRIPTION
## Summary

- Add \`truncated2Infinite_h_zero_of_ne\`: at h = 0, for i ≠ j, $U_2 = \langle \sigma_i \sigma_j \rangle_\infty$ (since singletons vanish by Z₂).
- Small but physically meaningful: connects truncated correlation to the raw 2-point correlation at zero external field.
- Glimm-Jaffe §5.1 p. 77.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check
- [ ] Refactoring scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)