### PR TITLE
feat: log Z super-additivity via disjoint sum subgraph (§4.6 Prop 4.6.1 Step 5 prep)

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -580,16 +580,28 @@ theorem partitionFunction_monotone_subgraph
     _ = _ := hexpand.symm
     _ ≤ _ := hsum_lb
 
+/-- The logarithm of the partition function is monotone in the subgraph
+order: for `G₁ ≤ G₂` and ferromagnetic `p`,
+`log Z_{G₁} p ≤ log Z_{G₂} p`. Consolidates the
+`Real.log_le_log ∘ partitionFunction_monotone_subgraph` pattern. -/
+theorem log_partitionFunction_monotone_subgraph
+    {G₁ G₂ : SimpleGraph ι} [Fintype G₁.edgeSet] [Fintype G₂.edgeSet]
+    (h₁₂ : G₁ ≤ G₂) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Real.log (partitionFunction G₁ p) ≤ Real.log (partitionFunction G₂ p) :=
+  Real.log_le_log (partitionFunction_pos G₁ p)
+    (partitionFunction_monotone_subgraph h₁₂ p hf)
+
 /-- The free energy is monotone in the subgraph order.
-Follows from `partitionFunction_monotone_subgraph` and `Real.log_le_log`. -/
+Follows from `log_partitionFunction_monotone_subgraph` after multiplying
+by `|ι|⁻¹ ≥ 0`. -/
 theorem freeEnergy_monotone_subgraph
     {G₁ G₂ : SimpleGraph ι} [Fintype G₁.edgeSet] [Fintype G₂.edgeSet]
     (h₁₂ : G₁ ≤ G₂) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
     freeEnergy G₁ p ≤ freeEnergy G₂ p := by
   unfold freeEnergy
-  apply mul_le_mul_of_nonneg_left _ (inv_nonneg.mpr (Nat.cast_nonneg _))
-  exact Real.log_le_log (partitionFunction_pos G₁ p)
-    (partitionFunction_monotone_subgraph h₁₂ p hf)
+  exact mul_le_mul_of_nonneg_left
+    (log_partitionFunction_monotone_subgraph h₁₂ p hf)
+    (inv_nonneg.mpr (Nat.cast_nonneg _))
 
 /-- The free energy rescaling identity in `β`:
 `f(J, h, β) = f(βJ, βh, 1)`. Follows from `partitionFunction_beta_rescale`

--- a/IsingModel/SumModel.lean
+++ b/IsingModel/SumModel.lean
@@ -1,3 +1,4 @@
+import IsingModel.FreeEnergy
 import IsingModel.GibbsMeasure
 import IsingModel.Hamiltonian
 import IsingModel.SumGraph
@@ -42,6 +43,12 @@ the uniform upper bound of PRs #122, #123) follows in a subsequent PR.
   (Glimm–Jaffe §4.6 super-additivity Step 4).
 * `IsingModel.log_partitionFunction_sum` — the logarithmic form
   `log Z_{G ⊕g H} = log Z_G + log Z_H`.
+* `IsingModel.partitionFunction_mul_le_of_sum_le` /
+  `IsingModel.log_partitionFunction_add_le_of_sum_le` — the
+  super-additivity inequalities `Z_G · Z_H ≤ Z_{G'}` and
+  `log Z_G + log Z_H ≤ log Z_{G'}` when `G ⊕g H ≤ G'` under
+  ferromagnetic parameters (combining Step 4 with the existing
+  subgraph monotonicity of `Z`).
 -/
 
 namespace IsingModel
@@ -186,5 +193,47 @@ theorem log_partitionFunction_sum
         + Real.log (partitionFunction H p) := by
   rw [partitionFunction_sum,
       Real.log_mul (partitionFunction_ne_zero G p) (partitionFunction_ne_zero H p)]
+
+/-- **Super-additivity inequality of the partition function**:
+for ferromagnetic parameters, any `G'` containing the disjoint sum
+`G ⊕g H` as a subgraph satisfies
+`Z_G(p) · Z_H(p) ≤ Z_{G'}(p)`.
+
+Proof: by Step 4 the left-hand side equals `Z_{G ⊕g H}(p)`; the
+existing `partitionFunction_monotone_subgraph` (from
+`FreeEnergy.lean`) upgrades the subgraph inequality
+`G ⊕g H ≤ G'` to `Z_{G ⊕g H}(p) ≤ Z_{G'}(p)` under ferromagnetic
+parameters. -/
+theorem partitionFunction_mul_le_of_sum_le
+    [Fintype ι] [Fintype ι'] [DecidableEq ι] [DecidableEq ι']
+    (G : SimpleGraph ι) (H : SimpleGraph ι')
+    [Fintype G.edgeSet] [Fintype H.edgeSet]
+    {G' : SimpleGraph (ι ⊕ ι')} [Fintype G'.edgeSet]
+    (hle : G.sum H ≤ G')
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunction G p * partitionFunction H p
+      ≤ partitionFunction G' p := by
+  rw [← partitionFunction_sum G H p]
+  exact partitionFunction_monotone_subgraph hle p hf
+
+/-- **Log form of super-additivity**:
+`log Z_G(p) + log Z_H(p) ≤ log Z_{G'}(p)` under the same assumptions.
+
+Proof: rewrite the left-hand side via `log_partitionFunction_sum`
+(Step 4) and apply the subgraph monotonicity
+`log_partitionFunction_monotone_subgraph` to `G.sum H ≤ G'`.
+This is the form used by the Fekete-style convergence argument of
+Glimm–Jaffe §4.6 (Step 5). -/
+theorem log_partitionFunction_add_le_of_sum_le
+    [Fintype ι] [Fintype ι'] [DecidableEq ι] [DecidableEq ι']
+    (G : SimpleGraph ι) (H : SimpleGraph ι')
+    [Fintype G.edgeSet] [Fintype H.edgeSet]
+    {G' : SimpleGraph (ι ⊕ ι')} [Fintype G'.edgeSet]
+    (hle : G.sum H ≤ G')
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Real.log (partitionFunction G p) + Real.log (partitionFunction H p)
+      ≤ Real.log (partitionFunction G' p) := by
+  rw [← log_partitionFunction_sum]
+  exact log_partitionFunction_monotone_subgraph hle p hf
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,7 @@ Named specializations at `A = {i}`:
 | `hamiltonian_sum` (§4.6 super-add. Step 2-3) | `hamiltonian (G ⊕g H) p (Sum.elim σ₁ σ₂) = hamiltonian G p σ₁ + hamiltonian H p σ₂` | `SumModel.lean` | Ising on sum graph |
 | `partitionFunction_sum` (§4.6 super-add. Step 4) | `Z_{G ⊕g H}(p) = Z_G(p) · Z_H(p)` | `SumModel.lean` | Ising on sum graph |
 | `log_partitionFunction_sum` | `log Z_{G ⊕g H}(p) = log Z_G(p) + log Z_H(p)` | `SumModel.lean` | Ising on sum graph |
+| `partitionFunction_mul_le_of_sum_le` / `log_partitionFunction_add_le_of_sum_le` (§4.6 super-add. Step 5 prep) | `G ⊕g H ≤ G' ⇒ Z_G · Z_H ≤ Z_{G'}` (ferromagnetic), log form | `SumModel.lean` | Ising on sum graph |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3199,11 +3199,45 @@ Immediate from the proposition and
 \texttt{partitionFunction\_pos} / \texttt{Real.log\_mul}.
 \end{corollary}
 
-\paragraph{Next step.} Step~5 combines the log-additivity above with
-the uniform upper bound (PR \#122, \#123) and Fekete's lemma to
-produce convergence of
+\paragraph{Step 5 preparation: super-additivity inequality.}
+
+\begin{proposition}[\texttt{IsingModel.partitionFunction\_mul\_le\_of\_sum\_le}]
+Let $G'$ be any finite simple graph on $\iota \oplus \iota'$
+satisfying $G \oplus_g H \le G'$. Then for ferromagnetic parameters
+$p$,
+\[
+  Z_G(p) \cdot Z_H(p) \le Z_{G'}(p).
+\]
+\end{proposition}
+
+\begin{proof}
+By Step 4, $Z_{G \oplus_g H}(p) = Z_G(p) \cdot Z_H(p)$. The
+existing \texttt{partitionFunction\_monotone\_subgraph} (proved in
+\texttt{FreeEnergy.lean} via GKS-I) gives
+$Z_{G \oplus_g H}(p) \le Z_{G'}(p)$ under ferromagnetic parameters.
+\end{proof}
+
+\begin{corollary}[\texttt{IsingModel.log\_partitionFunction\_add\_le\_of\_sum\_le}]
+Under the same assumptions,
+\[
+  \log Z_G(p) + \log Z_H(p) \le \log Z_{G'}(p).
+\]
+\end{corollary}
+
+\begin{proof}
+Positivity of partition functions and \texttt{Real.log\_mul} /
+\texttt{Real.log\_le\_log}.
+\end{proof}
+
+\paragraph{Closing Step 5.} Combining this super-additivity with the
+uniform upper bound (PR \#122, \#123) and Fekete's lemma produces
+convergence of
 $f_\Lambda = (\log Z_\Lambda)/|\Lambda|$ along arbitrary
-exhaustions of the ambient lattice. This completes the proof of
-Glimm--Jaffe \S 4.6 Prop 4.6.1.
+exhaustions of the ambient lattice, completing the proof of
+Glimm--Jaffe \S 4.6 Prop 4.6.1. The remaining technical piece is
+the type-level identification of an induced graph on
+$\Lambda_1 \cup \Lambda_2$ with a supergraph of
+$\mathrm{inducedGraph}\,G\,\Lambda_1 \oplus_g \mathrm{inducedGraph}\,G\,\Lambda_2$,
+which is the subject of a subsequent PR.
 
 \end{document}


### PR DESCRIPTION
## Summary

- Add the Step 5 input inequalities to `IsingModel/SumModel.lean`: for a supergraph `G'` of the disjoint sum `G ⊕g H` and ferromagnetic parameters, `Z_G · Z_H ≤ Z_{G'}` (and the log form).
- Refactor: consolidate the `log Z` subgraph-monotonicity pattern as `log_partitionFunction_monotone_subgraph` in `FreeEnergy.lean`, and route `freeEnergy_monotone_subgraph` through it.

## Main declarations

- `IsingModel.partitionFunction_mul_le_of_sum_le`
- `IsingModel.log_partitionFunction_add_le_of_sum_le`
- `IsingModel.log_partitionFunction_monotone_subgraph` (in `FreeEnergy.lean`, helper)

## Proof

The core combines PR #136 (`partitionFunction_sum`: `Z_{G⊕gH} = Z_G · Z_H`) with the existing `partitionFunction_monotone_subgraph` (`FreeEnergy.lean`, GKS-I based). The log form is then a single rewrite using `log_partitionFunction_sum` plus the new `log_partitionFunction_monotone_subgraph`.

## Dependencies

- PR #136 (`partitionFunction_sum`, `log_partitionFunction_sum`)
- Existing `IsingModel.partitionFunction_monotone_subgraph` (`FreeEnergy.lean`)

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no blocking issues. Applied findings: consolidated the repeated `Real.log_le_log ∘ partitionFunction_pos` pattern into `log_partitionFunction_monotone_subgraph`; clarified doc comment on `log_partitionFunction_add_le_of_sum_le`.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- All declarations have doc comments

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on all declarations
- [x] Cross-check applied
- [x] Refactoring consolidation applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)