### PR TITLE
feat: partitionFunctionAlongExhaustion zero-params comparison

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2939,6 +2939,23 @@ theorem freeEnergyAlongExhaustion_ge_zero_params
       (Set.self_mem_Ici) hJ hJ
   exact h1.trans h2
 
+/-- **Zero-params lower-bound comparison for `partitionFunctionAlongExhaustion`**
+(partition function analog of `freeEnergyAlongExhaustion_ge_zero_params`).
+For ferromagnetic, `Z(0, 0, β) ≤ Z(J, h, β)`. -/
+theorem partitionFunctionAlongExhaustion_ge_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (n : ℕ) :
+    partitionFunctionAlongExhaustion G Λ ⟨0, 0, β⟩ n
+      ≤ partitionFunctionAlongExhaustion G Λ ⟨J, h, β⟩ n := by
+  have h1 : partitionFunctionAlongExhaustion G Λ ⟨0, 0, β⟩ n
+      ≤ partitionFunctionAlongExhaustion G Λ ⟨0, h, β⟩ n :=
+    partitionFunctionAlongExhaustion_monotone_h G Λ 0 β le_rfl hβ le_rfl hh n
+  have h2 : partitionFunctionAlongExhaustion G Λ ⟨0, h, β⟩ n
+      ≤ partitionFunctionAlongExhaustion G Λ ⟨J, h, β⟩ n :=
+    partitionFunctionAlongExhaustion_monotone_J G Λ h β hh hβ le_rfl hJ n
+  exact h1.trans h2
+
 end Ambient
 end IsingModel
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -208,6 +208,7 @@ ambient framework:
 | `partitionFunctionAlongExhaustion_monotone_beta` | Pointwise β-monotone (J ≥ 0, h ≥ 0, 0 < β₁ ≤ β₂) |
 | `freeEnergyInfinite` | `limsup freeEnergyAlongExhaustion` — API anchor for §4.6 Prop 4.6.1 (convergence pending) |
 | `freeEnergyAlongExhaustion_ge_zero_params` | Zero-params comparison: `f(0,0,β) ≤ f(J,h,β)` for ferromagnetic |
+| `partitionFunctionAlongExhaustion_ge_zero_params` | Zero-params comparison: `Z(0,0,β) ≤ Z(J,h,β)` for ferromagnetic |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |


### PR DESCRIPTION
## Summary

Partition function analog of PR #117 free energy: for ferromagnetic,
\`Z(0, 0, β; n) ≤ Z(J, h, β; n)\`.

Transitive composition of PR #115 \`partitionFunctionAlongExhaustion_monotone_{J,h}\`.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter
- [ ] \`docs/index.md\` updated
- [ ] \`copilot\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)