### PR TITLE
feat: along-exhaustion h-symmetry + |h|-monotonicity

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3081,6 +3081,57 @@ theorem freeEnergyAlongExhaustion_le_uniform_upper_bound
     _ ≤ Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
           gcongr
 
+/-! ## h-symmetry / `|h|`-monotonicity along exhaustion
+
+Specializations of `IsingModel.freeEnergy_neg_h`, `freeEnergy_eq_abs_h`,
+and `freeEnergy_monotone_abs_h` (PRs #126–#127) to each stage of the
+exhaustion, via the `change` + definitional-unfolding pattern already
+used in this file. -/
+
+/-- **Along-exhaustion h-evenness**:
+`freeEnergyAlongExhaustion G Λ ⟨J, -h, β⟩ n = freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n`. -/
+theorem freeEnergyAlongExhaustion_neg_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ (⟨J, -h, β⟩ : IsingParams ℝ) n
+      = freeEnergyAlongExhaustion G Λ (⟨J, h, β⟩ : IsingParams ℝ) n := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨J, -h, β⟩ : IsingParams ℝ)
+    = IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+        (⟨J, h, β⟩ : IsingParams ℝ)
+  exact IsingModel.freeEnergy_neg_h _ J h β
+
+/-- **Along-exhaustion `|h|`-rewrite**:
+`freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n = freeEnergyAlongExhaustion G Λ ⟨J, |h|, β⟩ n`. -/
+theorem freeEnergyAlongExhaustion_eq_abs_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ (⟨J, h, β⟩ : IsingParams ℝ) n
+      = freeEnergyAlongExhaustion G Λ (⟨J, |h|, β⟩ : IsingParams ℝ) n := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨J, h, β⟩ : IsingParams ℝ)
+    = IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+        (⟨J, |h|, β⟩ : IsingParams ℝ)
+  exact IsingModel.freeEnergy_eq_abs_h _ J h β
+
+/-- **Along-exhaustion ferromagnetic `|h|`-monotonicity**:
+for `J ≥ 0`, `β > 0` and any real `h₁, h₂` with `|h₁| ≤ |h₂|`,
+`freeEnergyAlongExhaustion G Λ ⟨J, h₁, β⟩ n ≤ freeEnergyAlongExhaustion G Λ ⟨J, h₂, β⟩ n`. -/
+theorem freeEnergyAlongExhaustion_monotone_abs_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh : |h₁| ≤ |h₂|) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ (⟨J, h₁, β⟩ : IsingParams ℝ) n
+      ≤ freeEnergyAlongExhaustion G Λ (⟨J, h₂, β⟩ : IsingParams ℝ) n := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨J, h₁, β⟩ : IsingParams ℝ)
+    ≤ IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+        (⟨J, h₂, β⟩ : IsingParams ℝ)
+  exact IsingModel.freeEnergy_monotone_abs_h _ J β hJ hβ hh
+
 /-- **BddAbove for `freeEnergyAlongExhaustion` under bounded edge density**:
 assuming `BoundedEdgeDensity G Λ`, the range of the exhaustion free energy
 is bounded above.

--- a/docs/index.md
+++ b/docs/index.md
@@ -231,6 +231,7 @@ ambient framework:
 | `freeEnergy_neg_h` (FreeEnergy.lean) | **freeEnergy is even in h**: `f(J, -h, β) = f(J, h, β)` |
 | `freeEnergy_eq_abs_h` (FreeEnergy.lean) | `f(J, h, β) = f(J, |h|, β)` (case split + h-symmetry) |
 | `freeEnergy_monotone_abs_h` (FreeEnergy.lean) | **Ferromagnetic |h|-monotonicity**: `|h₁| ≤ |h₂| → f(J, h₁, β) ≤ f(J, h₂, β)` |
+| `freeEnergyAlongExhaustion_neg_h` / `_eq_abs_h` / `_monotone_abs_h` | Along-exhaustion specializations of h-symmetry + |h|-monotonicity |
 | `correlationAlongExhaustion_nonneg` | `0 ≤ correlationAlongExhaustion G Λ p A n` (ferromagnetic) |
 | `correlationΛ_gks_second` | **GKS-II at finite volume**, lifted form: `correlationΛ (lift A) · correlationΛ (lift B) ≤ correlationΛ (lift (A ∆ B))` |
 | **`correlationInfinite_gks_second`** | **GKS-II at infinite volume** (Glimm–Jaffe §4.2 Thm 4.2.3): `correlationInfinite A · correlationInfinite B ≤ correlationInfinite (A ∆ B)` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1607,6 +1607,20 @@ $|h| = h$ or $|h| = -h$ の場合分けと \texttt{freeEnergy\_neg\_h}.
 $|h_i| \ge 0$ から \texttt{freeEnergy\_monotone\_h} (Ici 0 上 monotone) を適用.
 \end{theorem}
 
+\subsubsection{Along-exhaustion specializations (PR \#128)}
+
+\begin{theorem}[\texttt{freeEnergyAlongExhaustion\_neg\_h} /
+\texttt{\_eq\_abs\_h} / \texttt{\_monotone\_abs\_h}]
+各 $n$ で finite-volume 版をそのまま specialize:
+\begin{itemize}
+  \item $f_n(J, -h, \beta) = f_n(J, h, \beta)$.
+  \item $f_n(J, h, \beta) = f_n(J, |h|, \beta)$.
+  \item 強磁性系 $J \ge 0, \beta > 0$ で $|h_1| \le |h_2| \Rightarrow f_n(h_1) \le f_n(h_2)$.
+\end{itemize}
+いずれも \texttt{change} + definitional unfolding で \texttt{IsingModel.freeEnergy\_*}
+を適用.
+\end{theorem}
+
 \subsection{Reflection positivity (\S10.4)}
 
 \begin{definition}[\texttt{ReflectionPositive}]


### PR DESCRIPTION
## Summary

Along-exhaustion specializations of PR #126 / PR #127:

- `freeEnergyAlongExhaustion_neg_h` — h-evenness.
- `freeEnergyAlongExhaustion_eq_abs_h` — rewrite to `|h|`.
- `freeEnergyAlongExhaustion_monotone_abs_h` — ferromagnetic `|h|`-monotonicity.

Each uses the `change ... IsingModel.freeEnergy (inducedGraph G (Λ.volume n)) ...` + definitional-unfolding pattern already established in this file.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)