### PR TITLE
feat: freeEnergy at empty graph (free spin limit)

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -674,4 +674,25 @@ theorem freeEnergy_zero_params (G : SimpleGraph ι) [Fintype G.edgeSet]
     exact_mod_cast hne.ne'
   field_simp
 
+/-- **Free energy on the empty graph** (free-spin / one-body limit):
+for nonempty `ι`,
+`freeEnergy (⊥ : SimpleGraph ι) p = log (2 · cosh(β · h))`.
+
+Combines `partitionFunction_bot` (`Z = (2 cosh(β h))^|ι|`) with
+`Real.log_pow` (`log(a^n) = n · log a`, valid here since
+`2 cosh(β h) > 0`); the `|ι|⁻¹` prefix then cancels to give
+`log (2 cosh(β h))`.
+
+Complements `freeEnergy_zero_params` (the `J = h = 0` point, where
+`cosh 0 = 1` recovers `log 2`) by extending to arbitrary `h` on the
+J-less graph. -/
+theorem freeEnergy_bot (p : IsingParams ℝ) (hne : 0 < Fintype.card ι) :
+    freeEnergy (⊥ : SimpleGraph ι) p
+      = Real.log (2 * Real.cosh (p.β * p.h)) := by
+  unfold freeEnergy
+  rw [partitionFunction_bot, Real.log_pow]
+  have hcard : (Fintype.card ι : ℝ) ≠ 0 := by
+    exact_mod_cast hne.ne'
+  field_simp
+
 end IsingModel

--- a/IsingModel/GibbsMeasure.lean
+++ b/IsingModel/GibbsMeasure.lean
@@ -1,5 +1,6 @@
 import IsingModel.Hamiltonian
 import Mathlib.Analysis.Complex.Exponential
+import Mathlib.Analysis.Complex.Trigonometric
 
 /-!
 # Gibbs measure, partition function, and expectations
@@ -132,5 +133,89 @@ is finite of size `2^(Fintype.card ι)`. -/
 theorem card_config_eq_two_pow :
     Fintype.card (Config ι) = 2 ^ Fintype.card ι := by
   simp [Config, card_spin]
+
+/-! ## Empty graph: free-spin / one-body limit
+
+For the empty graph `⊥` (no edges), the `J`-term of the Hamiltonian is
+the empty sum and hence vanishes, leaving only the external field term.
+The partition function then factorizes over sites as
+`(2 · cosh(β·h))^|ι|`. -/
+
+omit [DecidableEq ι] in
+/-- **Hamiltonian on the empty graph**: at `G = ⊥`, the interaction
+energy is the empty edge sum and vanishes, leaving only the
+external field term `-h · Σ sign(σ_i)`. -/
+theorem hamiltonian_bot (p : IsingParams ℝ) (σ : Config ι) :
+    hamiltonian (⊥ : SimpleGraph ι) p σ
+      = -p.h * ∑ i : ι, Spin.sign ℝ (σ i) := by
+  unfold hamiltonian interactionEnergy externalFieldEnergy
+  rw [SimpleGraph.edgeFinset_bot, Finset.sum_empty, mul_zero, zero_add]
+
+/-- **Sum over `Spin`**: `∑ s : Spin, f s = f Spin.up + f Spin.down`.
+Spin is a 2-element Fintype `{up, down}`, so the universal sum splits
+into these two terms. -/
+theorem sum_spin {α : Type*} [AddCommMonoid α] (f : Spin → α) :
+    ∑ s : Spin, f s = f Spin.up + f Spin.down := by
+  have huniv : (Finset.univ : Finset Spin) = {Spin.up, Spin.down} := by
+    ext s; cases s <;> simp
+  rw [huniv, Finset.sum_pair (fun h => Spin.noConfusion h)]
+
+/-- **Single-site sum at the empty-graph site**:
+`∑_{s ∈ Spin} exp(β·h · sign s) = 2 · cosh(β·h)`.
+
+The two-element sum over `{up, down}` evaluates to `exp(β·h) + exp(-β·h)`,
+which is `2 · cosh(β·h)` by `Real.cosh_eq`. -/
+theorem sum_exp_spin_sign (β h : ℝ) :
+    ∑ s : Spin, Real.exp (β * h * Spin.sign ℝ s)
+      = 2 * Real.cosh (β * h) := by
+  rw [sum_spin]
+  have hup : Spin.sign ℝ Spin.up = (1 : ℝ) := by
+    simp [Spin.sign, Spin.toSign]
+  have hdown : Spin.sign ℝ Spin.down = (-1 : ℝ) := by
+    simp [Spin.sign, Spin.toSign]
+  rw [hup, hdown]
+  simp only [mul_one, mul_neg_one, Real.cosh_eq]
+  ring
+
+/-- **Partition function on the empty graph**: at `G = ⊥`,
+`Z = (2 · cosh(β·h))^|ι|`.
+
+Proof: use `hamiltonian_bot` to drop the `J`-term, rewrite the exponential
+of a sum as a product of exponentials, then apply the finite-distributivity
+`Finset.sum_prod_piFinset` (equivalent to
+`∑_σ ∏_i f(σ i) = ∏_i ∑_s f(s)` when `σ : ι → Spin`), and finally evaluate
+the single-site sum via `sum_exp_spin_sign`. -/
+theorem partitionFunction_bot (p : IsingParams ℝ) :
+    partitionFunction (⊥ : SimpleGraph ι) p
+      = (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι := by
+  unfold partitionFunction boltzmannWeight
+  have hprod : ∀ σ : Config ι,
+      Real.exp (-p.β * hamiltonian (⊥ : SimpleGraph ι) p σ)
+        = ∏ i : ι, Real.exp (p.β * p.h * Spin.sign ℝ (σ i)) := by
+    intro σ
+    rw [hamiltonian_bot]
+    have hsum : -p.β * (-p.h * ∑ i : ι, Spin.sign ℝ (σ i))
+        = ∑ i : ι, p.β * p.h * Spin.sign ℝ (σ i) := by
+      rw [Finset.mul_sum, Finset.mul_sum]
+      refine Finset.sum_congr rfl fun i _ => ?_
+      ring
+    rw [hsum, Real.exp_sum]
+  calc ∑ σ : Config ι,
+        Real.exp (-p.β * hamiltonian (⊥ : SimpleGraph ι) p σ)
+      = ∑ σ : Config ι, ∏ i : ι,
+          Real.exp (p.β * p.h * Spin.sign ℝ (σ i)) := by
+        refine Finset.sum_congr rfl ?_
+        intros σ _; exact hprod σ
+    _ = ∑ σ ∈ Fintype.piFinset (fun _ : ι => (Finset.univ : Finset Spin)),
+          ∏ i : ι, Real.exp (p.β * p.h * Spin.sign ℝ (σ i)) := by
+        rw [Fintype.piFinset_univ]
+    _ = ∏ i : ι, ∑ s : Spin, Real.exp (p.β * p.h * Spin.sign ℝ s) :=
+        Finset.sum_prod_piFinset (Finset.univ : Finset Spin)
+          (fun _ s => Real.exp (p.β * p.h * Spin.sign ℝ s))
+    _ = ∏ _ : ι, 2 * Real.cosh (p.β * p.h) := by
+        refine Finset.prod_congr rfl ?_
+        intros i _; exact sum_exp_spin_sign p.β p.h
+    _ = (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι := by
+        rw [Finset.prod_const, Finset.card_univ]
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -220,6 +220,10 @@ ambient framework:
 | `BoundedEdgeDensity` | Hypothesis `∃ c, ∀ n (nonempty), \|E_n\| ≤ c·\|Λ_n\|` (e.g. bounded-degree ambient graphs) |
 | `freeEnergyAlongExhaustion_le_uniform_upper_bound` | **Uniform upper bound** under `BoundedEdgeDensity`: `f_n ≤ log 2 + \|β\|·(\|J\|·c + \|h\|)` |
 | `BddAbove_freeEnergyAlongExhaustion_range` | `BddAbove (Set.range (freeEnergyAlongExhaustion G Λ p))` under `BoundedEdgeDensity` |
+| `hamiltonian_bot` (GibbsMeasure.lean) | `H_⊥(σ) = -h · Σ sign(σ_i)` (interaction term vanishes on empty graph) |
+| `sum_spin` / `sum_exp_spin_sign` | Spin-sum lemmas: `Σ_s f(s) = f(up) + f(down)`; `Σ_s exp(β h sign(s)) = 2 cosh(β h)` |
+| `partitionFunction_bot` (GibbsMeasure.lean) | `Z_⊥(p) = (2 cosh(β h))^\|ι\|` (free-spin product formula) |
+| `freeEnergy_bot` (FreeEnergy.lean) | **Free-spin closed form**: `freeEnergy ⊥ p = log(2 cosh(β h))` (for nonempty ι) |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1522,6 +1522,41 @@ For nonempty $\Lambda.\text{volume}\,n$,
 specialization of \texttt{freeEnergy\_upper\_bound} at each stage.
 \end{theorem}
 
+\subsection{Free-spin / one-body limit $(G = \bot)$}
+
+参考: Glimm--Jaffe, \S 4 chapter 冒頭 (free spin).
+$J$ に関わらず ambient graph が $\bot$ (辺なし) なら相互作用項は消える.
+
+\begin{theorem}[\texttt{hamiltonian\_bot}]
+$H_{\bot, p}(\sigma) = -h \sum_{i \in \iota} \operatorname{sign}(\sigma_i)$.
+\texttt{edgeFinset\_bot}: $(\bot).\text{edgeFinset} = \emptyset$ で
+$J$ 項は空和, 0 になる.
+\end{theorem}
+
+\begin{theorem}[\texttt{sum\_exp\_spin\_sign}]
+$\sum_{s \in \{\pm 1\}} \exp(\beta h \cdot s) = 2 \cosh(\beta h)$.
+\end{theorem}
+
+\begin{theorem}[\texttt{partitionFunction\_bot}]
+$Z_{\bot, p} = (2 \cosh(\beta h))^{|\iota|}$.
+\end{theorem}
+
+\begin{proof}
+\texttt{hamiltonian\_bot} + $\exp(-\beta H) = \prod_i \exp(\beta h \cdot \operatorname{sign}(\sigma_i))$.
+finite 分配則 \texttt{Finset.sum\_prod\_piFinset} で
+$\sum_\sigma \prod_i f(\sigma_i) = \prod_i \sum_s f(s)$.
+単サイト和を \texttt{sum\_exp\_spin\_sign} で閉じる.
+\end{proof}
+
+\begin{theorem}[\texttt{freeEnergy\_bot}]
+$|\iota| > 0$ で
+\[
+  f(\bot, p) = \log(2 \cosh(\beta h)).
+\]
+\texttt{partitionFunction\_bot} に \texttt{Real.log\_pow} を適用し
+$|\iota|$ で割る.
+\end{theorem}
+
 \subsection{Reflection positivity (\S10.4)}
 
 \begin{definition}[\texttt{ReflectionPositive}]


### PR DESCRIPTION
## Summary

- `hamiltonian_bot`: at `G = ⊥`, the `J`-term of the Hamiltonian is the empty sum; `H_⊥(σ) = -h · Σ sign(σ_i)`.
- `partitionFunction_bot`: `Z_⊥(p) = (2 · cosh(β·h))^|ι|`, via the finite distributivity `Σ_σ ∏_i f(σ_i) = ∏_i Σ_s f(s)` and the single-site sum `exp(βh) + exp(-βh) = 2 cosh(βh)`.
- `freeEnergy_bot` (for nonempty `ι`): `f(⊥, p) = log(2 · cosh(β·h))`, the ``free spin / one-body'' closed form.

Complements PR #120 (`freeEnergy_zero_params`) by extending from the special point `J = h = 0` to arbitrary `h` on the J-less graph.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)