### PR TITLE
feat: Hamiltonian additivity on disjoint sum graph (§4.6 Prop 4.6.1 Step 2-3)

### DIFF
--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -2,6 +2,7 @@ import IsingModel.Basic
 import IsingModel.Hamiltonian
 import IsingModel.GibbsMeasure
 import IsingModel.SumGraph
+import IsingModel.SumModel
 import IsingModel.Inequalities.NonnegCorrelations
 import IsingModel.Inequalities.GKS
 import IsingModel.Inequalities.FKG

--- a/IsingModel/SumModel.lean
+++ b/IsingModel/SumModel.lean
@@ -1,0 +1,132 @@
+import IsingModel.Hamiltonian
+import IsingModel.SumGraph
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Logic.Equiv.Prod
+
+/-!
+# Hamiltonian additivity on the disjoint sum graph
+
+This file lifts the combinatorial edge-set decomposition from
+`IsingModel.SumGraph` to the Ising Hamiltonian: on the disjoint sum
+`G ⊕g H`, with a configuration of the form `Sum.elim σ₁ σ₂`, the
+Hamiltonian splits additively,
+`hamiltonian (G ⊕g H) p (Sum.elim σ₁ σ₂)
+  = hamiltonian G p σ₁ + hamiltonian H p σ₂`.
+
+This is Step 2–3 of the Glimm–Jaffe §4.6 (pp. 70ff) super-additivity
+route toward convergence of the thermodynamic-limit free-energy
+density (Prop 4.6.1). Step 4 (partition-function multiplicativity)
+and Step 5 (`log Z` super-additivity + Fekete) follow in subsequent PRs.
+
+## Main declarations
+
+* `IsingModel.Config.sumEquiv` — `Config (ι ⊕ ι') ≃ Config ι × Config ι'`.
+* `IsingModel.edgeSpin_sumInl_sym2Map` /
+  `IsingModel.edgeSpin_sumInr_sym2Map` — per-edge spin pullback through
+  `Sum.inl` / `Sum.inr`.
+* `IsingModel.externalFieldEnergy_sum` — additivity of the field term.
+* `IsingModel.interactionEnergy_sum` — additivity of the interaction term.
+* `IsingModel.hamiltonian_sum` — Hamiltonian additivity on `G ⊕g H`.
+-/
+
+namespace IsingModel
+
+variable {ι ι' : Type*}
+variable {K : Type*} [Field K]
+
+/-- The configuration space of a disjoint sum of vertex types is the
+product of the component configuration spaces, via the standard
+`Equiv.sumArrowEquivProdArrow`. -/
+def Config.sumEquiv : Config (ι ⊕ ι') ≃ Config ι × Config ι' :=
+  Equiv.sumArrowEquivProdArrow ι ι' Spin
+
+/-- The first component of `Config.sumEquiv σ` is the restriction of
+`σ` along `Sum.inl`. -/
+@[simp]
+theorem Config.sumEquiv_apply_fst (σ : Config (ι ⊕ ι')) (i : ι) :
+    ((Config.sumEquiv σ).1 : Config ι) i = σ (Sum.inl i) := rfl
+
+/-- The second component of `Config.sumEquiv σ` is the restriction of
+`σ` along `Sum.inr`. -/
+@[simp]
+theorem Config.sumEquiv_apply_snd (σ : Config (ι ⊕ ι')) (i : ι') :
+    ((Config.sumEquiv σ).2 : Config ι') i = σ (Sum.inr i) := rfl
+
+/-- The inverse of `Config.sumEquiv` assembles a pair of
+configurations back into a configuration on the disjoint sum type
+via `Sum.elim`. -/
+@[simp]
+theorem Config.sumEquiv_symm (σ₁ : Config ι) (σ₂ : Config ι') :
+    Config.sumEquiv.symm (σ₁, σ₂) = Sum.elim σ₁ σ₂ := rfl
+
+/-- Per-edge spin pullback through `Sum.inl`: the edge product on a
+`Sum.inl`-image edge in the sum graph equals the edge product on the
+corresponding edge of the first component. -/
+theorem edgeSpin_sumInl_sym2Map (σ₁ : Config ι) (σ₂ : Config ι')
+    (e : Sym2 ι) :
+    edgeSpin (K := K) (Sum.elim σ₁ σ₂)
+        ((Function.Embedding.inl : ι ↪ ι ⊕ ι').sym2Map e)
+      = edgeSpin σ₁ e := by
+  refine e.ind (fun i j => ?_)
+  simp [edgeSpin, Function.Embedding.sym2Map_apply, Sym2.map_mk,
+        Function.Embedding.inl_apply]
+
+/-- Per-edge spin pullback through `Sum.inr`. -/
+theorem edgeSpin_sumInr_sym2Map (σ₁ : Config ι) (σ₂ : Config ι')
+    (e : Sym2 ι') :
+    edgeSpin (K := K) (Sum.elim σ₁ σ₂)
+        ((Function.Embedding.inr : ι' ↪ ι ⊕ ι').sym2Map e)
+      = edgeSpin σ₂ e := by
+  refine e.ind (fun i j => ?_)
+  simp [edgeSpin, Function.Embedding.sym2Map_apply, Sym2.map_mk,
+        Function.Embedding.inr_apply]
+
+/-- Additivity of the external field energy on disjoint-sum
+configurations: the energy of a `Sum.elim` splits additively by
+`Fintype.sum_sum_type`. -/
+theorem externalFieldEnergy_sum [Fintype ι] [Fintype ι']
+    (h : K) (σ₁ : Config ι) (σ₂ : Config ι') :
+    externalFieldEnergy (ι := ι ⊕ ι') h (Sum.elim σ₁ σ₂)
+      = externalFieldEnergy h σ₁ + externalFieldEnergy h σ₂ := by
+  unfold externalFieldEnergy
+  rw [Fintype.sum_sum_type]
+  simp only [Sum.elim_inl, Sum.elim_inr]
+  ring
+
+/-- Additivity of the interaction energy on disjoint-sum
+configurations: via the edge-set decomposition (PR #134) and
+`edgeSpin` pullback, the sum over `(G ⊕g H).edgeFinset` splits
+additively. -/
+theorem interactionEnergy_sum
+    (G : SimpleGraph ι) (H : SimpleGraph ι')
+    [Fintype G.edgeSet] [Fintype H.edgeSet]
+    (J : K) (σ₁ : Config ι) (σ₂ : Config ι') :
+    interactionEnergy (G.sum H) J (Sum.elim σ₁ σ₂)
+      = interactionEnergy G J σ₁ + interactionEnergy H J σ₂ := by
+  classical
+  unfold interactionEnergy
+  rw [SimpleGraph.edgeFinset_sum,
+      Finset.sum_union (SimpleGraph.disjoint_inl_inr_edgeFinset G H),
+      Finset.sum_map, Finset.sum_map]
+  simp only [edgeSpin_sumInl_sym2Map, edgeSpin_sumInr_sym2Map]
+  ring
+
+/-- **Hamiltonian additivity on the disjoint sum graph**
+(Glimm–Jaffe §4.6 super-additivity Step 2-3, pp. 70ff):
+`H_{G ⊕g H}(Sum.elim σ₁ σ₂) = H_G(σ₁) + H_H(σ₂)`.
+
+Summing the interaction and external-field contributions, each of
+which decomposes additively by `interactionEnergy_sum` and
+`externalFieldEnergy_sum`. -/
+theorem hamiltonian_sum [LinearOrder K] [IsStrictOrderedRing K]
+    [Fintype ι] [Fintype ι']
+    (G : SimpleGraph ι) (H : SimpleGraph ι')
+    [Fintype G.edgeSet] [Fintype H.edgeSet]
+    (p : IsingParams K) (σ₁ : Config ι) (σ₂ : Config ι') :
+    hamiltonian (G.sum H) p (Sum.elim σ₁ σ₂)
+      = hamiltonian G p σ₁ + hamiltonian H p σ₂ := by
+  unfold hamiltonian
+  rw [interactionEnergy_sum, externalFieldEnergy_sum]
+  ring
+
+end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,9 @@ Named specializations at `A = {i}`:
 | `edgeSet_sum` | Edge-set decomposition of `G ⊕g H` | `SumGraph.lean` | Disjoint-sum lemma |
 | `disjoint_inl_inr_edgeSet` / `disjoint_inl_inr_edgeFinset` | Set / Finset disjointness of the two images | `SumGraph.lean` | Disjoint-sum lemma |
 | `card_edgeFinset_sum` | `#(G ⊕g H).edgeFinset = #G.edgeFinset + #H.edgeFinset` | `SumGraph.lean` | Disjoint-sum lemma |
+| `Config.sumEquiv` | `Config (ι ⊕ ι') ≃ Config ι × Config ι'` | `SumModel.lean` | Ising on sum graph |
+| `interactionEnergy_sum` / `externalFieldEnergy_sum` | Per-summand additivity of the Hamiltonian's interaction / field contributions on `G ⊕g H` | `SumModel.lean` | Ising on sum graph |
+| `hamiltonian_sum` (§4.6 super-add. Step 2-3) | `hamiltonian (G ⊕g H) p (Sum.elim σ₁ σ₂) = hamiltonian G p σ₁ + hamiltonian H p σ₂` | `SumModel.lean` | Ising on sum graph |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3096,4 +3096,79 @@ of $f_{\Lambda}$ from the current \emph{discretized} subgraph
 setting (\texttt{freeEnergy\_convergent\_subgraph}) to the genuine
 infinite-volume exhaustion of the ambient lattice framework.
 
+\subsection{Hamiltonian additivity on the disjoint sum graph (\texttt{SumModel.lean})}
+
+With the combinatorial edge-set decomposition from \texttt{SumGraph.lean}
+in hand (\S 0099), the Ising Hamiltonian on the disjoint sum graph
+splits additively with respect to the \texttt{Sum.elim} decomposition
+of configurations.
+
+\begin{lemma}[\texttt{IsingModel.Config.sumEquiv}]
+$\mathrm{Config}(\iota \oplus \iota')
+  \simeq \mathrm{Config}\,\iota \times \mathrm{Config}\,\iota'$,
+given by \texttt{Equiv.sumArrowEquivProdArrow}.
+\end{lemma}
+
+\begin{lemma}[\texttt{externalFieldEnergy\_sum}]
+\[
+  \sum_{i \in \iota \oplus \iota'}
+    \mathrm{sign}(\mathrm{Sum.elim}\,\sigma_1\,\sigma_2\,i)
+  = \sum_{i \in \iota} \mathrm{sign}(\sigma_1\,i)
+    + \sum_{i \in \iota'} \mathrm{sign}(\sigma_2\,i),
+\]
+proved by \texttt{Fintype.sum\_sum\_type} together with the evaluation
+of \texttt{Sum.elim} on \texttt{inl}/\texttt{inr}.
+\end{lemma}
+
+\begin{lemma}[\texttt{edgeSpin\_sumInl\_sym2Map} /
+\texttt{edgeSpin\_sumInr\_sym2Map}]
+For any $e \in \mathrm{Sym}^2\,\iota$,
+\[
+  \mathrm{edgeSpin}(\mathrm{Sum.elim}\,\sigma_1\,\sigma_2)
+    (\mathrm{Sym}^2.\mathrm{map}\,\mathrm{Sum.inl}\,e)
+  = \mathrm{edgeSpin}\,\sigma_1\,e,
+\]
+and analogously for \texttt{Sum.inr}.
+\end{lemma}
+
+\begin{proposition}[\texttt{interactionEnergy\_sum}]
+For $G, H$ with finite edge sets, $J \in K$, and
+$\sigma_1, \sigma_2$ configurations,
+\[
+  \mathrm{interactionEnergy}(G \oplus_g H)\,J\,(\mathrm{Sum.elim}\,\sigma_1\,\sigma_2)
+  = \mathrm{interactionEnergy}\,G\,J\,\sigma_1
+    + \mathrm{interactionEnergy}\,H\,J\,\sigma_2.
+\]
+\end{proposition}
+
+\begin{proof}
+Combine the edge-finset decomposition \texttt{edgeFinset\_sum} (PR \#134)
+with \texttt{Finset.sum\_union} (using
+\texttt{disjoint\_inl\_inr\_edgeFinset} for the disjointness side
+condition), then \texttt{Finset.sum\_map} and the per-edge pullbacks
+\texttt{edgeSpin\_sumInl\_sym2Map} / \texttt{edgeSpin\_sumInr\_sym2Map}.
+\end{proof}
+
+\begin{theorem}[\texttt{hamiltonian\_sum}]
+For $G, H$ with finite edge sets, and parameters $p = (J, h, \beta)$,
+\[
+  \mathcal{H}_{G \oplus_g H}(p)(\mathrm{Sum.elim}\,\sigma_1\,\sigma_2)
+  = \mathcal{H}_G(p)(\sigma_1) + \mathcal{H}_H(p)(\sigma_2).
+\]
+\end{theorem}
+
+\begin{proof}
+By additivity of each summand in
+$\mathcal{H} = \mathrm{interactionEnergy} + \mathrm{externalFieldEnergy}$
+(previous proposition and lemma).
+\end{proof}
+
+\paragraph{Next steps.} Step~4 of the super-additivity route will
+establish partition-function multiplicativity,
+$Z_{G \oplus_g H}(p) = Z_G(p) \cdot Z_H(p)$, by summing the
+exponential of the Hamiltonian over the product equivalence
+\texttt{Config.sumEquiv}; Step~5 will combine this with the already
+established upper bound (PR \#122, \#123) and Fekete's lemma to
+produce convergence of $f_\Lambda$ along arbitrary exhaustions.
+
 \end{document}


### PR DESCRIPTION
## Summary

- Add `IsingModel/SumModel.lean` proving the Hamiltonian on the disjoint sum graph `G ⊕g H` with a `Sum.elim`-split configuration decomposes additively:
  `hamiltonian (G ⊕g H) p (Sum.elim σ₁ σ₂) = hamiltonian G p σ₁ + hamiltonian H p σ₂`.
- This is Step 2–3 of the Glimm–Jaffe §4.6 super-additivity route toward Prop 4.6.1. Steps 4 and 5 follow.

## Main declarations

- `IsingModel.Config.sumEquiv`: `Config (ι ⊕ ι') ≃ Config ι × Config ι'` via `Equiv.sumArrowEquivProdArrow`.
- `IsingModel.edgeSpin_sumInl_sym2Map` / `edgeSpin_sumInr_sym2Map`: per-edge spin pullback.
- `IsingModel.externalFieldEnergy_sum`: additivity via `Fintype.sum_sum_type`.
- `IsingModel.interactionEnergy_sum`: additivity via PR #134 `edgeFinset_sum`.
- `IsingModel.hamiltonian_sum`: the final result.

## Dependencies

- PR #134: `SimpleGraph.edgeFinset_sum`, `disjoint_inl_inr_edgeFinset`.

## Cross-check

- `copilot -p` quota still exhausted on 2026-04-18; per `RESUME.md §0` codex is pre-approved.
- codex review: no blocking issues. Applied findings: moved `[LinearOrder K] [IsStrictOrderedRing K]` from file-scope `variable` to `hamiltonian_sum` locally (removing `omit` blocks in the other four theorems); clarified `docs/index.md` wording for per-summand additivity.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- All declarations have doc comments (8 / 8)
- Docs and `tex/proof-guide.tex` updated

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Linter warnings: zero
- [x] Doc comments on all declarations
- [x] Cross-check applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)