### PR TITLE
feat: partitionFunction multiplicativity on disjoint sum graph (§4.6 Prop 4.6.1 Step 4)

### DIFF
--- a/IsingModel/SumModel.lean
+++ b/IsingModel/SumModel.lean
@@ -1,5 +1,8 @@
+import IsingModel.GibbsMeasure
 import IsingModel.Hamiltonian
 import IsingModel.SumGraph
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Logic.Equiv.Prod
 
@@ -13,10 +16,17 @@ Hamiltonian splits additively,
 `hamiltonian (G ⊕g H) p (Sum.elim σ₁ σ₂)
   = hamiltonian G p σ₁ + hamiltonian H p σ₂`.
 
-This is Step 2–3 of the Glimm–Jaffe §4.6 (pp. 70ff) super-additivity
-route toward convergence of the thermodynamic-limit free-energy
-density (Prop 4.6.1). Step 4 (partition-function multiplicativity)
-and Step 5 (`log Z` super-additivity + Fekete) follow in subsequent PRs.
+This file now covers Steps 2–4 of the Glimm–Jaffe §4.6 (pp. 70ff)
+super-additivity route toward convergence of the thermodynamic-limit
+free-energy density (Prop 4.6.1):
+
+* Step 2 — `Config.sumEquiv` (configuration product equivalence).
+* Step 3 — `hamiltonian_sum` (Hamiltonian additivity).
+* Step 4 — `partitionFunction_sum` / `log_partitionFunction_sum`
+  (partition function multiplicativity, hence `log Z` additivity).
+
+Step 5 (Fekete-style convergence from `log Z` super-additivity and
+the uniform upper bound of PRs #122, #123) follows in a subsequent PR.
 
 ## Main declarations
 
@@ -27,6 +37,11 @@ and Step 5 (`log Z` super-additivity + Fekete) follow in subsequent PRs.
 * `IsingModel.externalFieldEnergy_sum` — additivity of the field term.
 * `IsingModel.interactionEnergy_sum` — additivity of the interaction term.
 * `IsingModel.hamiltonian_sum` — Hamiltonian additivity on `G ⊕g H`.
+* `IsingModel.partitionFunction_sum` —
+  `Z_{G ⊕g H}(p) = Z_G(p) · Z_H(p)` on the disjoint sum graph
+  (Glimm–Jaffe §4.6 super-additivity Step 4).
+* `IsingModel.log_partitionFunction_sum` — the logarithmic form
+  `log Z_{G ⊕g H} = log Z_G + log Z_H`.
 -/
 
 namespace IsingModel
@@ -128,5 +143,48 @@ theorem hamiltonian_sum [LinearOrder K] [IsStrictOrderedRing K]
   unfold hamiltonian
   rw [interactionEnergy_sum, externalFieldEnergy_sum]
   ring
+
+/-- **Partition function multiplicativity on the disjoint sum graph**
+(Glimm–Jaffe §4.6 super-additivity Step 4, pp. 70ff):
+`Z_{G ⊕g H}(p) = Z_G(p) · Z_H(p)`.
+
+Proof sketch. By `Equiv.sum_comp` applied to `Config.sumEquiv.symm`,
+the sum over `Config (ι ⊕ ι')` becomes a sum over
+`Config ι × Config ι'` (`Sum.elim`-assembled). `Fintype.sum_prod_type`
+splits it into a double sum. The Hamiltonian additivity of the
+previous theorem (`hamiltonian_sum`) and `Real.exp_add` turn
+`exp(-β (H_G + H_H))` into the product `exp(-β H_G) · exp(-β H_H)`.
+Finally `Finset.sum_mul_sum` collapses the double sum back into the
+product of two partition functions. -/
+theorem partitionFunction_sum
+    [Fintype ι] [Fintype ι'] [DecidableEq ι] [DecidableEq ι']
+    (G : SimpleGraph ι) (H : SimpleGraph ι')
+    [Fintype G.edgeSet] [Fintype H.edgeSet]
+    (p : IsingParams ℝ) :
+    partitionFunction (G.sum H) p
+      = partitionFunction G p * partitionFunction H p := by
+  unfold partitionFunction boltzmannWeight
+  rw [← Equiv.sum_comp Config.sumEquiv.symm
+        (fun σ => Real.exp (-p.β * hamiltonian (G.sum H) p σ))]
+  rw [Fintype.sum_prod_type]
+  simp only [Config.sumEquiv_symm, hamiltonian_sum, mul_add, Real.exp_add]
+  rw [← Finset.sum_mul_sum]
+
+/-- **Log-partition additivity on the disjoint sum graph**:
+`log Z_{G ⊕g H}(p) = log Z_G(p) + log Z_H(p)`.
+
+Immediate consequence of `partitionFunction_sum` combined with
+`Real.log_mul`, whose side conditions are discharged by
+nonvanishing (`partitionFunction_ne_zero`). -/
+theorem log_partitionFunction_sum
+    [Fintype ι] [Fintype ι'] [DecidableEq ι] [DecidableEq ι']
+    (G : SimpleGraph ι) (H : SimpleGraph ι')
+    [Fintype G.edgeSet] [Fintype H.edgeSet]
+    (p : IsingParams ℝ) :
+    Real.log (partitionFunction (G.sum H) p)
+      = Real.log (partitionFunction G p)
+        + Real.log (partitionFunction H p) := by
+  rw [partitionFunction_sum,
+      Real.log_mul (partitionFunction_ne_zero G p) (partitionFunction_ne_zero H p)]
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,8 @@ Named specializations at `A = {i}`:
 | `Config.sumEquiv` | `Config (ι ⊕ ι') ≃ Config ι × Config ι'` | `SumModel.lean` | Ising on sum graph |
 | `interactionEnergy_sum` / `externalFieldEnergy_sum` | Per-summand additivity of the Hamiltonian's interaction / field contributions on `G ⊕g H` | `SumModel.lean` | Ising on sum graph |
 | `hamiltonian_sum` (§4.6 super-add. Step 2-3) | `hamiltonian (G ⊕g H) p (Sum.elim σ₁ σ₂) = hamiltonian G p σ₁ + hamiltonian H p σ₂` | `SumModel.lean` | Ising on sum graph |
+| `partitionFunction_sum` (§4.6 super-add. Step 4) | `Z_{G ⊕g H}(p) = Z_G(p) · Z_H(p)` | `SumModel.lean` | Ising on sum graph |
+| `log_partitionFunction_sum` | `log Z_{G ⊕g H}(p) = log Z_G(p) + log Z_H(p)` | `SumModel.lean` | Ising on sum graph |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3163,12 +3163,47 @@ $\mathcal{H} = \mathrm{interactionEnergy} + \mathrm{externalFieldEnergy}$
 (previous proposition and lemma).
 \end{proof}
 
-\paragraph{Next steps.} Step~4 of the super-additivity route will
-establish partition-function multiplicativity,
-$Z_{G \oplus_g H}(p) = Z_G(p) \cdot Z_H(p)$, by summing the
-exponential of the Hamiltonian over the product equivalence
-\texttt{Config.sumEquiv}; Step~5 will combine this with the already
-established upper bound (PR \#122, \#123) and Fekete's lemma to
-produce convergence of $f_\Lambda$ along arbitrary exhaustions.
+\paragraph{Step 4: partition function multiplicativity.}
+
+\begin{proposition}[\texttt{IsingModel.partitionFunction\_sum}]
+For finite lattices $G, H$ and parameters $p = (J, h, \beta)$ over $\mathbb{R}$,
+\[
+  Z_{G \oplus_g H}(p) = Z_G(p) \cdot Z_H(p).
+\]
+\end{proposition}
+
+\begin{proof}
+Unfolding $Z = \sum_\sigma e^{-\beta \mathcal{H}}$,
+\begin{align*}
+  Z_{G \oplus_g H}(p)
+  &= \sum_{\sigma : \iota \oplus \iota' \to \mathrm{Spin}}
+       e^{-\beta \mathcal{H}_{G \oplus_g H}(\sigma)}
+     && \text{(\texttt{Equiv.sum\_comp}\,\texttt{Config.sumEquiv.symm})} \\
+  &= \sum_{\sigma_1, \sigma_2}
+       e^{-\beta (\mathcal{H}_G(\sigma_1) + \mathcal{H}_H(\sigma_2))}
+     && \text{(\texttt{Fintype.sum\_prod\_type}, \texttt{hamiltonian\_sum})} \\
+  &= \sum_{\sigma_1, \sigma_2}
+       e^{-\beta \mathcal{H}_G(\sigma_1)}
+       \cdot e^{-\beta \mathcal{H}_H(\sigma_2)}
+     && \text{(\texttt{mul\_add}, \texttt{Real.exp\_add})} \\
+  &= Z_G(p) \cdot Z_H(p)
+     && \text{(\texttt{Finset.sum\_mul\_sum}).}
+\end{align*}
+\end{proof}
+
+\begin{corollary}[\texttt{IsingModel.log\_partitionFunction\_sum}]
+\[
+  \log Z_{G \oplus_g H}(p) = \log Z_G(p) + \log Z_H(p).
+\]
+Immediate from the proposition and
+\texttt{partitionFunction\_pos} / \texttt{Real.log\_mul}.
+\end{corollary}
+
+\paragraph{Next step.} Step~5 combines the log-additivity above with
+the uniform upper bound (PR \#122, \#123) and Fekete's lemma to
+produce convergence of
+$f_\Lambda = (\log Z_\Lambda)/|\Lambda|$ along arbitrary
+exhaustions of the ambient lattice. This completes the proof of
+Glimm--Jaffe \S 4.6 Prop 4.6.1.
 
 \end{document}


### PR DESCRIPTION
## Summary

- Extend `IsingModel/SumModel.lean` with `partitionFunction_sum`: `Z_{G ⊕g H}(p) = Z_G(p) · Z_H(p)` and the log form `log_partitionFunction_sum`.
- Step 4 of the Glimm–Jaffe §4.6 super-additivity route.

## Proof

`∑_{σ : Config (ι ⊕ ι')} e^{-β H_{G⊕H}(σ)}` is reindexed via `Equiv.sum_comp Config.sumEquiv.symm` into `∑_{(σ₁, σ₂) : Config ι × Config ι'} e^{-β H_{G⊕H}(Sum.elim σ₁ σ₂)}`, expanded via `Fintype.sum_prod_type`, decomposed via `hamiltonian_sum` (PR #135) and `Real.exp_add`, and collapsed via `Finset.sum_mul_sum`. The log form uses `partitionFunction_ne_zero` + `Real.log_mul`.

## Main declarations

- `IsingModel.partitionFunction_sum`
- `IsingModel.log_partitionFunction_sum`

## Dependencies

- PR #135 (`hamiltonian_sum`)
- PR #134 (`edgeFinset_sum` indirectly, via `hamiltonian_sum`)

## Cross-check

- `copilot -p` quota still exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no mathematical issues. Applied findings: module-doc updated to reflect Step 4 inclusion; `log_partitionFunction_sum` doc wording corrected (nonvanishing, not positivity).

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- All declarations have doc comments
- Docs and `tex/proof-guide.tex` updated

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on all declarations
- [x] Cross-check applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)