### PR TITLE
feat: freeEnergyAlongExhaustion infrastructure (§4.6 Prop 4.6.1 scaffold)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -214,6 +214,31 @@ noncomputable def correlationAlongExhaustion
       correlationΛ G (Λ.volume n) p (liftFinset A h)
     else 0
 
+/-- **Free energy along an exhaustion**: the volume-direction free
+energy density sequence $f_n := f_{\Lambda_n}$ whose convergence
+Glimm–Jaffe §4.6 Proposition 4.6.1 (pp. 78ff) asserts.
+
+This is the scaffold object; the full convergence theorem (volume
+direction, genuine `Λ ↑ V`) requires subadditivity of `log Z`
+combined with Fekete's lemma and is deferred to a follow-up PR. -/
+noncomputable def freeEnergyAlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) : ℕ → ℝ :=
+  fun n => freeEnergyΛ G (Λ.volume n) p
+
+/-- **Unfolding of `freeEnergyAlongExhaustion`**: by construction, equal
+to `freeEnergyΛ` at the `n`-th volume of the exhaustion.  Marked `@[simp]`
+(unconditional `rfl`-proved unfolding) for ergonomic downstream use in
+the Fekete/subadditivity follow-up. -/
+@[simp]
+theorem freeEnergyAlongExhaustion_apply
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ p n = freeEnergyΛ G (Λ.volume n) p :=
+  rfl
+
 /-- Unfold `correlationAlongExhaustion` when `A ⊆ Λ.volume n`:
 it equals the lifted finite-volume correlation. -/
 theorem correlationAlongExhaustion_of_subset

--- a/docs/index.md
+++ b/docs/index.md
@@ -192,6 +192,8 @@ ambient framework:
 | `liftFinset_insert` | `insert ⟨a, ha⟩ (liftFinset A) = liftFinset (insert a A)` |
 | `liftFinset_sdiff` | `liftFinset A \ liftFinset B = liftFinset (A \ B)` |
 | **`correlationInfinite_cor_4_3_5_h0`** | **Cor 4.3.5 at infinite volume** (Glimm–Jaffe §4.3 Cor 4.3.5 p. 62): inductive (n+2)-point bound at `h = 0` |
+| `freeEnergyAlongExhaustion` | Free energy density sequence `n ↦ freeEnergyΛ G (Λ.volume n) p` (scaffold for §4.6 Prop 4.6.1 ∞-vol lift) |
+| `freeEnergyAlongExhaustion_apply` | Definitional unfolding (simp): `= freeEnergyΛ G (Λ.volume n) p` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2744,6 +2744,21 @@ $\texttt{MonotoneOn}\,(\beta \mapsto \langle \sigma^A \rangle^*)\,(\mathrm{Ioi}\
 単サイト $A = \{i\}$ specialization of \texttt{spontaneousCorrelation\_monotone\_beta}.
 \end{theorem}
 
+\subsection{freeEnergyAlongExhaustion (§4.6 Prop 4.6.1 scaffold)}
+
+参考: Glimm--Jaffe \S 4.6 Proposition 4.6.1, pp.\ 78ff
+(volume 方向 free energy 収束).
+
+\begin{definition}[\texttt{freeEnergyAlongExhaustion}]
+\[
+\texttt{freeEnergyAlongExhaustion}\,G\,\Lambda\,p\,n
+  \;:=\; \texttt{freeEnergyΛ}\,G\,(\Lambda.\text{volume}\,n)\,p.
+\]
+\end{definition}
+
+本 PR は scaffold. 完全 convergence 証明 (subadditivity + Fekete) は
+deferred.
+
 \subsection{Cor 4.3.5 (inductive n-point at $h = 0$) at infinite volume}
 
 参考: Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987),


### PR DESCRIPTION
## Summary

Infrastructure step toward Glimm-Jaffe §4.6 Prop 4.6.1 genuine ∞-vol lift.

Defines \`freeEnergyAlongExhaustion G Λ p n := freeEnergyΛ G (Λ.volume n) p\` — the sequence whose convergence Prop 4.6.1 asserts. Full convergence proof (requires subadditivity + Fekete's lemma, substantial) is deferred to a dedicated follow-up PR.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated with page numbers
- [ ] \`copilot --allow-all-tools -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)