### PR TITLE
feat: freeEnergyInfinite via limsup (§4.6 Prop 4.6.1 API anchor)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2898,6 +2898,20 @@ theorem correlationInfinite_cor_4_3_5_h0
         (correlationAlongExhaustion_nonneg G Λ p hf _ n)
     linarith
 
+/-- **Infinite-volume free energy density** (limsup form).
+
+Defined as the `Filter.limsup` of `freeEnergyAlongExhaustion`, which
+is always well-defined for real sequences (even non-convergent ones).
+Glimm–Jaffe Proposition 4.6.1 asserts that this limsup equals the
+liminf (i.e., the sequence converges); the convergence theorem itself
+is deferred pending partition function super-additivity + Fekete's
+lemma machinery. -/
+noncomputable def freeEnergyInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) : ℝ :=
+  Filter.limsup (freeEnergyAlongExhaustion G Λ p) Filter.atTop
+
 end Ambient
 end IsingModel
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -206,6 +206,7 @@ ambient framework:
 | `partitionFunctionAlongExhaustion_monotone_J` | Pointwise J-monotone (h ≥ 0, β > 0, 0 ≤ J₁ ≤ J₂) |
 | `partitionFunctionAlongExhaustion_monotone_h` | Pointwise h-monotone (J ≥ 0, β > 0, 0 ≤ h₁ ≤ h₂) |
 | `partitionFunctionAlongExhaustion_monotone_beta` | Pointwise β-monotone (J ≥ 0, h ≥ 0, 0 < β₁ ≤ β₂) |
+| `freeEnergyInfinite` | `limsup freeEnergyAlongExhaustion` — API anchor for §4.6 Prop 4.6.1 (convergence pending) |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |


### PR DESCRIPTION
## Summary

Define \`freeEnergyInfinite\` as the \`Filter.limsup\` of \`freeEnergyAlongExhaustion\`. Establishes the API target object for Glimm-Jaffe §4.6 Prop 4.6.1 (convergence theorem) without requiring convergence to be proved yet.

\`limsup\` is always defined for real sequences (even non-convergent), so downstream code can reference \`freeEnergyInfinite\` immediately. The full Prop 4.6.1 (liminf = limsup) remains deferred.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter warning 0
- [ ] \`docs/index.md\` updated
- [ ] \`copilot --allow-all-tools -p\` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)