### PR TITLE
feat: freeEnergy at β = 0 = log 2

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -737,6 +737,23 @@ theorem freeEnergy_monotone_abs_h
     (Set.mem_Ici.mpr (abs_nonneg h₂)) hh
   exact this
 
+/-- **Free energy at `β = 0`**: for nonempty `ι` and any `J, h : ℝ`,
+`freeEnergy G ⟨J, h, 0⟩ = log 2`.
+
+Corollary of `partitionFunction_beta_zero` (`Z = |Config ι| = 2^|ι|`),
+taking `log` and dividing by `|ι|`. β-direction analogue of
+`freeEnergy_zero_params` (`J = h = 0`), holds for any ambient `G`. -/
+theorem freeEnergy_beta_zero (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h : ℝ) (hne : 0 < Fintype.card ι) :
+    freeEnergy G (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2 := by
+  unfold freeEnergy
+  rw [partitionFunction_beta_zero, card_config_eq_two_pow]
+  push_cast
+  rw [Real.log_pow]
+  have hcard : (Fintype.card ι : ℝ) ≠ 0 := by
+    exact_mod_cast hne.ne'
+  field_simp
+
 /-- **Free energy on the empty graph at zero field**: for nonempty `ι`
 and any `J, β : ℝ`,
 `freeEnergy (⊥ : SimpleGraph ι) ⟨J, 0, β⟩ = log 2`.

--- a/IsingModel/GibbsMeasure.lean
+++ b/IsingModel/GibbsMeasure.lean
@@ -125,6 +125,27 @@ theorem partitionFunction_zero_params (G : SimpleGraph ι) [Fintype G.edgeSet]
     _ = (Fintype.card (Config ι) : ℝ) := by
         rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one]
 
+/-- **Partition function at `β = 0`**: the prefactor `-β` in the
+Boltzmann weight vanishes, so every weight collapses to
+`exp 0 = 1` regardless of `J` and `h`, and
+`Z_G(⟨J, h, 0⟩) = Fintype.card (Config ι)` for every ambient graph. -/
+theorem partitionFunction_beta_zero (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h : ℝ) :
+    partitionFunction G (⟨J, h, 0⟩ : IsingParams ℝ)
+      = (Fintype.card (Config ι) : ℝ) := by
+  unfold partitionFunction boltzmannWeight
+  calc ∑ σ : Config ι,
+        Real.exp (-(⟨J, h, 0⟩ : IsingParams ℝ).β *
+          hamiltonian G (⟨J, h, 0⟩ : IsingParams ℝ) σ)
+      = ∑ _σ : Config ι, (1 : ℝ) := by
+        refine Finset.sum_congr rfl ?_
+        intros σ _
+        change Real.exp (-(0 : ℝ) *
+          hamiltonian G (⟨J, h, 0⟩ : IsingParams ℝ) σ) = 1
+        rw [neg_zero, zero_mul, Real.exp_zero]
+    _ = (Fintype.card (Config ι) : ℝ) := by
+        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one]
+
 /-- **Cardinality of `Spin` is 2**. -/
 theorem card_spin : Fintype.card Spin = 2 := rfl
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -225,6 +225,8 @@ ambient framework:
 | `partitionFunction_bot` (GibbsMeasure.lean) | `Z_⊥(p) = (2 cosh(β h))^\|ι\|` (free-spin product formula) |
 | `freeEnergy_bot` (FreeEnergy.lean) | **Free-spin closed form**: `freeEnergy ⊥ p = log(2 cosh(β h))` (for nonempty ι) |
 | `freeEnergy_bot_h_zero` (FreeEnergy.lean) | Corollary at `h = 0`: `freeEnergy ⊥ ⟨J, 0, β⟩ = log 2` for any J, β |
+| `partitionFunction_beta_zero` (GibbsMeasure.lean) | `Z G ⟨J, h, 0⟩ = |Config ι|` (all weights collapse to `exp 0 = 1`) |
+| `freeEnergy_beta_zero` (FreeEnergy.lean) | β=0 direction: `freeEnergy G ⟨J, h, 0⟩ = log 2` for nonempty ι, any J, h, G |
 | `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) | **Sharp ferromagnetic lower bound**: `log(2 cosh(β h)) ≤ freeEnergy G p` (via `freeEnergy_bot` + `freeEnergy_monotone_subgraph`) |
 | `freeEnergyAlongExhaustion_ge_log_two_cosh` | Along-exhaustion specialization of the sharp ferromagnetic lower bound |
 | `hamiltonian_neg_h` (Hamiltonian.lean) | `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)` (spin-flip / h-sign identity) |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1567,6 +1567,20 @@ $\bot$ で $J$ 項が空和になるため. PR \#120 \texttt{freeEnergy\_zero\_p
 ($J = h = 0$) の $J$-arbitrary 拡張.
 \end{theorem}
 
+\begin{theorem}[\texttt{partitionFunction\_beta\_zero}]
+$Z_G(\langle J, h, 0 \rangle) = |\text{Config}\,\iota|$.
+$-\beta = 0$ で Boltzmann weight $= \exp 0 = 1$.
+\end{theorem}
+
+\begin{theorem}[\texttt{freeEnergy\_beta\_zero}]
+$|\iota| > 0$, 任意の $J, h, G$ で
+\[
+  f(G, \langle J, h, 0 \rangle) = \log 2.
+\]
+PR \#120 \texttt{freeEnergy\_zero\_params} の $\beta$-direction 版.
+\texttt{partitionFunction\_beta\_zero} + \texttt{Real.log\_pow} + $|\iota|^{-1}$ cancel.
+\end{theorem}
+
 \begin{theorem}[\texttt{inducedGraph\_bot}; PR \#129]
 $\texttt{inducedGraph}\,(\bot : \texttt{SimpleGraph}\,V)\,\Lambda
   = (\bot : \texttt{SimpleGraph}\,\uparrow\Lambda)$.


### PR DESCRIPTION
## Summary

- `partitionFunction_beta_zero`: `Z G ⟨J, h, 0⟩ = |Config ι|`. All Boltzmann weights collapse to `exp 0 = 1`.
- `freeEnergy_beta_zero` (for nonempty `ι`): `freeEnergy G ⟨J, h, 0⟩ = log 2` for any `J, h`.

Mirrors PR #120 `freeEnergy_zero_params` in the β direction.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)