### PR TITLE
feat: freeEnergyInfinite at β = 0 = log 2

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3102,6 +3102,29 @@ theorem freeEnergyAlongExhaustion_beta_zero
       (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2
   exact IsingModel.freeEnergy_beta_zero _ J h hcard
 
+/-- **Infinite-volume β=0 closed form**:
+under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2`
+for any `J, h, G, Λ`.
+
+The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n` is constantly
+`log 2` by `freeEnergyAlongExhaustion_beta_zero`, so its `limsup` on
+`atTop` is `log 2` by `Filter.limsup_const`.
+
+Sanity check: the β = 0 slice of the §4.6 Prop 4.6.1 infinite-volume
+free energy is trivially the maximum-entropy value. -/
+theorem freeEnergyInfinite_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite G Λ (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2 := by
+  unfold freeEnergyInfinite
+  have hconst : freeEnergyAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ)
+      = fun _ : ℕ => Real.log 2 := by
+    funext n
+    exact freeEnergyAlongExhaustion_beta_zero G Λ J h n (hne n)
+  rw [hconst]
+  exact Filter.limsup_const (Real.log 2)
+
 /-! ## Free-spin identity for induced subgraph -/
 
 omit [DecidableEq V] in

--- a/docs/index.md
+++ b/docs/index.md
@@ -228,6 +228,7 @@ ambient framework:
 | `partitionFunction_beta_zero` (GibbsMeasure.lean) | `Z G ⟨J, h, 0⟩ = |Config ι|` (all weights collapse to `exp 0 = 1`) |
 | `freeEnergy_beta_zero` (FreeEnergy.lean) | β=0 direction: `freeEnergy G ⟨J, h, 0⟩ = log 2` for nonempty ι, any J, h, G |
 | `freeEnergyAlongExhaustion_beta_zero` | Along-exhaustion specialization: `f_n(J, h, 0) = log 2` per nonempty stage |
+| `freeEnergyInfinite_beta_zero` | **∞-volume lift**: `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2` (all stages nonempty) |
 | `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) | **Sharp ferromagnetic lower bound**: `log(2 cosh(β h)) ≤ freeEnergy G p` (via `freeEnergy_bot` + `freeEnergy_monotone_subgraph`) |
 | `freeEnergyAlongExhaustion_ge_log_two_cosh` | Along-exhaustion specialization of the sharp ferromagnetic lower bound |
 | `hamiltonian_neg_h` (Hamiltonian.lean) | `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)` (spin-flip / h-sign identity) |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1587,6 +1587,12 @@ $\texttt{freeEnergyAlongExhaustion}\,G\,\Lambda\,\langle J, h, 0 \rangle\,n = \l
 \texttt{change} + definitional unfolding で specialize.
 \end{theorem}
 
+\begin{theorem}[\texttt{freeEnergyInfinite\_beta\_zero}; PR \#133]
+$\forall n, \Lambda.\text{volume}\,n$ nonempty を仮定:
+$\texttt{freeEnergyInfinite}\,G\,\Lambda\,\langle J, h, 0 \rangle = \log 2$.
+Constant 列に書き直して \texttt{Filter.limsup\_const} で閉.
+\end{theorem}
+
 \begin{theorem}[\texttt{inducedGraph\_bot}; PR \#129]
 $\texttt{inducedGraph}\,(\bot : \texttt{SimpleGraph}\,V)\,\Lambda
   = (\bot : \texttt{SimpleGraph}\,\uparrow\Lambda)$.


### PR DESCRIPTION
## Summary

- `freeEnergyInfinite_beta_zero`: under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2` for any `J, h, G, Λ`.

Rewrites the sequence as the constant `log 2` via `freeEnergyAlongExhaustion_beta_zero` (PR #132) and applies `Filter.limsup_const` (NeBot `atTop`).

Sanity confirmation that the β = 0 slice of the §4.6 Prop 4.6.1 infinite-volume free energy is trivially `log 2`.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] linter warning zero
- [ ] `docs/index.md` and `tex/proof-guide.tex` updated
- [ ] Independent cross-check (copilot → codex exec fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)