### PR TITLE
feat: freeEnergyAlongExhaustion J/h/β monotonicity

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -414,6 +414,43 @@ theorem freeEnergyAlongExhaustion_eq_log_div_card
     partitionFunctionAlongExhaustion_apply, freeEnergyΛ,
     partitionFunctionΛ, IsingModel.freeEnergy]
 
+/-- **J-direction monotonicity of `freeEnergyAlongExhaustion`**: for
+fixed `h ≥ 0`, `β > 0`, and any `n`, the free energy along the
+exhaustion is monotone in `J ∈ Set.Ici 0`.  Direct specialization of
+`IsingModel.freeEnergy_monotone_J`. -/
+theorem freeEnergyAlongExhaustion_monotone_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β) (n : ℕ) :
+    MonotoneOn
+      (fun J : ℝ => freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n)
+      (Set.Ici 0) :=
+  IsingModel.freeEnergy_monotone_J (inducedGraph G (Λ.volume n)) h β hh hβ
+
+/-- **h-direction monotonicity of `freeEnergyAlongExhaustion`**: for
+fixed `J ≥ 0`, `β > 0`, and any `n`, the free energy along the
+exhaustion is monotone in `h ∈ Set.Ici 0`. -/
+theorem freeEnergyAlongExhaustion_monotone_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (n : ℕ) :
+    MonotoneOn
+      (fun h : ℝ => freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n)
+      (Set.Ici 0) :=
+  IsingModel.freeEnergy_monotone_h (inducedGraph G (Λ.volume n)) J β hJ hβ
+
+/-- **β-direction monotonicity of `freeEnergyAlongExhaustion`**: for
+fixed `J ≥ 0`, `h ≥ 0`, and any `n`, the free energy along the
+exhaustion is monotone in `β ∈ Set.Ioi 0`. -/
+theorem freeEnergyAlongExhaustion_monotone_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {h : ℝ} (hh : 0 ≤ h) (n : ℕ) :
+    MonotoneOn
+      (fun β : ℝ => freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n)
+      (Set.Ioi 0) :=
+  IsingModel.freeEnergy_monotone_beta (inducedGraph G (Λ.volume n)) J hJ h hh
+
 /-! ## Extension of a Λ₁-graph to Λ₂ (for volume-direction monotonicity)
 
 For `Λ₁ ⊆ Λ₂` and `G : SimpleGraph V`, we construct a graph on

--- a/docs/index.md
+++ b/docs/index.md
@@ -200,6 +200,9 @@ ambient framework:
 | `freeEnergyAlongExhaustion_monotone_ambient_subgraph` | `G₁ ≤ G₂` ⇒ pointwise `freeEnergyAlongExhaustion G₁ Λ p n ≤ freeEnergyAlongExhaustion G₂ Λ p n` |
 | `partitionFunctionAlongExhaustion_monotone_ambient_subgraph` | Partition-function analog of above |
 | `freeEnergyAlongExhaustion_eq_log_div_card` | Log-bridge: `freeEnergyAlongExhaustion = log(partitionFunctionAlongExhaustion) / |Λ.volume n|` |
+| `freeEnergyAlongExhaustion_monotone_J` | MonotoneOn (Ici 0) for fixed h ≥ 0, β > 0 |
+| `freeEnergyAlongExhaustion_monotone_h` | MonotoneOn (Ici 0) for fixed J ≥ 0, β > 0 |
+| `freeEnergyAlongExhaustion_monotone_beta` | MonotoneOn (Ioi 0) for fixed J ≥ 0, h ≥ 0 |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |


### PR DESCRIPTION
## Summary

Add J/h/β-direction monotonicity for \`freeEnergyAlongExhaustion\`:
- \`freeEnergyAlongExhaustion_monotone_J\` (MonotoneOn (Ici 0))
- \`freeEnergyAlongExhaustion_monotone_h\` (MonotoneOn (Ici 0))
- \`freeEnergyAlongExhaustion_monotone_beta\` (MonotoneOn (Ioi 0))

Each a direct specialization of the finite-volume \`freeEnergy_monotone_{J,h,beta}\` at \`inducedGraph G (Λ.volume n)\`.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` updated
- [ ] \`copilot --allow-all-tools -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)