### PR TITLE
feat: freeEnergy_bot_h_zero + tex backfill for inducedGraph_bot

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -737,6 +737,19 @@ theorem freeEnergy_monotone_abs_h
     (Set.mem_Ici.mpr (abs_nonneg h₂)) hh
   exact this
 
+/-- **Free energy on the empty graph at zero field**: for nonempty `ι`
+and any `J, β : ℝ`,
+`freeEnergy (⊥ : SimpleGraph ι) ⟨J, 0, β⟩ = log 2`.
+
+Corollary of `freeEnergy_bot` at `h = 0` (`cosh 0 = 1`, `log(2·1) = log 2`).
+Consistent with `freeEnergy_zero_params` (`J = h = 0`) and shows that on
+the J-less graph the coupling `J` is dormant. -/
+theorem freeEnergy_bot_h_zero (J β : ℝ) (hne : 0 < Fintype.card ι) :
+    freeEnergy (⊥ : SimpleGraph ι) (⟨J, 0, β⟩ : IsingParams ℝ)
+      = Real.log 2 := by
+  rw [freeEnergy_bot _ hne]
+  simp [Real.cosh_zero]
+
 /-- **Sharp ferromagnetic lower bound**: for any graph `G` with
 `|ι| > 0` and ferromagnetic parameters, `log(2·cosh(β·h)) ≤ freeEnergy G p`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -224,6 +224,7 @@ ambient framework:
 | `sum_spin` / `sum_exp_spin_sign` | Spin-sum lemmas: `Σ_s f(s) = f(up) + f(down)`; `Σ_s exp(β h sign(s)) = 2 cosh(β h)` |
 | `partitionFunction_bot` (GibbsMeasure.lean) | `Z_⊥(p) = (2 cosh(β h))^\|ι\|` (free-spin product formula) |
 | `freeEnergy_bot` (FreeEnergy.lean) | **Free-spin closed form**: `freeEnergy ⊥ p = log(2 cosh(β h))` (for nonempty ι) |
+| `freeEnergy_bot_h_zero` (FreeEnergy.lean) | Corollary at `h = 0`: `freeEnergy ⊥ ⟨J, 0, β⟩ = log 2` for any J, β |
 | `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) | **Sharp ferromagnetic lower bound**: `log(2 cosh(β h)) ≤ freeEnergy G p` (via `freeEnergy_bot` + `freeEnergy_monotone_subgraph`) |
 | `freeEnergyAlongExhaustion_ge_log_two_cosh` | Along-exhaustion specialization of the sharp ferromagnetic lower bound |
 | `hamiltonian_neg_h` (Hamiltonian.lean) | `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)` (spin-flip / h-sign identity) |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1557,6 +1557,23 @@ $|\iota| > 0$ で
 $|\iota|$ で割る.
 \end{theorem}
 
+\begin{theorem}[\texttt{freeEnergy\_bot\_h\_zero}]
+$|\iota| > 0$ と任意の $J, \beta \in \mathbb R$ で
+\[
+  f(\bot, \langle J, 0, \beta \rangle) = \log 2.
+\]
+$\cosh 0 = 1$ で \texttt{freeEnergy\_bot} から即座. J 任意なのは
+$\bot$ で $J$ 項が空和になるため. PR \#120 \texttt{freeEnergy\_zero\_params}
+($J = h = 0$) の $J$-arbitrary 拡張.
+\end{theorem}
+
+\begin{theorem}[\texttt{inducedGraph\_bot}; PR \#129]
+$\texttt{inducedGraph}\,(\bot : \texttt{SimpleGraph}\,V)\,\Lambda
+  = (\bot : \texttt{SimpleGraph}\,\uparrow\Lambda)$.
+\texttt{induce = comap} + \texttt{SimpleGraph.comap\_bot}.
+\texttt{@[simp]} 付与.
+\end{theorem}
+
 \begin{theorem}[\texttt{freeEnergy\_ge\_log\_two\_cosh}]
 強磁性系 $J \ge 0, h \ge 0, \beta > 0$, $|\iota| > 0$ で
 \[


### PR DESCRIPTION
## Summary

- `freeEnergy_bot_h_zero`: `freeEnergy (⊥ : SimpleGraph ι) ⟨J, 0, β⟩ = log 2` for any `J, β` and nonempty `ι`. Immediate corollary of PR #124 via `Real.cosh_zero`.
- tex/proof-guide.tex: backfill missing `inducedGraph_bot` (PR #129) and add `freeEnergy_bot_h_zero`.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)