### PR TITLE
feat: freeEnergyAlongExhaustion subgraph monotonicity

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -371,6 +371,20 @@ theorem freeEnergyΛ_monotone_ambient_subgraph
     freeEnergyΛ G₁ Λ p ≤ freeEnergyΛ G₂ Λ p :=
   IsingModel.freeEnergy_monotone_subgraph (inducedGraph_mono h Λ) p hf
 
+/-- **Subgraph monotonicity of `freeEnergyAlongExhaustion`**: for
+`G₁ ≤ G₂` and ferromagnetic parameters, the free energy along the
+exhaustion is pointwise monotone in the ambient subgraph. Direct
+specialization of `freeEnergyΛ_monotone_ambient_subgraph` at each
+`Λ.volume n`. -/
+theorem freeEnergyAlongExhaustion_monotone_ambient_subgraph
+    {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G₂ (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ) :
+    freeEnergyAlongExhaustion G₁ Λ p n
+      ≤ freeEnergyAlongExhaustion G₂ Λ p n :=
+  freeEnergyΛ_monotone_ambient_subgraph h (Λ.volume n) p hf
+
 /-! ## Extension of a Λ₁-graph to Λ₂ (for volume-direction monotonicity)
 
 For `Λ₁ ⊆ Λ₂` and `G : SimpleGraph V`, we construct a graph on

--- a/docs/index.md
+++ b/docs/index.md
@@ -197,6 +197,7 @@ ambient framework:
 | `partitionFunctionAlongExhaustion` | Partition function sequence `n ↦ partitionFunctionΛ G (Λ.volume n) p` (§4.6 Prop 4.6.1 scaffold #2) |
 | `partitionFunctionAlongExhaustion_apply` | Definitional unfolding (simp) |
 | `partitionFunctionAlongExhaustion_pos` | `0 < partitionFunctionAlongExhaustion` for every `n` |
+| `freeEnergyAlongExhaustion_monotone_ambient_subgraph` | `G₁ ≤ G₂` ⇒ pointwise `freeEnergyAlongExhaustion G₁ Λ p n ≤ freeEnergyAlongExhaustion G₂ Λ p n` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2788,6 +2788,12 @@ GKS-II は HNC / Boltzmann weight log-supermodularity で証明される
 $0 <$ positivity trivial from \texttt{partitionFunctionΛ\_pos}.
 \end{definition}
 
+\begin{theorem}[\texttt{freeEnergyAlongExhaustion\_monotone\_ambient\_subgraph}]
+$G_1 \le G_2$ のとき任意の $n$ で pointwise monotone.
+\texttt{freeEnergyΛ\_monotone\_ambient\_subgraph} を各 $\Lambda.\text{volume}\,n$
+で specialize.
+\end{theorem}
+
 本 PR は scaffold. 完全 convergence 証明 (subadditivity + Fekete) は
 deferred.
 


### PR DESCRIPTION
## Summary

Add pointwise subgraph monotonicity for \`freeEnergyAlongExhaustion\` (PR #109 scaffold):
\`G₁ ≤ G₂ ⇒ ∀ n, freeEnergyAlongExhaustion G₁ Λ p n ≤ freeEnergyAlongExhaustion G₂ Λ p n\`

Simple 5-line theorem using existing \`freeEnergyΛ_monotone_ambient_subgraph\`.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot --allow-all-tools -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)