### PR TITLE
feat: freeEnergy |h|-monotonicity via spin flip symmetry

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -706,6 +706,37 @@ theorem freeEnergy_neg_h (G : SimpleGraph ι) [Fintype G.edgeSet]
   unfold freeEnergy
   rw [partitionFunction_neg_h]
 
+/-- **Free energy equals its value at `|h|`**:
+`freeEnergy G ⟨J, h, β⟩ = freeEnergy G ⟨J, |h|, β⟩`.
+
+Case-split on `|h| = h ∨ |h| = -h` and apply `freeEnergy_neg_h` when
+needed. -/
+theorem freeEnergy_eq_abs_h (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h β : ℝ) :
+    freeEnergy G (⟨J, h, β⟩ : IsingParams ℝ)
+      = freeEnergy G (⟨J, |h|, β⟩ : IsingParams ℝ) := by
+  rcases abs_choice h with habs | habs
+  · rw [habs]
+  · rw [habs, freeEnergy_neg_h]
+
+/-- **Free energy is monotone in `|h|`** for ferromagnetic parameters:
+`|h₁| ≤ |h₂| → freeEnergy G ⟨J, h₁, β⟩ ≤ freeEnergy G ⟨J, h₂, β⟩`.
+
+Combines `freeEnergy_eq_abs_h` (h-even) with `freeEnergy_monotone_h`
+on `[0, ∞)`: rewrite both sides as `freeEnergy G ⟨J, |hᵢ|, β⟩` and
+apply the `Ici 0` monotonicity using `abs_nonneg`. -/
+theorem freeEnergy_monotone_abs_h
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh : |h₁| ≤ |h₂|) :
+    freeEnergy G (⟨J, h₁, β⟩ : IsingParams ℝ)
+      ≤ freeEnergy G (⟨J, h₂, β⟩ : IsingParams ℝ) := by
+  rw [freeEnergy_eq_abs_h G J h₁ β, freeEnergy_eq_abs_h G J h₂ β]
+  have := freeEnergy_monotone_h G J β hJ hβ
+    (Set.mem_Ici.mpr (abs_nonneg h₁))
+    (Set.mem_Ici.mpr (abs_nonneg h₂)) hh
+  exact this
+
 /-- **Sharp ferromagnetic lower bound**: for any graph `G` with
 `|ι| > 0` and ferromagnetic parameters, `log(2·cosh(β·h)) ≤ freeEnergy G p`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -229,6 +229,8 @@ ambient framework:
 | `hamiltonian_neg_h` (Hamiltonian.lean) | `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)` (spin-flip / h-sign identity) |
 | `partitionFunction_neg_h` (GibbsMeasure.lean) | **Z h-symmetry**: `Z(J, -h, β) = Z(J, h, β)` via flip involution |
 | `freeEnergy_neg_h` (FreeEnergy.lean) | **freeEnergy is even in h**: `f(J, -h, β) = f(J, h, β)` |
+| `freeEnergy_eq_abs_h` (FreeEnergy.lean) | `f(J, h, β) = f(J, |h|, β)` (case split + h-symmetry) |
+| `freeEnergy_monotone_abs_h` (FreeEnergy.lean) | **Ferromagnetic |h|-monotonicity**: `|h₁| ≤ |h₂| → f(J, h₁, β) ≤ f(J, h₂, β)` |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1594,6 +1594,19 @@ $f(J, -h, \beta) = f(J, h, \beta)$.
 自由エネルギー密度は $h$ の偶関数.
 \end{theorem}
 
+\subsection{$|h|$-monotonicity (PR \#127)}
+
+\begin{theorem}[\texttt{freeEnergy\_eq\_abs\_h}]
+$f(J, h, \beta) = f(J, |h|, \beta)$.
+$|h| = h$ or $|h| = -h$ の場合分けと \texttt{freeEnergy\_neg\_h}.
+\end{theorem}
+
+\begin{theorem}[\texttt{freeEnergy\_monotone\_abs\_h}]
+強磁性系で $|h_1| \le |h_2| \Rightarrow f(J, h_1, \beta) \le f(J, h_2, \beta)$.
+両辺を \texttt{freeEnergy\_eq\_abs\_h} で $|h_i|$ に書き換え,
+$|h_i| \ge 0$ から \texttt{freeEnergy\_monotone\_h} (Ici 0 上 monotone) を適用.
+\end{theorem}
+
 \subsection{Reflection positivity (\S10.4)}
 
 \begin{definition}[\texttt{ReflectionPositive}]


### PR DESCRIPTION
## Summary

- `freeEnergy_eq_abs_h`: `f(J, h, β) = f(J, |h|, β)` via case split on `|h| = h ∨ |h| = -h` and `freeEnergy_neg_h` (PR #126).
- `freeEnergy_monotone_abs_h`: for ferromagnetic `J ≥ 0`, `β > 0` and any real `h₁, h₂`,
  `|h₁| ≤ |h₂| → freeEnergy G ⟨J, h₁, β⟩ ≤ freeEnergy G ⟨J, h₂, β⟩`. Rewrite both sides via `freeEnergy_eq_abs_h` and apply `freeEnergy_monotone_h` on `[0, ∞)`.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)