### PR TITLE
feat: edgeSet decomposition for disjoint sum graph (§4.6 Prop 4.6.1 Step 1)

### DIFF
--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -1,6 +1,7 @@
 import IsingModel.Basic
 import IsingModel.Hamiltonian
 import IsingModel.GibbsMeasure
+import IsingModel.SumGraph
 import IsingModel.Inequalities.NonnegCorrelations
 import IsingModel.Inequalities.GKS
 import IsingModel.Inequalities.FKG

--- a/IsingModel/SumGraph.lean
+++ b/IsingModel/SumGraph.lean
@@ -27,10 +27,13 @@ the canonical `Sum.inl` / `Sum.inr` embeddings.
   `Function.Embedding.inr`.
 * `SimpleGraph.edgeSet_sum` — edge-set decomposition as a union of
   `Sym2`-level images.
-* `SimpleGraph.disjoint_inl_inr_edgeSet` — the two images are disjoint.
+* `SimpleGraph.disjoint_inl_inr_edgeSet` — the two Set-level images are
+  disjoint.
 * `SimpleGraph.edgeSet_sum_finite` / `fintypeEdgeSetSum` — finiteness
   of the sum edge set from finiteness of the summands' edge sets.
 * `SimpleGraph.edgeFinset_sum` — `Finset`-level decomposition.
+* `SimpleGraph.disjoint_inl_inr_edgeFinset` — `Finset`-level disjointness
+  of the two images.
 * `SimpleGraph.card_edgeFinset_sum` — cardinality identity.
 -/
 
@@ -108,29 +111,28 @@ theorem edgeFinset_sum [DecidableEq V] [DecidableEq W]
   rw [Finset.coe_union, coe_edgeFinset, Finset.coe_map, Finset.coe_map,
       coe_edgeFinset, coe_edgeFinset, edgeSet_sum]
 
+/-- Finset-level disjointness: the two image finsets in `edgeFinset_sum`
+are disjoint. Derived from the Set-level `disjoint_inl_inr_edgeSet`
+by pushing disjointness through `Finset.coe`. -/
+theorem disjoint_inl_inr_edgeFinset [Fintype G.edgeSet] [Fintype H.edgeSet] :
+    Disjoint
+      (G.edgeFinset.map (Function.Embedding.inl : V ↪ V ⊕ W).sym2Map)
+      (H.edgeFinset.map (Function.Embedding.inr : W ↪ V ⊕ W).sym2Map) := by
+  rw [← Finset.disjoint_coe, Finset.coe_map, Finset.coe_map,
+      coe_edgeFinset, coe_edgeFinset]
+  exact disjoint_inl_inr_edgeSet G H
+
 /-- Cardinality identity:
 `(G ⊕g H).edgeFinset.card = G.edgeFinset.card + H.edgeFinset.card`.
 
 Classical decidability of `V` and `W` is introduced in the proof to
-invoke `edgeFinset_sum`; these instances do not appear in the type. -/
+invoke `edgeFinset_sum` and `disjoint_inl_inr_edgeFinset`; these
+instances do not appear in the type. -/
 theorem card_edgeFinset_sum [Fintype G.edgeSet] [Fintype H.edgeSet] :
     (G.sum H).edgeFinset.card = G.edgeFinset.card + H.edgeFinset.card := by
   classical
-  have hDisj :
-      Disjoint
-        (G.edgeFinset.map (Function.Embedding.inl : V ↪ V ⊕ W).sym2Map)
-        (H.edgeFinset.map (Function.Embedding.inr : W ↪ V ⊕ W).sym2Map) := by
-    rw [Finset.disjoint_left]
-    intro e heG heH
-    rw [Finset.mem_map] at heG heH
-    obtain ⟨eG, _, rfl⟩ := heG
-    obtain ⟨eH, _, hEq⟩ := heH
-    refine Sym2.inductionOn₂ eG eH
-      (fun v₁ v₂ w₁ w₂ (hEq : Sym2.map _ s(w₁, w₂) = Sym2.map _ s(v₁, v₂)) => ?_) hEq
-    simp only [Sym2.map_mk, Function.Embedding.inl_apply, Function.Embedding.inr_apply,
-               Sym2.eq_iff] at hEq
-    rcases hEq with ⟨h, _⟩ | ⟨h, _⟩ <;> exact nomatch h
-  rw [edgeFinset_sum, Finset.card_union_of_disjoint hDisj,
+  rw [edgeFinset_sum,
+      Finset.card_union_of_disjoint (disjoint_inl_inr_edgeFinset G H),
       Finset.card_map, Finset.card_map]
 
 end SimpleGraph

--- a/IsingModel/SumGraph.lean
+++ b/IsingModel/SumGraph.lean
@@ -1,0 +1,136 @@
+import Mathlib.Combinatorics.SimpleGraph.Sum
+import Mathlib.Combinatorics.SimpleGraph.Finite
+
+/-!
+# Edge-set decomposition for the disjoint sum graph
+
+Basic edge-set identities for `SimpleGraph.sum` (the disjoint sum
+`G ⊕g H`). These are infrastructure for the thermodynamic-limit
+argument of Glimm–Jaffe *Quantum Physics* (2nd ed.) §4.6 (pp. 70ff):
+on the disjoint sum graph the partition function factorizes,
+`Z_{G ⊕g H}(p) = Z_G(p) · Z_H(p)`, and therefore the log-partition
+function is additive, `log Z_{G ⊕g H} = log Z_G + log Z_H`. This
+additive identity is the combinatorial root of the super-additivity
+property of `log Z` over unions of disjoint sub-lattices, which in
+turn yields convergence of the free-energy density
+`f_Λ := (log Z_Λ) / |Λ|` via Fekete's lemma.
+
+The file proves the single combinatorial ingredient that Hamiltonian
+splitting on disjoint sums requires: the edge set of `G ⊕g H` is
+the disjoint union of the images of the summands' edge sets under
+the canonical `Sum.inl` / `Sum.inr` embeddings.
+
+## Main declarations
+
+* `SimpleGraph.sum_eq_map_sup` — `G ⊕g H` equals the join of the
+  pushforwards of `G` and `H` along `Function.Embedding.inl` and
+  `Function.Embedding.inr`.
+* `SimpleGraph.edgeSet_sum` — edge-set decomposition as a union of
+  `Sym2`-level images.
+* `SimpleGraph.disjoint_inl_inr_edgeSet` — the two images are disjoint.
+* `SimpleGraph.edgeSet_sum_finite` / `fintypeEdgeSetSum` — finiteness
+  of the sum edge set from finiteness of the summands' edge sets.
+* `SimpleGraph.edgeFinset_sum` — `Finset`-level decomposition.
+* `SimpleGraph.card_edgeFinset_sum` — cardinality identity.
+-/
+
+namespace SimpleGraph
+
+variable {V W : Type*} (G : SimpleGraph V) (H : SimpleGraph W)
+
+/-- The disjoint sum `G ⊕g H` equals the join of the pushforwards of
+`G` along `Sum.inl` and of `H` along `Sum.inr`.
+
+Case analysis on the two vertex arguments in `V ⊕ W`:
+on the diagonal (`inl,inl` / `inr,inr`) the sum-graph adjacency
+reduces to the original adjacency while the opposite `map`-summand
+vanishes by constructor disjointness; in the off-diagonal
+(`inl,inr` / `inr,inl`) both sides evaluate to `False`. -/
+theorem sum_eq_map_sup :
+    G.sum H = G.map (Function.Embedding.inl : V ↪ V ⊕ W)
+              ⊔ H.map (Function.Embedding.inr : W ↪ V ⊕ W) := by
+  ext a b
+  rcases a with a | a <;> rcases b with b | b <;>
+    simp only [sum_adj, sup_adj, map_adj',
+               Function.Embedding.inl_apply, Function.Embedding.inr_apply,
+               Sum.inl.injEq, Sum.inr.injEq, ne_eq, reduceCtorEq,
+               and_false, false_and, exists_false,
+               or_false, false_or, exists_eq_right_right, exists_eq_right]
+  · exact ⟨fun h => ⟨h.ne, h⟩, fun ⟨_, h⟩ => h⟩
+  · exact ⟨fun h => ⟨h.ne, h⟩, fun ⟨_, h⟩ => h⟩
+
+/-- Edge-set decomposition: edges of `G ⊕g H` are the union of edges
+pushed forward from `G` via `Sum.inl` and from `H` via `Sum.inr`. -/
+theorem edgeSet_sum :
+    (G.sum H).edgeSet =
+      (Function.Embedding.inl : V ↪ V ⊕ W).sym2Map '' G.edgeSet ∪
+      (Function.Embedding.inr : W ↪ V ⊕ W).sym2Map '' H.edgeSet := by
+  rw [sum_eq_map_sup, edgeSet_sup, edgeSet_map, edgeSet_map]
+
+/-- The two images in `edgeSet_sum` are disjoint: an edge of form
+`s(Sum.inl v₁, Sum.inl v₂)` cannot equal an edge of form
+`s(Sum.inr w₁, Sum.inr w₂)`. -/
+theorem disjoint_inl_inr_edgeSet :
+    Disjoint
+      ((Function.Embedding.inl : V ↪ V ⊕ W).sym2Map '' G.edgeSet)
+      ((Function.Embedding.inr : W ↪ V ⊕ W).sym2Map '' H.edgeSet) := by
+  rw [Set.disjoint_iff]
+  rintro e ⟨⟨eG, _, rfl⟩, ⟨eH, _, hEq⟩⟩
+  refine Sym2.inductionOn₂ eG eH
+    (fun v₁ v₂ w₁ w₂ (hEq : Sym2.map _ s(w₁, w₂) = Sym2.map _ s(v₁, v₂)) => ?_) hEq
+  simp only [Sym2.map_mk, Function.Embedding.inl_apply, Function.Embedding.inr_apply,
+             Sym2.eq_iff] at hEq
+  rcases hEq with ⟨h, _⟩ | ⟨h, _⟩ <;> exact nomatch h
+
+/-- The edge set of `G ⊕g H` is finite whenever both summands' edge
+sets are finite (expressed via `Set.Finite`). -/
+theorem edgeSet_sum_finite (hG : G.edgeSet.Finite) (hH : H.edgeSet.Finite) :
+    (G.sum H).edgeSet.Finite := by
+  rw [edgeSet_sum]
+  exact (hG.image _).union (hH.image _)
+
+/-- Fintype instance for `(G ⊕g H).edgeSet` from Fintype on the
+summand edge sets. -/
+noncomputable instance fintypeEdgeSetSum
+    [Fintype G.edgeSet] [Fintype H.edgeSet] : Fintype (G.sum H).edgeSet :=
+  (edgeSet_sum_finite G H (Set.toFinite _) (Set.toFinite _)).fintype
+
+/-- Finset-level decomposition: `(G ⊕g H).edgeFinset` equals the union
+of the two image finsets. The `[DecidableEq V]` / `[DecidableEq W]`
+instances are required to express the Finset union `∪` in the target. -/
+theorem edgeFinset_sum [DecidableEq V] [DecidableEq W]
+    [Fintype G.edgeSet] [Fintype H.edgeSet] :
+    (G.sum H).edgeFinset =
+      G.edgeFinset.map (Function.Embedding.inl : V ↪ V ⊕ W).sym2Map ∪
+      H.edgeFinset.map (Function.Embedding.inr : W ↪ V ⊕ W).sym2Map := by
+  classical
+  apply Finset.coe_injective
+  rw [Finset.coe_union, coe_edgeFinset, Finset.coe_map, Finset.coe_map,
+      coe_edgeFinset, coe_edgeFinset, edgeSet_sum]
+
+/-- Cardinality identity:
+`(G ⊕g H).edgeFinset.card = G.edgeFinset.card + H.edgeFinset.card`.
+
+Classical decidability of `V` and `W` is introduced in the proof to
+invoke `edgeFinset_sum`; these instances do not appear in the type. -/
+theorem card_edgeFinset_sum [Fintype G.edgeSet] [Fintype H.edgeSet] :
+    (G.sum H).edgeFinset.card = G.edgeFinset.card + H.edgeFinset.card := by
+  classical
+  have hDisj :
+      Disjoint
+        (G.edgeFinset.map (Function.Embedding.inl : V ↪ V ⊕ W).sym2Map)
+        (H.edgeFinset.map (Function.Embedding.inr : W ↪ V ⊕ W).sym2Map) := by
+    rw [Finset.disjoint_left]
+    intro e heG heH
+    rw [Finset.mem_map] at heG heH
+    obtain ⟨eG, _, rfl⟩ := heG
+    obtain ⟨eH, _, hEq⟩ := heH
+    refine Sym2.inductionOn₂ eG eH
+      (fun v₁ v₂ w₁ w₂ (hEq : Sym2.map _ s(w₁, w₂) = Sym2.map _ s(v₁, v₂)) => ?_) hEq
+    simp only [Sym2.map_mk, Function.Embedding.inl_apply, Function.Embedding.inr_apply,
+               Sym2.eq_iff] at hEq
+    rcases hEq with ⟨h, _⟩ | ⟨h, _⟩ <;> exact nomatch h
+  rw [edgeFinset_sum, Finset.card_union_of_disjoint hDisj,
+      Finset.card_map, Finset.card_map]
+
+end SimpleGraph

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,7 @@ Named specializations at `A = {i}`:
 | `isingEdgePoly_nonvanishing_of_graph` | Lee–Yang for Ising partition polynomial | `FreeEnergy.lean` | Finite |
 | `sum_eq_map_sup` (§4.6 super-add. prep) | `G ⊕g H = G.map Sum.inl ⊔ H.map Sum.inr` | `SumGraph.lean` | Disjoint-sum lemma |
 | `edgeSet_sum` | Edge-set decomposition of `G ⊕g H` | `SumGraph.lean` | Disjoint-sum lemma |
+| `disjoint_inl_inr_edgeSet` / `disjoint_inl_inr_edgeFinset` | Set / Finset disjointness of the two images | `SumGraph.lean` | Disjoint-sum lemma |
 | `card_edgeFinset_sum` | `#(G ⊕g H).edgeFinset = #G.edgeFinset + #H.edgeFinset` | `SumGraph.lean` | Disjoint-sum lemma |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,9 @@ Named specializations at `A = {i}`:
 | `partitionFunctionH_analyticAt` | `Z(h)` real-analytic | `FreeEnergy.lean` | Finite |
 | `partitionFunctionJ_analyticAt` | `Z(J)` real-analytic | `FreeEnergy.lean` | Finite |
 | `isingEdgePoly_nonvanishing_of_graph` | Lee–Yang for Ising partition polynomial | `FreeEnergy.lean` | Finite |
+| `sum_eq_map_sup` (§4.6 super-add. prep) | `G ⊕g H = G.map Sum.inl ⊔ H.map Sum.inr` | `SumGraph.lean` | Disjoint-sum lemma |
+| `edgeSet_sum` | Edge-set decomposition of `G ⊕g H` | `SumGraph.lean` | Disjoint-sum lemma |
+| `card_edgeFinset_sum` | `#(G ⊕g H).edgeFinset = #G.edgeFinset + #H.edgeFinset` | `SumGraph.lean` | Disjoint-sum lemma |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3028,4 +3028,72 @@ compound set identifications.
 \texttt{le\_of\_tendsto\_of\_tendsto'} で結論.
 \end{proof}
 
+\subsection{Edge-set decomposition for disjoint sum graphs (\texttt{SumGraph.lean})}
+
+The file \texttt{IsingModel/SumGraph.lean} records the combinatorial
+identities for \texttt{SimpleGraph.sum} ($G \oplus_g H$) that underlie
+the super-additivity argument of Glimm--Jaffe \S 4.6 (pp.\ 70ff.):
+the free-energy density on a disjoint union of lattices decomposes
+additively into the two factor contributions, which in turn rests on
+a disjoint splitting of the edge set.
+
+\begin{lemma}[\texttt{SimpleGraph.sum\_eq\_map\_sup}]
+For $G : \mathrm{SimpleGraph}\,V$ and $H : \mathrm{SimpleGraph}\,W$,
+\[
+  G \oplus_g H
+    = G.\mathrm{map}(\mathrm{inl}_{V,W})
+      \sqcup H.\mathrm{map}(\mathrm{inr}_{V,W}),
+\]
+where $\mathrm{inl}_{V,W} : V \hookrightarrow V \oplus W$ and
+$\mathrm{inr}_{V,W} : W \hookrightarrow V \oplus W$ are the canonical
+embeddings.
+\end{lemma}
+
+\begin{proof}
+Case analysis on $a, b \in V \oplus W$: both sides evaluate
+identically on \texttt{Adj}.
+\end{proof}
+
+\begin{lemma}[\texttt{SimpleGraph.edgeSet\_sum}]
+\[
+  (G \oplus_g H).E
+    = \mathrm{inl}_*(G.E) \,\cup\, \mathrm{inr}_*(H.E),
+\]
+where $\mathrm{inl}_*, \mathrm{inr}_*$ denote the induced maps on
+$\mathrm{Sym}^2$. The two summands are disjoint
+(\texttt{disjoint\_sumInlEmb\_sumInrEmb\_edgeSet}).
+\end{lemma}
+
+\begin{proof}
+Apply \texttt{edgeSet\_sup} and \texttt{edgeSet\_map} to the previous
+lemma. Disjointness follows from $\mathrm{inl}\,v \ne \mathrm{inr}\,w$.
+\end{proof}
+
+\begin{proposition}[\texttt{SimpleGraph.card\_edgeFinset\_sum}]
+If $V, W$ are finite and $G, H$ have decidable adjacency, then
+\[
+  \#(G \oplus_g H).\mathrm{edgeFinset}
+    = \#G.\mathrm{edgeFinset} + \#H.\mathrm{edgeFinset}.
+\]
+\end{proposition}
+
+\begin{proof}
+Disjoint union of Finset images. The Finset identity
+\texttt{edgeFinset\_sum} is derived from the set-level
+\texttt{edgeSet\_sum} by \texttt{Finset.coe\_injective}. Cardinality
+then follows from \texttt{Finset.card\_union\_of\_disjoint} combined
+with \texttt{Finset.card\_map} applied to the injective
+$\mathrm{Embedding.sym2Map}$.
+\end{proof}
+
+\paragraph{Context.} This file is the combinatorial Step~1 toward the
+Glimm--Jaffe \S 4.6 super-additivity proof of thermodynamic-limit
+convergence of the free-energy density. Subsequent steps
+(\texttt{Config}-product equivalence, Hamiltonian splitting,
+partition-function multiplicativity, and $\log Z$ super-additivity)
+will consume the present lemmas to lift the Fekete-type convergence
+of $f_{\Lambda}$ from the current \emph{discretized} subgraph
+setting (\texttt{freeEnergy\_convergent\_subgraph}) to the genuine
+infinite-volume exhaustion of the ambient lattice framework.
+
 \end{document}


### PR DESCRIPTION
## Summary

- Add `IsingModel/SumGraph.lean` with the combinatorial infrastructure for the Glimm–Jaffe §4.6 super-additivity argument: the edge set of `G ⊕g H = SimpleGraph.sum G H` decomposes as a disjoint union of the summands' edge sets under the canonical `Sum.inl` / `Sum.inr` embeddings.
- This is Step 1 of the Prop 4.6.1 super-additivity route; Step 2 (`Config` product equivalence), Step 3 (Hamiltonian additivity), Step 4 (partition function multiplicativity) will follow in separate PRs.

## Main declarations

- `SimpleGraph.sum_eq_map_sup`: `G ⊕g H = G.map (Embedding.inl) ⊔ H.map (Embedding.inr)`
- `SimpleGraph.edgeSet_sum`: `edgeSet` decomposition as a union of `Sym2`-level images
- `SimpleGraph.disjoint_inl_inr_edgeSet`: Set-level disjointness
- `SimpleGraph.edgeSet_sum_finite` + `fintypeEdgeSetSum`: finiteness / Fintype instance
- `SimpleGraph.edgeFinset_sum`: Finset-level decomposition
- `SimpleGraph.disjoint_inl_inr_edgeFinset`: Finset-level disjointness (derived)
- `SimpleGraph.card_edgeFinset_sum`: `#(G ⊕g H).edgeFinset = #G.edgeFinset + #H.edgeFinset`

## Cross-check

- `copilot -p` quota exhausted on 2026-04-18; per `RESUME.md §0` the codex alternative is pre-approved for this session.
- Two codex review rounds applied: initial review → address naming (use `Function.Embedding.inl/inr`), minimize hypotheses, replace `aesop` with explicit case proof. Refactor pass → extract `disjoint_inl_inr_edgeFinset` to remove duplicated `Sym2.inductionOn₂` disjointness proof from `card_edgeFinset_sum`; no remaining issues.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- All `theorem`/`instance` declarations have doc comments
- Docs and `tex/proof-guide.tex` updated

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Linter warnings: zero
- [x] Doc comments on all declarations
- [x] Cross-check reviewed and applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)