### PR TITLE
feat: freeEnergy upper bound + freeEnergyAlongExhaustion variant

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2982,6 +2982,28 @@ theorem freeEnergyAlongExhaustion_ge_log_two
     _ ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n :=
         freeEnergyAlongExhaustion_ge_zero_params G Λ hJ hh hβ n
 
+/-- **Along-exhaustion upper bound for the free energy**:
+for nonempty `Λ.volume n`,
+`freeEnergyAlongExhaustion G Λ p n ≤
+  log 2 + |β|·(|J|·|E_n| + |h|·|Λ_n|) / |Λ_n|`,
+where `E_n` is the edge count of the induced subgraph on `Λ.volume n`
+and `|Λ_n|` is its cardinality.
+
+Specialization of `IsingModel.freeEnergy_upper_bound` (Conditioning.lean,
+Cor. 10.3.2 divided by `|ι|`) to the exhaustion setting. -/
+theorem freeEnergyAlongExhaustion_upper_bound
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    freeEnergyAlongExhaustion G Λ p n ≤ Real.log 2 +
+      |p.β| * (|p.J| * (inducedGraph G (Λ.volume n)).edgeFinset.card +
+          |p.h| * Fintype.card (↑(Λ.volume n) : Type _))
+        / Fintype.card (↑(Λ.volume n) : Type _) := by
+  have hcard : 0 < Fintype.card (↑(Λ.volume n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n)) p ≤ _
+  exact IsingModel.freeEnergy_upper_bound _ p hcard
+
 end Ambient
 end IsingModel
 

--- a/IsingModel/Conditioning.lean
+++ b/IsingModel/Conditioning.lean
@@ -277,39 +277,27 @@ theorem freeEnergy_upper_bound (G : SimpleGraph ι) [Fintype G.edgeSet]
     freeEnergy G p ≤ Real.log 2 +
       |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι)
         / Fintype.card ι := by
+  set A : ℝ :=
+    |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι)
   have hcard_pos : (0 : ℝ) < (Fintype.card ι : ℝ) := by exact_mod_cast hne
-  have hcard_ne : (Fintype.card ι : ℝ) ≠ 0 := hcard_pos.ne'
-  have hZ_pos := partitionFunction_pos G p
-  have hUp := partitionFunction_upper G p
-  have h_exp_pos : (0 : ℝ) <
-      Real.exp (|p.β| *
-        (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι)) :=
-    Real.exp_pos _
   have h_config_pos : (0 : ℝ) < (Fintype.card (Config ι) : ℝ) := by
     rw [card_config_eq_two_pow]; positivity
-  have hlog : Real.log (partitionFunction G p) ≤
-      (Fintype.card ι : ℝ) * Real.log 2 +
-      |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι) := by
+  have h_exp_pos : (0 : ℝ) < Real.exp A := Real.exp_pos _
+  have hlog : Real.log (partitionFunction G p)
+      ≤ (Fintype.card ι : ℝ) * Real.log 2 + A := by
     calc Real.log (partitionFunction G p)
-        ≤ Real.log ((Fintype.card (Config ι) : ℝ) *
-            Real.exp (|p.β| *
-              (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι))) :=
-          (Real.log_le_log_iff hZ_pos (mul_pos h_config_pos h_exp_pos)).mpr hUp
-      _ = Real.log (Fintype.card (Config ι) : ℝ) +
-          |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι) := by
+        ≤ Real.log ((Fintype.card (Config ι) : ℝ) * Real.exp A) :=
+          (Real.log_le_log_iff (partitionFunction_pos G p)
+            (mul_pos h_config_pos h_exp_pos)).mpr (partitionFunction_upper G p)
+      _ = Real.log (Fintype.card (Config ι) : ℝ) + A := by
           rw [Real.log_mul h_config_pos.ne' h_exp_pos.ne', Real.log_exp]
-      _ = (Fintype.card ι : ℝ) * Real.log 2 +
-          |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι) := by
+      _ = (Fintype.card ι : ℝ) * Real.log 2 + A := by
           rw [card_config_eq_two_pow]; push_cast; rw [Real.log_pow]
   unfold freeEnergy
-  rw [show (Real.log 2 +
-        |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι) /
-          (Fintype.card ι : ℝ))
-      = (Fintype.card ι : ℝ)⁻¹ *
-          ((Fintype.card ι : ℝ) * Real.log 2 +
-            |p.β| *
-              (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι)) from by
-    field_simp]
-  exact mul_le_mul_of_nonneg_left hlog (inv_nonneg.mpr hcard_pos.le)
+  calc (Fintype.card ι : ℝ)⁻¹ * Real.log (partitionFunction G p)
+      ≤ (Fintype.card ι : ℝ)⁻¹ * ((Fintype.card ι : ℝ) * Real.log 2 + A) :=
+        mul_le_mul_of_nonneg_left hlog (inv_nonneg.mpr hcard_pos.le)
+    _ = Real.log 2 + A / (Fintype.card ι : ℝ) := by
+        field_simp
 
 end IsingModel

--- a/IsingModel/Conditioning.lean
+++ b/IsingModel/Conditioning.lean
@@ -263,4 +263,53 @@ theorem highTempParam_lt_one (β J : ℝ) :
   unfold highTempParam
   exact tanh_lt_one (β * J)
 
+/-! ## Free energy upper bound (Corollary 10.3.2, divided by `|ι|`) -/
+
+/-- **Free energy upper bound** (Glimm–Jaffe, Cor. 10.3.2 divided by `|ι|`):
+for nonempty `ι`,
+`f(G, p) ≤ log 2 + |β|·(|J|·|E| + |h|·|ι|) / |ι|`.
+
+Obtained from `partitionFunction_upper` by taking the logarithm
+(`Z ≤ 2^|ι| · exp(|β|·(|J|·|E| + |h|·|ι|))` implies
+`log Z ≤ |ι|·log 2 + |β|·(|J|·|E| + |h|·|ι|)`) and dividing by `|ι|`. -/
+theorem freeEnergy_upper_bound (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hne : 0 < Fintype.card ι) :
+    freeEnergy G p ≤ Real.log 2 +
+      |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι)
+        / Fintype.card ι := by
+  have hcard_pos : (0 : ℝ) < (Fintype.card ι : ℝ) := by exact_mod_cast hne
+  have hcard_ne : (Fintype.card ι : ℝ) ≠ 0 := hcard_pos.ne'
+  have hZ_pos := partitionFunction_pos G p
+  have hUp := partitionFunction_upper G p
+  have h_exp_pos : (0 : ℝ) <
+      Real.exp (|p.β| *
+        (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι)) :=
+    Real.exp_pos _
+  have h_config_pos : (0 : ℝ) < (Fintype.card (Config ι) : ℝ) := by
+    rw [card_config_eq_two_pow]; positivity
+  have hlog : Real.log (partitionFunction G p) ≤
+      (Fintype.card ι : ℝ) * Real.log 2 +
+      |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι) := by
+    calc Real.log (partitionFunction G p)
+        ≤ Real.log ((Fintype.card (Config ι) : ℝ) *
+            Real.exp (|p.β| *
+              (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι))) :=
+          (Real.log_le_log_iff hZ_pos (mul_pos h_config_pos h_exp_pos)).mpr hUp
+      _ = Real.log (Fintype.card (Config ι) : ℝ) +
+          |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι) := by
+          rw [Real.log_mul h_config_pos.ne' h_exp_pos.ne', Real.log_exp]
+      _ = (Fintype.card ι : ℝ) * Real.log 2 +
+          |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι) := by
+          rw [card_config_eq_two_pow]; push_cast; rw [Real.log_pow]
+  unfold freeEnergy
+  rw [show (Real.log 2 +
+        |p.β| * (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι) /
+          (Fintype.card ι : ℝ))
+      = (Fintype.card ι : ℝ)⁻¹ *
+          ((Fintype.card ι : ℝ) * Real.log 2 +
+            |p.β| *
+              (|p.J| * G.edgeFinset.card + |p.h| * Fintype.card ι)) from by
+    field_simp]
+  exact mul_le_mul_of_nonneg_left hlog (inv_nonneg.mpr hcard_pos.le)
+
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -215,6 +215,8 @@ ambient framework:
 | `card_config_eq_two_pow` (GibbsMeasure.lean) | `Fintype.card (Config ι) = 2 ^ Fintype.card ι` |
 | `freeEnergy_zero_params` (FreeEnergy.lean) | `freeEnergy G ⟨0, 0, β⟩ = log 2` (for nonempty ι) |
 | **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
+| `freeEnergy_upper_bound` (Conditioning.lean) | **Explicit upper bound** (Cor. 10.3.2 / \|ι\|): `freeEnergy G p ≤ log 2 + \|β\|·(\|J\|·\|E\| + \|h\|·\|ι\|)/\|ι\|` for nonempty ι |
+| `freeEnergyAlongExhaustion_upper_bound` | Along-exhaustion specialization of `freeEnergy_upper_bound` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1503,6 +1503,25 @@ $Z \le 2^{|\iota|} \cdot \exp(|\beta|(|J| \cdot |E| + |h| \cdot |\iota|))$.
 $\exp(-|\beta|(|J| \cdot |E| + |h| \cdot |\iota|)) \le Z$.
 \end{theorem}
 
+\begin{theorem}[\texttt{freeEnergy\_upper\_bound}]
+For $|\iota| > 0$,
+\[
+\texttt{freeEnergy}\,G\,p \;\le\; \log 2
+  + \frac{|\beta|(|J| \cdot |E| + |h| \cdot |\iota|)}{|\iota|}.
+\]
+Take $\log$ of \texttt{partitionFunction\_upper} and use
+$|\text{Config}| = 2^{|\iota|}$, then divide by $|\iota|$.
+\end{theorem}
+
+\begin{theorem}[\texttt{freeEnergyAlongExhaustion\_upper\_bound}]
+For nonempty $\Lambda.\text{volume}\,n$,
+\[
+\texttt{freeEnergyAlongExhaustion}\,G\,\Lambda\,p\,n \;\le\; \log 2
+  + \frac{|\beta|(|J| \cdot |E_n| + |h| \cdot |\Lambda_n|)}{|\Lambda_n|},
+\]
+specialization of \texttt{freeEnergy\_upper\_bound} at each stage.
+\end{theorem}
+
 \subsection{Reflection positivity (\S10.4)}
 
 \begin{definition}[\texttt{ReflectionPositive}]


### PR DESCRIPTION
## Summary

Concrete upper bound for \`freeEnergy\` via existing \`partitionFunction_upper\` (Conditioning.lean):
\`\`\`
freeEnergy G p ≤ log 2 + |β|(|J|·|E| + |h|·|ι|) / |ι|
\`\`\`

Plus along-exhaustion specialization. Together with PR #121 (lower bound), gives two-sided bounds on \`freeEnergyAlongExhaustion\`.

## Test plan

- [ ] \`lake build\` + \`lake exe GKSTest\`
- [ ] Doc comments + linter
- [ ] docs/index.md updated
- [ ] \`copilot\` or \`gemini\` review

🤖 Generated with [Claude Code](https://claude.com/claude-code)