### PR TITLE
feat: along-exhaustion β=0 (log 2)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3081,6 +3081,27 @@ theorem freeEnergyAlongExhaustion_le_uniform_upper_bound
     _ ≤ Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
           gcongr
 
+/-! ## β = 0 closed form along exhaustion -/
+
+/-- **Along-exhaustion β=0 closed form**:
+for nonempty `Λ.volume n` and any ambient graph `G, Λ, J, h`,
+`freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n = log 2`.
+
+Specialization of `IsingModel.freeEnergy_beta_zero` (PR #131) via
+`change` + definitional unfolding of `freeEnergyAlongExhaustion`
+through `freeEnergyΛ` to `IsingModel.freeEnergy (inducedGraph …)`. -/
+theorem freeEnergyAlongExhaustion_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    freeEnergyAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ) n
+      = Real.log 2 := by
+  have hcard : 0 < Fintype.card (↑(Λ.volume n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2
+  exact IsingModel.freeEnergy_beta_zero _ J h hcard
+
 /-! ## Free-spin identity for induced subgraph -/
 
 omit [DecidableEq V] in

--- a/docs/index.md
+++ b/docs/index.md
@@ -227,6 +227,7 @@ ambient framework:
 | `freeEnergy_bot_h_zero` (FreeEnergy.lean) | Corollary at `h = 0`: `freeEnergy ⊥ ⟨J, 0, β⟩ = log 2` for any J, β |
 | `partitionFunction_beta_zero` (GibbsMeasure.lean) | `Z G ⟨J, h, 0⟩ = |Config ι|` (all weights collapse to `exp 0 = 1`) |
 | `freeEnergy_beta_zero` (FreeEnergy.lean) | β=0 direction: `freeEnergy G ⟨J, h, 0⟩ = log 2` for nonempty ι, any J, h, G |
+| `freeEnergyAlongExhaustion_beta_zero` | Along-exhaustion specialization: `f_n(J, h, 0) = log 2` per nonempty stage |
 | `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) | **Sharp ferromagnetic lower bound**: `log(2 cosh(β h)) ≤ freeEnergy G p` (via `freeEnergy_bot` + `freeEnergy_monotone_subgraph`) |
 | `freeEnergyAlongExhaustion_ge_log_two_cosh` | Along-exhaustion specialization of the sharp ferromagnetic lower bound |
 | `hamiltonian_neg_h` (Hamiltonian.lean) | `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)` (spin-flip / h-sign identity) |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1581,6 +1581,12 @@ PR \#120 \texttt{freeEnergy\_zero\_params} の $\beta$-direction 版.
 \texttt{partitionFunction\_beta\_zero} + \texttt{Real.log\_pow} + $|\iota|^{-1}$ cancel.
 \end{theorem}
 
+\begin{theorem}[\texttt{freeEnergyAlongExhaustion\_beta\_zero}; PR \#132]
+Nonempty $\Lambda.\text{volume}\,n$ で
+$\texttt{freeEnergyAlongExhaustion}\,G\,\Lambda\,\langle J, h, 0 \rangle\,n = \log 2$.
+\texttt{change} + definitional unfolding で specialize.
+\end{theorem}
+
 \begin{theorem}[\texttt{inducedGraph\_bot}; PR \#129]
 $\texttt{inducedGraph}\,(\bot : \texttt{SimpleGraph}\,V)\,\Lambda
   = (\bot : \texttt{SimpleGraph}\,\uparrow\Lambda)$.


### PR DESCRIPTION
## Summary

- `freeEnergyAlongExhaustion_beta_zero`: `freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n = log 2` for nonempty `Λ.volume n` and arbitrary `J, h, G, Λ`. Specialization of PR #131 via the standard `change` + definitional-unfolding pattern.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)