### PR TITLE
feat: partitionFunction subgraph monotonicity + freeEnergy log-bridge (§4.6 scaffold)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -385,6 +385,35 @@ theorem freeEnergyAlongExhaustion_monotone_ambient_subgraph
       ≤ freeEnergyAlongExhaustion G₂ Λ p n :=
   freeEnergyΛ_monotone_ambient_subgraph h (Λ.volume n) p hf
 
+/-- **Subgraph monotonicity of `partitionFunctionAlongExhaustion`**:
+for `G₁ ≤ G₂` and ferromagnetic parameters, the partition function
+along the exhaustion is pointwise monotone in the ambient subgraph.
+Direct specialization of `partitionFunctionΛ_monotone_ambient_subgraph`
+at each `Λ.volume n`. -/
+theorem partitionFunctionAlongExhaustion_monotone_ambient_subgraph
+    {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G₂ (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ) :
+    partitionFunctionAlongExhaustion G₁ Λ p n
+      ≤ partitionFunctionAlongExhaustion G₂ Λ p n :=
+  partitionFunctionΛ_monotone_ambient_subgraph h (Λ.volume n) p hf
+
+/-- **Log-bridge identity**: the `freeEnergyAlongExhaustion` sequence
+is the log of the `partitionFunctionAlongExhaustion` sequence divided
+by the cardinality of the volume.  Direct unfolding of the underlying
+`IsingModel.freeEnergy` definition (log-partition function per site). -/
+theorem freeEnergyAlongExhaustion_eq_log_div_card
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ p n =
+      (Fintype.card (↑(Λ.volume n) : Type _) : ℝ)⁻¹ *
+        Real.log (partitionFunctionAlongExhaustion G Λ p n) := by
+  simp only [freeEnergyAlongExhaustion_apply,
+    partitionFunctionAlongExhaustion_apply, freeEnergyΛ,
+    partitionFunctionΛ, IsingModel.freeEnergy]
+
 /-! ## Extension of a Λ₁-graph to Λ₂ (for volume-direction monotonicity)
 
 For `Λ₁ ⊆ Λ₂` and `G : SimpleGraph V`, we construct a graph on

--- a/docs/index.md
+++ b/docs/index.md
@@ -198,6 +198,8 @@ ambient framework:
 | `partitionFunctionAlongExhaustion_apply` | Definitional unfolding (simp) |
 | `partitionFunctionAlongExhaustion_pos` | `0 < partitionFunctionAlongExhaustion` for every `n` |
 | `freeEnergyAlongExhaustion_monotone_ambient_subgraph` | `G₁ ≤ G₂` ⇒ pointwise `freeEnergyAlongExhaustion G₁ Λ p n ≤ freeEnergyAlongExhaustion G₂ Λ p n` |
+| `partitionFunctionAlongExhaustion_monotone_ambient_subgraph` | Partition-function analog of above |
+| `freeEnergyAlongExhaustion_eq_log_div_card` | Log-bridge: `freeEnergyAlongExhaustion = log(partitionFunctionAlongExhaustion) / |Λ.volume n|` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2794,6 +2794,17 @@ $G_1 \le G_2$ のとき任意の $n$ で pointwise monotone.
 で specialize.
 \end{theorem}
 
+\begin{theorem}[\texttt{partitionFunctionAlongExhaustion\_monotone\_ambient\_subgraph}]
+$G_1 \le G_2$ のとき任意の $n$ で $Z_{G_1}(\Lambda_n) \le Z_{G_2}(\Lambda_n)$.
+\end{theorem}
+
+\begin{theorem}[\texttt{freeEnergyAlongExhaustion\_eq\_log\_div\_card}]
+\[
+f_n = |\Lambda.\text{volume}\,n|^{-1} \cdot \log Z_n.
+\]
+\texttt{IsingModel.freeEnergy} 定義の展開.
+\end{theorem}
+
 本 PR は scaffold. 完全 convergence 証明 (subadditivity + Fekete) は
 deferred.
 


### PR DESCRIPTION
## Summary

Two §4.6 Prop 4.6.1 scaffold lemmas (after PR #109/#111/#112):

1. \`partitionFunctionAlongExhaustion_monotone_ambient_subgraph\` (partition function analog of PR #112).
2. \`freeEnergyAlongExhaustion_eq_log_div_card\` — explicit bridge between free energy and log(partition function)/|Λ.volume n|.

Both are short direct specializations/unfoldings.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` + \`tex/proof-guide.tex\` updated
- [ ] \`copilot --allow-all-tools -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)