### PR TITLE
feat: freeEnergy at zero params = log 2 (for nonempty ι)

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -656,4 +656,22 @@ theorem freeEnergy_convergent_subgraph
      fun _ ⟨n, hn⟩ => hn ▸ freeEnergy_monotone_subgraph le_top p hf⟩
   exact ⟨_, tendsto_atTop_ciSup h_mono h_bdd⟩
 
+/-- **Free energy at zero parameters**: for nonempty lattice `ι` with
+`0 < Fintype.card ι`, `freeEnergy G ⟨0, 0, β⟩ = log 2`.
+
+Combines `partitionFunction_zero_params` (Z = |Config ι|) with
+`card_config_eq_two_pow` (|Config ι| = 2^|ι|) and
+`Real.log_pow` (log(2^|ι|) = |ι| · log 2); the `|ι|⁻¹` prefix then
+cancels to give `log 2`. -/
+theorem freeEnergy_zero_params (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (β : ℝ) (hne : 0 < Fintype.card ι) :
+    freeEnergy G (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2 := by
+  unfold freeEnergy
+  rw [partitionFunction_zero_params, card_config_eq_two_pow]
+  push_cast
+  rw [Real.log_pow]
+  have hcard : (Fintype.card ι : ℝ) ≠ 0 := by
+    exact_mod_cast hne.ne'
+  field_simp
+
 end IsingModel

--- a/IsingModel/GibbsMeasure.lean
+++ b/IsingModel/GibbsMeasure.lean
@@ -124,4 +124,13 @@ theorem partitionFunction_zero_params (G : SimpleGraph ι) [Fintype G.edgeSet]
     _ = (Fintype.card (Config ι) : ℝ) := by
         rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one]
 
+/-- **Cardinality of `Spin` is 2**. -/
+theorem card_spin : Fintype.card Spin = 2 := rfl
+
+/-- **Cardinality of the configuration space**: `Config ι = ι → Spin`
+is finite of size `2^(Fintype.card ι)`. -/
+theorem card_config_eq_two_pow :
+    Fintype.card (Config ι) = 2 ^ Fintype.card ι := by
+  simp [Config, card_spin]
+
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,6 +211,9 @@ ambient framework:
 | `partitionFunctionAlongExhaustion_ge_zero_params` | Zero-params comparison: `Z(0,0,β) ≤ Z(J,h,β)` for ferromagnetic |
 | `hamiltonian_zero_params` (GibbsMeasure.lean) | `hamiltonian G ⟨0, 0, β⟩ σ = 0` identically |
 | `partitionFunction_zero_params` (GibbsMeasure.lean) | `Z G ⟨0, 0, β⟩ = Fintype.card (Config ι)` |
+| `card_spin` (GibbsMeasure.lean) | `Fintype.card Spin = 2` |
+| `card_config_eq_two_pow` (GibbsMeasure.lean) | `Fintype.card (Config ι) = 2 ^ Fintype.card ι` |
+| `freeEnergy_zero_params` (FreeEnergy.lean) | `freeEnergy G ⟨0, 0, β⟩ = log 2` (for nonempty ι) |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |


### PR DESCRIPTION
## Summary

Complete §4.6 Prop 4.6.1 concrete lower-bound: derive from PR #119 the explicit value at zero parameters.

- card_config_eq_two_pow: \`Fintype.card (Config ι) = 2^(Fintype.card ι)\`
- freeEnergy_zero_params: for \`0 < Fintype.card ι\`, \`freeEnergy G ⟨0, 0, β⟩ = Real.log 2\`.

Combined with PR #117 zero-params comparison, this gives a uniform lower bound \`freeEnergyAlongExhaustion ≥ log 2\` for ferromagnetic.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter
- [ ] docs/index.md updated
- [ ] \`copilot\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)