### PR TITLE
feat: freeEnergy h-symmetry (spin flip)

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -695,6 +695,17 @@ theorem freeEnergy_bot (p : IsingParams ℝ) (hne : 0 < Fintype.card ι) :
     exact_mod_cast hne.ne'
   field_simp
 
+/-- **Free energy h-symmetry**: `freeEnergy G ⟨J, -h, β⟩ = freeEnergy G ⟨J, h, β⟩`.
+
+Immediate from `partitionFunction_neg_h` (spin-flip reindexing) by
+taking `log` and dividing by `|ι|`. -/
+theorem freeEnergy_neg_h (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h β : ℝ) :
+    freeEnergy G (⟨J, -h, β⟩ : IsingParams ℝ)
+      = freeEnergy G (⟨J, h, β⟩ : IsingParams ℝ) := by
+  unfold freeEnergy
+  rw [partitionFunction_neg_h]
+
 /-- **Sharp ferromagnetic lower bound**: for any graph `G` with
 `|ι| > 0` and ferromagnetic parameters, `log(2·cosh(β·h)) ≤ freeEnergy G p`.
 

--- a/IsingModel/GibbsMeasure.lean
+++ b/IsingModel/GibbsMeasure.lean
@@ -218,4 +218,36 @@ theorem partitionFunction_bot (p : IsingParams ℝ) :
     _ = (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι := by
         rw [Finset.prod_const, Finset.card_univ]
 
+/-! ## h-symmetry: `Z(-h) = Z(h)` via spin flip
+
+From `hamiltonian_neg_h` (`H(σ; -h) = H(σ.flip; h)`) and the fact that
+`σ ↦ σ.flip` is an involution of `Config ι`, the partition function is
+invariant under `h ↦ -h`. -/
+
+/-- **Partition function h-symmetry**: `Z(J, -h, β) = Z(J, h, β)`.
+
+Proof: `exp(-β · H(σ; -h)) = exp(-β · H(σ.flip; h))` (`hamiltonian_neg_h`),
+then reindex the Config-sum via the self-inverse `flipEquiv`. -/
+theorem partitionFunction_neg_h (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h β : ℝ) :
+    partitionFunction G (⟨J, -h, β⟩ : IsingParams ℝ)
+      = partitionFunction G (⟨J, h, β⟩ : IsingParams ℝ) := by
+  unfold partitionFunction boltzmannWeight
+  let flipEquiv : Equiv.Perm (Config ι) :=
+    ⟨Config.flip, Config.flip, Config.flip_flip, Config.flip_flip⟩
+  calc ∑ σ : Config ι,
+        Real.exp (-(⟨J, -h, β⟩ : IsingParams ℝ).β *
+          hamiltonian G (⟨J, -h, β⟩ : IsingParams ℝ) σ)
+      = ∑ σ : Config ι,
+          Real.exp (-(⟨J, h, β⟩ : IsingParams ℝ).β *
+            hamiltonian G (⟨J, h, β⟩ : IsingParams ℝ) σ.flip) := by
+        refine Finset.sum_congr rfl ?_
+        intros σ _
+        rw [hamiltonian_neg_h]
+    _ = ∑ σ : Config ι,
+          Real.exp (-(⟨J, h, β⟩ : IsingParams ℝ).β *
+            hamiltonian G (⟨J, h, β⟩ : IsingParams ℝ) σ) :=
+        (Fintype.sum_equiv flipEquiv _ _
+          (fun σ => by dsimp [flipEquiv]; simp [Config.flip_flip])).symm
+
 end IsingModel

--- a/IsingModel/Hamiltonian.lean
+++ b/IsingModel/Hamiltonian.lean
@@ -71,4 +71,24 @@ theorem hamiltonian_flip_eq (G : SimpleGraph ι) [Fintype G.edgeSet]
   unfold externalFieldEnergy Config.flip
   simp [hp]
 
+omit [DecidableEq ι] in
+/-- **Hamiltonian under `h ↦ -h` and spin flip**:
+`H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)`.
+
+The `J`-term is invariant under spin flip (`interactionEnergy_flip`),
+while the external field contributes
+`-(-h)·Σ sign(σ_i) = h·Σ sign(σ_i)
+  = -h·Σ sign(σ.flip_i)`, matching the `h` term evaluated at `σ.flip`. -/
+theorem hamiltonian_neg_h (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h β : K) (σ : Config ι) :
+    hamiltonian G (⟨J, -h, β⟩ : IsingParams K) σ
+      = hamiltonian G (⟨J, h, β⟩ : IsingParams K) σ.flip := by
+  unfold hamiltonian
+  rw [interactionEnergy_flip]
+  congr 1
+  unfold externalFieldEnergy Config.flip
+  simp only [Spin.sign_flip]
+  rw [Finset.sum_neg_distrib]
+  ring
+
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -226,6 +226,9 @@ ambient framework:
 | `freeEnergy_bot` (FreeEnergy.lean) | **Free-spin closed form**: `freeEnergy ⊥ p = log(2 cosh(β h))` (for nonempty ι) |
 | `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) | **Sharp ferromagnetic lower bound**: `log(2 cosh(β h)) ≤ freeEnergy G p` (via `freeEnergy_bot` + `freeEnergy_monotone_subgraph`) |
 | `freeEnergyAlongExhaustion_ge_log_two_cosh` | Along-exhaustion specialization of the sharp ferromagnetic lower bound |
+| `hamiltonian_neg_h` (Hamiltonian.lean) | `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)` (spin-flip / h-sign identity) |
+| `partitionFunction_neg_h` (GibbsMeasure.lean) | **Z h-symmetry**: `Z(J, -h, β) = Z(J, h, β)` via flip involution |
+| `freeEnergy_neg_h` (FreeEnergy.lean) | **freeEnergy is even in h**: `f(J, -h, β) = f(J, h, β)` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1570,7 +1570,29 @@ PR \#121 の uniform $\log 2$ 下界を $\cosh \ge 1$ で sharpen.
 \begin{theorem}[\texttt{freeEnergyAlongExhaustion\_ge\_log\_two\_cosh}]
 各 nonempty stage で同じ下界.
 Specialization via \texttt{change} + definitional unfolding.
-\end{theorem>
+\end{theorem}
+
+\subsection{Spin flip symmetry / $h$-even (PR \#126)}
+
+\begin{theorem}[\texttt{hamiltonian\_neg\_h}]
+\[
+  H_{G, (J, -h, \beta)}(\sigma)
+    = H_{G, (J, h, \beta)}(\sigma.\text{flip}).
+\]
+$J$ 項は \texttt{interactionEnergy\_flip} で不変, 外部磁場は
+$-(-h) \sum \text{sign}(\sigma_i) = h \sum \text{sign}(\sigma_i)
+  = -h \sum \text{sign}(\sigma.\text{flip}_i)$.
+\end{theorem}
+
+\begin{theorem}[\texttt{partitionFunction\_neg\_h}]
+$Z(J, -h, \beta) = Z(J, h, \beta)$.
+\texttt{hamiltonian\_neg\_h} + \texttt{flipEquiv} 双射での reindex.
+\end{theorem}
+
+\begin{theorem}[\texttt{freeEnergy\_neg\_h}]
+$f(J, -h, \beta) = f(J, h, \beta)$.
+自由エネルギー密度は $h$ の偶関数.
+\end{theorem}
 
 \subsection{Reflection positivity (\S10.4)}
 


### PR DESCRIPTION
## Summary

- `hamiltonian_neg_h`: `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)`, extending `hamiltonian_flip_eq` (currently `h = 0` only) to arbitrary `h`.
- `partitionFunction_neg_h`: `Z(J, -h, β) = Z(J, h, β)`, reindexing the Config-sum via the self-inverse `flipEquiv : Config ι ≃ Config ι`.
- `freeEnergy_neg_h`: `f(J, -h, β) = f(J, h, β)` — immediate from the above.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)