### PR TITLE
feat: sharp ferromagnetic lower bound log(2·cosh(β·h))

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2982,6 +2982,26 @@ theorem freeEnergyAlongExhaustion_ge_log_two
     _ ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n :=
         freeEnergyAlongExhaustion_ge_zero_params G Λ hJ hh hβ n
 
+/-- **Sharp along-exhaustion lower bound**:
+for ferromagnetic parameters and nonempty stage,
+`log(2·cosh(β·h)) ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n`.
+
+Specialization of `IsingModel.freeEnergy_ge_log_two_cosh` (FreeEnergy.lean)
+at the induced subgraph on `Λ.volume n`. Sharpens the `log 2` uniform
+lower bound (`freeEnergyAlongExhaustion_ge_log_two`). -/
+theorem freeEnergyAlongExhaustion_ge_log_two_cosh
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
+    (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    Real.log (2 * Real.cosh (β * h))
+      ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n := by
+  have hcard : 0 < Fintype.card (↑(Λ.volume n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  change Real.log (2 * Real.cosh (β * h))
+      ≤ IsingModel.freeEnergy (inducedGraph G (Λ.volume n)) ⟨J, h, β⟩
+  exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hcard
+
 /-- **Along-exhaustion upper bound for the free energy**:
 for nonempty `Λ.volume n`,
 `freeEnergyAlongExhaustion G Λ p n ≤

--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -695,4 +695,21 @@ theorem freeEnergy_bot (p : IsingParams ℝ) (hne : 0 < Fintype.card ι) :
     exact_mod_cast hne.ne'
   field_simp
 
+/-- **Sharp ferromagnetic lower bound**: for any graph `G` with
+`|ι| > 0` and ferromagnetic parameters, `log(2·cosh(β·h)) ≤ freeEnergy G p`.
+
+Obtained from `freeEnergy_bot` (free-spin closed form) and
+`freeEnergy_monotone_subgraph` (ferromagnetic, `⊥ ≤ G` via `bot_le`).
+Sharpens `log 2` (since `cosh(β h) ≥ 1`, with equality at `h = 0`). -/
+theorem freeEnergy_ge_log_two_cosh (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
+    (hne : 0 < Fintype.card ι) :
+    Real.log (2 * Real.cosh (β * h)) ≤ freeEnergy G ⟨J, h, β⟩ := by
+  have hferm : Ferromagnetic (⟨J, h, β⟩ : IsingParams ℝ) := ⟨hJ, hh, hβ⟩
+  calc Real.log (2 * Real.cosh (β * h))
+      = freeEnergy (⊥ : SimpleGraph ι) (⟨J, h, β⟩ : IsingParams ℝ) := by
+        rw [freeEnergy_bot _ hne]
+    _ ≤ freeEnergy G (⟨J, h, β⟩ : IsingParams ℝ) :=
+        freeEnergy_monotone_subgraph bot_le _ hferm
+
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -224,6 +224,8 @@ ambient framework:
 | `sum_spin` / `sum_exp_spin_sign` | Spin-sum lemmas: `Σ_s f(s) = f(up) + f(down)`; `Σ_s exp(β h sign(s)) = 2 cosh(β h)` |
 | `partitionFunction_bot` (GibbsMeasure.lean) | `Z_⊥(p) = (2 cosh(β h))^\|ι\|` (free-spin product formula) |
 | `freeEnergy_bot` (FreeEnergy.lean) | **Free-spin closed form**: `freeEnergy ⊥ p = log(2 cosh(β h))` (for nonempty ι) |
+| `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) | **Sharp ferromagnetic lower bound**: `log(2 cosh(β h)) ≤ freeEnergy G p` (via `freeEnergy_bot` + `freeEnergy_monotone_subgraph`) |
+| `freeEnergyAlongExhaustion_ge_log_two_cosh` | Along-exhaustion specialization of the sharp ferromagnetic lower bound |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1557,6 +1557,21 @@ $|\iota| > 0$ で
 $|\iota|$ で割る.
 \end{theorem}
 
+\begin{theorem}[\texttt{freeEnergy\_ge\_log\_two\_cosh}]
+強磁性系 $J \ge 0, h \ge 0, \beta > 0$, $|\iota| > 0$ で
+\[
+  \log(2 \cosh(\beta h)) \le \texttt{freeEnergy}\,G\,p.
+\]
+\texttt{freeEnergy\_bot} で LHS $= f(\bot, p)$,
+\texttt{freeEnergy\_monotone\_subgraph} を \texttt{bot\_le} に適用.
+PR \#121 の uniform $\log 2$ 下界を $\cosh \ge 1$ で sharpen.
+\end{theorem}
+
+\begin{theorem}[\texttt{freeEnergyAlongExhaustion\_ge\_log\_two\_cosh}]
+各 nonempty stage で同じ下界.
+Specialization via \texttt{change} + definitional unfolding.
+\end{theorem>
+
 \subsection{Reflection positivity (\S10.4)}
 
 \begin{definition}[\texttt{ReflectionPositive}]


### PR DESCRIPTION
## Summary

- `freeEnergy_ge_log_two_cosh`: `log(2·cosh(β·h)) ≤ freeEnergy G p` for any `G` and ferromagnetic `p` with `|ι| > 0`.
  Immediate from `freeEnergy_bot` (PR #124) + `freeEnergy_monotone_subgraph` applied at `bot_le`.
- `freeEnergyAlongExhaustion_ge_log_two_cosh`: along-exhaustion specialization at each nonempty stage.

This sharpens PR #121's uniform `log 2` lower bound, since `cosh(β·h) ≥ 1` (with equality at `h = 0`).

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)