### PR TITLE
feat: liftFinset infrastructure (insert, sdiff) for future ∞-vol lifts

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -174,6 +174,33 @@ theorem liftFinset_symmDiff {Λ : Finset V} {A B : Finset V}
   ext x
   simp only [Finset.mem_symmDiff, mem_liftFinset]
 
+/-- `liftFinset` commutes with `insert`: if `a ∈ Λ` and `A ⊆ Λ` then
+`insert ⟨a, ha⟩ (liftFinset A hA) = liftFinset (insert a A) h_insert`. -/
+theorem liftFinset_insert {Λ : Finset V} {A : Finset V} {a : V}
+    (ha : a ∈ Λ) (hA : A ⊆ Λ) :
+    insert (⟨a, ha⟩ : (↑Λ : Type _)) (liftFinset A hA)
+      = liftFinset (insert a A)
+          (fun _ hx => (Finset.mem_insert.mp hx).elim
+            (fun h => h ▸ ha) (fun h => hA h)) := by
+  ext x
+  simp only [Finset.mem_insert, mem_liftFinset]
+  constructor
+  · rintro (rfl | hx)
+    · exact Or.inl rfl
+    · exact Or.inr hx
+  · rintro (rfl | hx)
+    · exact Or.inl (Subtype.ext rfl)
+    · exact Or.inr hx
+
+/-- `liftFinset` commutes with `sdiff` (set difference): if `A, B ⊆ Λ` then
+`liftFinset A hA \ liftFinset B hB = liftFinset (A \ B) h_sdiff`. -/
+theorem liftFinset_sdiff {Λ : Finset V} {A B : Finset V}
+    (hA : A ⊆ Λ) (hB : B ⊆ Λ) :
+    liftFinset A hA \ liftFinset B hB
+      = liftFinset (A \ B) (fun _ hx => hA (Finset.mem_sdiff.mp hx).1) := by
+  ext x
+  simp only [Finset.mem_sdiff, mem_liftFinset]
+
 /-- The correlation along an exhaustion, evaluated eventually (from the
 first `n` with `A ⊆ volume n`). Returns a function `ℕ → ℝ` which equals
 `correlationΛ G (volume n) p (liftFinset A _)` once `A ⊆ volume n`, and
@@ -2477,3 +2504,4 @@ theorem spontaneousMagnetization_monotone_beta
 
 end Ambient
 end IsingModel
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,6 +189,8 @@ ambient framework:
 | **`correlationInfinite_monotone_ambient_subgraph`** | **Ambient-subgraph monotonicity at infinite volume**: `G₁ ≤ G₂` ⇒ `correlationInfinite G₁ Λ ≤ correlationInfinite G₂ Λ` |
 | `mem_liftFinset` | membership characterization: `x ∈ liftFinset A hA ↔ x.val ∈ A` |
 | `liftFinset_symmDiff` | `liftFinset` commutes with `∆`: `liftFinset A ∆ liftFinset B = liftFinset (A ∆ B)` |
+| `liftFinset_insert` | `insert ⟨a, ha⟩ (liftFinset A) = liftFinset (insert a A)` |
+| `liftFinset_sdiff` | `liftFinset A \ liftFinset B = liftFinset (A \ B)` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |


### PR DESCRIPTION
## Summary

Add two Finset infrastructure lemmas:
- \`liftFinset_insert\`: \`insert ⟨a, ha⟩ (liftFinset A hA) = liftFinset (insert a A) h_insert\`
- \`liftFinset_sdiff\`: \`liftFinset A \\ liftFinset B = liftFinset (A \\ B) h_sdiff\`

These generalize the existing \`liftFinset_symmDiff\` (PR #94) pattern for use in future infinite-volume lifts that require compound set operations.

## Motivation

Attempted PR for Cor 4.3.5 (inductive n-point at h=0, Glimm-Jaffe §4.3 p. 62) infinite-volume lift revealed that the proof requires:
1. Powerset sum reindexing via \`Finset.sum_bij\`
2. Compound liftFinset identifications for \`insert j (insert k S)\`, \`insert j T\`, \`insert k (S \\ T)\`

This PR provides the lemmas needed for (2); the full Cor 4.3.5 lift is deferred to a follow-up (complexity requires dedicated PR scope).

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot --allow-all-tools -p\` substantive cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)