### PR TITLE
feat: partitionFunction at zero params equals |Config|

### DIFF
--- a/IsingModel/GibbsMeasure.lean
+++ b/IsingModel/GibbsMeasure.lean
@@ -96,4 +96,32 @@ theorem spinProduct_sq (A : Finset ι) (σ : Config ι) :
   exact Finset.prod_eq_one fun i _ => by
     simp [← sq, ← Int.cast_pow, Spin.toSign_sq]
 
+omit [DecidableEq ι] in
+/-- **Hamiltonian vanishes at zero parameters**: with `J = 0` and `h = 0`,
+the Hamiltonian is identically zero (no coupling, no field). -/
+theorem hamiltonian_zero_params (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (β : ℝ) (σ : Config ι) :
+    hamiltonian G (⟨0, 0, β⟩ : IsingParams ℝ) σ = 0 := by
+  unfold hamiltonian interactionEnergy externalFieldEnergy
+  simp
+
+/-- **Partition function at zero parameters**: with `J = 0` and `h = 0`,
+the Hamiltonian is identically zero, so every Boltzmann weight equals 1
+and the partition function counts the configurations:
+`Z_G(⟨0, 0, β⟩) = Fintype.card (Config ι)`. -/
+theorem partitionFunction_zero_params (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (β : ℝ) :
+    partitionFunction G (⟨0, 0, β⟩ : IsingParams ℝ)
+      = (Fintype.card (Config ι) : ℝ) := by
+  unfold partitionFunction boltzmannWeight
+  calc ∑ σ : Config ι,
+        Real.exp (-(⟨0, 0, β⟩ : IsingParams ℝ).β *
+          hamiltonian G (⟨0, 0, β⟩ : IsingParams ℝ) σ)
+      = ∑ _σ : Config ι, (1 : ℝ) := by
+        refine Finset.sum_congr rfl ?_
+        intro σ _
+        rw [hamiltonian_zero_params, mul_zero, Real.exp_zero]
+    _ = (Fintype.card (Config ι) : ℝ) := by
+        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one]
+
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -209,6 +209,8 @@ ambient framework:
 | `freeEnergyInfinite` | `limsup freeEnergyAlongExhaustion` — API anchor for §4.6 Prop 4.6.1 (convergence pending) |
 | `freeEnergyAlongExhaustion_ge_zero_params` | Zero-params comparison: `f(0,0,β) ≤ f(J,h,β)` for ferromagnetic |
 | `partitionFunctionAlongExhaustion_ge_zero_params` | Zero-params comparison: `Z(0,0,β) ≤ Z(J,h,β)` for ferromagnetic |
+| `hamiltonian_zero_params` (GibbsMeasure.lean) | `hamiltonian G ⟨0, 0, β⟩ σ = 0` identically |
+| `partitionFunction_zero_params` (GibbsMeasure.lean) | `Z G ⟨0, 0, β⟩ = Fintype.card (Config ι)` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |


### PR DESCRIPTION
## Summary

Finite-volume identity: \`partitionFunction G ⟨0, 0, β⟩ = Fintype.card (Config ι)\`.

At zero J and h, the Hamiltonian vanishes identically, so the Boltzmann weight is 1 and Z = Σ 1 = |Config|.

Useful building block for §4.6 Prop 4.6.1 lower-bound computation (since |Config ι| = 2^|ι|).

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter
- [ ] \`docs/index.md\` updated
- [ ] \`copilot\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)