### PR TITLE
feat: freeEnergyAlongExhaustion ≥ log 2 uniform lower bound

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2956,6 +2956,32 @@ theorem partitionFunctionAlongExhaustion_ge_zero_params
     partitionFunctionAlongExhaustion_monotone_J G Λ h β hh hβ le_rfl hJ n
   exact h1.trans h2
 
+/-- **Uniform lower bound** `freeEnergyAlongExhaustion ≥ log 2` for
+ferromagnetic parameters on a nonempty volume.
+
+Combines the zero-params comparison
+(`freeEnergyAlongExhaustion_ge_zero_params`, PR #117) with the
+explicit value at zero parameters (`freeEnergy_zero_params = log 2`,
+PR #120) via `IsingModel.freeEnergy` definitional unfolding.
+
+This is half of the data needed for Glimm–Jaffe §4.6 Proposition 4.6.1
+(convergence): the sequence is bounded below by `log 2`. -/
+theorem freeEnergyAlongExhaustion_ge_log_two
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
+    (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    Real.log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n := by
+  have hcard : 0 < Fintype.card (↑(Λ.volume n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  have h_zero : freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n = Real.log 2 := by
+    change freeEnergyΛ G (Λ.volume n) (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2
+    exact IsingModel.freeEnergy_zero_params _ β hcard
+  calc Real.log 2
+      = freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n := h_zero.symm
+    _ ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n :=
+        freeEnergyAlongExhaustion_ge_zero_params G Λ hJ hh hβ n
+
 end Ambient
 end IsingModel
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -214,6 +214,7 @@ ambient framework:
 | `card_spin` (GibbsMeasure.lean) | `Fintype.card Spin = 2` |
 | `card_config_eq_two_pow` (GibbsMeasure.lean) | `Fintype.card (Config ι) = 2 ^ Fintype.card ι` |
 | `freeEnergy_zero_params` (FreeEnergy.lean) | `freeEnergy G ⟨0, 0, β⟩ = log 2` (for nonempty ι) |
+| **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |


### PR DESCRIPTION
## Summary

Combine PR #117 (zero-params comparison) + PR #120 (freeEnergy_zero_params = log 2) to obtain a concrete uniform lower bound:

\`\`\`
freeEnergyAlongExhaustion_ge_log_two :
  (0 ≤ J) → (0 ≤ h) → (0 < β) → (Λ.volume n).Nonempty →
  Real.log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n
\`\`\`

This establishes that the sequence is **bounded below** — half of what's needed for Prop 4.6.1 convergence.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter
- [ ] docs/index.md updated
- [ ] \`copilot\` or \`gemini\` review

🤖 Generated with [Claude Code](https://claude.com/claude-code)