### PR TITLE
feat: BddAbove for freeEnergyAlongExhaustion under bounded edge density

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3004,6 +3004,99 @@ theorem freeEnergyAlongExhaustion_upper_bound
   change IsingModel.freeEnergy (inducedGraph G (Λ.volume n)) p ≤ _
   exact IsingModel.freeEnergy_upper_bound _ p hcard
 
+/-! ## Uniform upper bound under bounded edge density
+
+The per-stage upper bound `freeEnergyAlongExhaustion_upper_bound` depends
+on `|E_n| / |Λ_n|`; this ratio can diverge for an arbitrary exhaustion.
+Under the natural hypothesis `BoundedEdgeDensity`, the sequence is
+uniformly bounded above — a step toward Glimm–Jaffe §4.6 Prop 4.6.1
+convergence (which still needs super-additivity + Fekete). -/
+
+/-- **Bounded edge density along an exhaustion**: there is `c : ℝ` such
+that for every `n` with `Λ.volume n` nonempty,
+`|E(G[Λ_n])| ≤ c · |Λ_n|`.
+
+Example: bounded-degree ambient graphs with max degree `Δ` satisfy
+this with `c = Δ / 2`. -/
+def BoundedEdgeDensity (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] : Prop :=
+  ∃ c : ℝ, ∀ n, (Λ.volume n).Nonempty →
+    ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) ≤
+      c * Fintype.card (↑(Λ.volume n) : Type _)
+
+/-- **Uniform upper bound on `freeEnergyAlongExhaustion` under bounded
+edge density**: if `BoundedEdgeDensity G Λ` with constant `c`, then for
+every `n` with `Λ.volume n` nonempty and any Ising parameters `p`,
+`freeEnergyAlongExhaustion G Λ p n ≤ log 2 + |β|·(|J|·c + |h|)`.
+
+Direct consequence of `freeEnergyAlongExhaustion_upper_bound` (PR #122)
+and the edge-density bound `|E_n|/|Λ_n| ≤ c`. -/
+theorem freeEnergyAlongExhaustion_le_uniform_upper_bound
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) ≤
+        c * Fintype.card (↑(Λ.volume n) : Type _))
+    (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    freeEnergyAlongExhaustion G Λ p n ≤
+      Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
+  have hcard_pos : (0 : ℝ) < Fintype.card (↑(Λ.volume n) : Type _) := by
+    rw [Fintype.card_coe]; exact_mod_cast Finset.card_pos.mpr hne
+  have hcard_ne : (Fintype.card (↑(Λ.volume n) : Type _) : ℝ) ≠ 0 :=
+    hcard_pos.ne'
+  have hE := hc n hne
+  have hupper := freeEnergyAlongExhaustion_upper_bound G Λ p n hne
+  calc freeEnergyAlongExhaustion G Λ p n
+      ≤ Real.log 2 +
+          |p.β| * (|p.J| * (inducedGraph G (Λ.volume n)).edgeFinset.card +
+              |p.h| * Fintype.card (↑(Λ.volume n) : Type _))
+            / Fintype.card (↑(Λ.volume n) : Type _) := hupper
+    _ = Real.log 2 +
+          |p.β| * (|p.J| *
+              ((inducedGraph G (Λ.volume n)).edgeFinset.card /
+                Fintype.card (↑(Λ.volume n) : Type _)) + |p.h|) := by
+          field_simp
+    _ ≤ Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
+          have hratio :
+              ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) /
+                Fintype.card (↑(Λ.volume n) : Type _) ≤ c :=
+            (div_le_iff₀ hcard_pos).mpr hE
+          have : |p.J| *
+              (((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) /
+                Fintype.card (↑(Λ.volume n) : Type _))
+              ≤ |p.J| * c :=
+            mul_le_mul_of_nonneg_left hratio (abs_nonneg _)
+          gcongr
+
+/-- **BddAbove for `freeEnergyAlongExhaustion` under bounded edge density**:
+assuming `BoundedEdgeDensity G Λ`, the range of the exhaustion free energy
+is bounded above.
+
+For nonempty stages the bound is `log 2 + |β|·(|J|·c + |h|)` by the
+uniform upper bound above; for empty stages the value is
+`(Fintype.card ∅)⁻¹ · log 1 = 0`, which is at most the same constant
+(after taking its `max` with `0`). -/
+theorem BddAbove_freeEnergyAlongExhaustion_range
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hBED : BoundedEdgeDensity G Λ) :
+    BddAbove (Set.range (freeEnergyAlongExhaustion G Λ p)) := by
+  obtain ⟨c, hc⟩ := hBED
+  refine ⟨max 0 (Real.log 2 + |p.β| * (|p.J| * c + |p.h|)), ?_⟩
+  rintro y ⟨n, rfl⟩
+  by_cases hne : (Λ.volume n).Nonempty
+  · exact le_max_of_le_right
+      (freeEnergyAlongExhaustion_le_uniform_upper_bound G Λ p hc n hne)
+  · rw [Finset.not_nonempty_iff_eq_empty] at hne
+    have hcard : Fintype.card (↑(Λ.volume n) : Type _) = 0 := by
+      rw [Fintype.card_coe, hne]; rfl
+    have hfe : freeEnergyAlongExhaustion G Λ p n = 0 := by
+      change IsingModel.freeEnergy (inducedGraph G (Λ.volume n)) p = 0
+      unfold IsingModel.freeEnergy
+      rw [hcard, Nat.cast_zero, inv_zero, zero_mul]
+    rw [hfe]; exact le_max_left _ _
+
 end Ambient
 end IsingModel
 

--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3043,30 +3043,22 @@ theorem freeEnergyAlongExhaustion_le_uniform_upper_bound
       Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
   have hcard_pos : (0 : ℝ) < Fintype.card (↑(Λ.volume n) : Type _) := by
     rw [Fintype.card_coe]; exact_mod_cast Finset.card_pos.mpr hne
-  have hcard_ne : (Fintype.card (↑(Λ.volume n) : Type _) : ℝ) ≠ 0 :=
-    hcard_pos.ne'
-  have hE := hc n hne
-  have hupper := freeEnergyAlongExhaustion_upper_bound G Λ p n hne
+  have hratio :
+      ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) /
+        Fintype.card (↑(Λ.volume n) : Type _) ≤ c :=
+    (div_le_iff₀ hcard_pos).mpr (hc n hne)
   calc freeEnergyAlongExhaustion G Λ p n
       ≤ Real.log 2 +
           |p.β| * (|p.J| * (inducedGraph G (Λ.volume n)).edgeFinset.card +
               |p.h| * Fintype.card (↑(Λ.volume n) : Type _))
-            / Fintype.card (↑(Λ.volume n) : Type _) := hupper
+            / Fintype.card (↑(Λ.volume n) : Type _) :=
+        freeEnergyAlongExhaustion_upper_bound G Λ p n hne
     _ = Real.log 2 +
           |p.β| * (|p.J| *
               ((inducedGraph G (Λ.volume n)).edgeFinset.card /
                 Fintype.card (↑(Λ.volume n) : Type _)) + |p.h|) := by
           field_simp
     _ ≤ Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
-          have hratio :
-              ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) /
-                Fintype.card (↑(Λ.volume n) : Type _) ≤ c :=
-            (div_le_iff₀ hcard_pos).mpr hE
-          have : |p.J| *
-              (((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) /
-                Fintype.card (↑(Λ.volume n) : Type _))
-              ≤ |p.J| * c :=
-            mul_le_mul_of_nonneg_left hratio (abs_nonneg _)
           gcongr
 
 /-- **BddAbove for `freeEnergyAlongExhaustion` under bounded edge density**:

--- a/docs/index.md
+++ b/docs/index.md
@@ -217,6 +217,9 @@ ambient framework:
 | **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
 | `freeEnergy_upper_bound` (Conditioning.lean) | **Explicit upper bound** (Cor. 10.3.2 / \|ι\|): `freeEnergy G p ≤ log 2 + \|β\|·(\|J\|·\|E\| + \|h\|·\|ι\|)/\|ι\|` for nonempty ι |
 | `freeEnergyAlongExhaustion_upper_bound` | Along-exhaustion specialization of `freeEnergy_upper_bound` |
+| `BoundedEdgeDensity` | Hypothesis `∃ c, ∀ n (nonempty), \|E_n\| ≤ c·\|Λ_n\|` (e.g. bounded-degree ambient graphs) |
+| `freeEnergyAlongExhaustion_le_uniform_upper_bound` | **Uniform upper bound** under `BoundedEdgeDensity`: `f_n ≤ log 2 + \|β\|·(\|J\|·c + \|h\|)` |
+| `BddAbove_freeEnergyAlongExhaustion_range` | `BddAbove (Set.range (freeEnergyAlongExhaustion G Λ p))` under `BoundedEdgeDensity` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2827,6 +2827,34 @@ f_n = |\Lambda.\text{volume}\,n|^{-1} \cdot \log Z_n.
 本 PR は scaffold. 完全 convergence 証明 (subadditivity + Fekete) は
 deferred.
 
+\subsubsection{Bounded edge density と一様上界 (PR \#123)}
+
+\begin{definition}[\texttt{BoundedEdgeDensity}]
+\[
+  \exists c \in \mathbb R,\ \forall n,\
+    \Lambda.\text{volume}\,n \neq \emptyset \implies
+    |E(G[\Lambda_n])| \le c \cdot |\Lambda_n|.
+\]
+Bounded-degree 環境 ($\max\deg = \Delta$) で $c = \Delta/2$.
+\end{definition}
+
+\begin{theorem}[\texttt{freeEnergyAlongExhaustion\_le\_uniform\_upper\_bound}]
+\texttt{BoundedEdgeDensity} 定数 $c$ のもと, 任意の $n$ かつ
+$\Lambda_n \neq \emptyset$ で
+\[
+  f_n \le \log 2 + |\beta| \bigl(|J| \cdot c + |h|\bigr).
+\]
+\texttt{freeEnergyAlongExhaustion\_upper\_bound} (PR \#122) に
+$|E_n|/|\Lambda_n| \le c$ を代入.
+\end{theorem}
+
+\begin{theorem}[\texttt{BddAbove\_freeEnergyAlongExhaustion\_range}]
+\texttt{BoundedEdgeDensity} のもと,
+$\operatorname{BddAbove}(\operatorname{range}(\texttt{freeEnergyAlongExhaustion}\,G\,\Lambda\,p))$.
+空 $\Lambda_n$ では $f_n = 0$ (definitional) なので $\max\{0, \log 2 + |\beta|(|J|c+|h|)\}$
+が一様上界.
+\end{theorem}
+
 \subsection{Cor 4.3.5 (inductive n-point at $h = 0$) at infinite volume}
 
 参考: Glimm--Jaffe, \textit{Quantum Physics}, 2nd ed.\ (1987),


### PR DESCRIPTION
## Summary

- Introduce `BoundedEdgeDensity G Λ` as the hypothesis `∃ c, ∀ n, |E_n| ≤ c · |Λ_n|` (for nonempty `Λ_n`).
- `freeEnergyAlongExhaustion_le_uniform_upper_bound`: under bounded edge density, `f_n ≤ log 2 + |β|·(|J|·c + |h|)` for every nonempty stage.
- `BddAbove_freeEnergyAlongExhaustion_range`: the range of `freeEnergyAlongExhaustion` is bounded above.
- Consequence of `freeEnergyAlongExhaustion_upper_bound` (PR #122) + hypothesis.

Groundwork toward §4.6 Prop 4.6.1 (Glimm–Jaffe, p. 68).
The actual convergence theorem is still deferred pending partition-function
super-additivity + Fekete's lemma.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback if copilot quota exhausted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)