### PR TITLE
feat: partitionFunctionAlongExhaustion scaffold (§4.6 Prop 4.6.1 #2)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -239,6 +239,37 @@ theorem freeEnergyAlongExhaustion_apply
     freeEnergyAlongExhaustion G Λ p n = freeEnergyΛ G (Λ.volume n) p :=
   rfl
 
+/-- **Partition function along an exhaustion**: the volume-direction
+partition function sequence $Z_n := Z_{\Lambda_n}$.  Companion to
+`freeEnergyAlongExhaustion` (Glimm–Jaffe §4.6); useful for Prop 4.6.1
+∞-vol proofs that decompose `freeEnergy = log Z / |Λ|`. -/
+noncomputable def partitionFunctionAlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) : ℕ → ℝ :=
+  fun n => partitionFunctionΛ G (Λ.volume n) p
+
+/-- **Unfolding of `partitionFunctionAlongExhaustion`**: by construction
+equal to `partitionFunctionΛ` at the `n`-th volume.  Unconditional
+`rfl`-proof, marked `@[simp]`. -/
+@[simp]
+theorem partitionFunctionAlongExhaustion_apply
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (n : ℕ) :
+    partitionFunctionAlongExhaustion G Λ p n
+      = partitionFunctionΛ G (Λ.volume n) p :=
+  rfl
+
+/-- **Positivity along an exhaustion**:
+`0 < partitionFunctionAlongExhaustion G Λ p n` for every `n`. -/
+theorem partitionFunctionAlongExhaustion_pos
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (n : ℕ) :
+    0 < partitionFunctionAlongExhaustion G Λ p n :=
+  partitionFunctionΛ_pos G (Λ.volume n) p
+
 /-- Unfold `correlationAlongExhaustion` when `A ⊆ Λ.volume n`:
 it equals the lifted finite-volume correlation. -/
 theorem correlationAlongExhaustion_of_subset

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,6 +194,9 @@ ambient framework:
 | **`correlationInfinite_cor_4_3_5_h0`** | **Cor 4.3.5 at infinite volume** (Glimm–Jaffe §4.3 Cor 4.3.5 p. 62): inductive (n+2)-point bound at `h = 0` |
 | `freeEnergyAlongExhaustion` | Free energy density sequence `n ↦ freeEnergyΛ G (Λ.volume n) p` (scaffold for §4.6 Prop 4.6.1 ∞-vol lift) |
 | `freeEnergyAlongExhaustion_apply` | Definitional unfolding (simp): `= freeEnergyΛ G (Λ.volume n) p` |
+| `partitionFunctionAlongExhaustion` | Partition function sequence `n ↦ partitionFunctionΛ G (Λ.volume n) p` (§4.6 Prop 4.6.1 scaffold #2) |
+| `partitionFunctionAlongExhaustion_apply` | Definitional unfolding (simp) |
+| `partitionFunctionAlongExhaustion_pos` | `0 < partitionFunctionAlongExhaustion` for every `n` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2780,6 +2780,14 @@ GKS-II は HNC / Boltzmann weight log-supermodularity で証明される
 \]
 \end{definition}
 
+\begin{definition}[\texttt{partitionFunctionAlongExhaustion}]
+\[
+\texttt{partitionFunctionAlongExhaustion}\,G\,\Lambda\,p\,n
+  \;:=\; \texttt{partitionFunctionΛ}\,G\,(\Lambda.\text{volume}\,n)\,p.
+\]
+$0 <$ positivity trivial from \texttt{partitionFunctionΛ\_pos}.
+\end{definition}
+
 本 PR は scaffold. 完全 convergence 証明 (subadditivity + Fekete) は
 deferred.
 


### PR DESCRIPTION
## Summary

Second scaffold PR toward §4.6 Prop 4.6.1 ∞-vol lift (after PR #109 `freeEnergyAlongExhaustion`).

Adds the partition-function sequence along an exhaustion:
- \`partitionFunctionAlongExhaustion G Λ p n := partitionFunctionΛ G (Λ.volume n) p\`
- \`partitionFunctionAlongExhaustion_apply\` (simp, rfl)
- \`partitionFunctionAlongExhaustion_pos\` (trivial from partitionFunctionΛ_pos)

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot --allow-all-tools -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)