### PR TITLE
feat: partitionFunction invariance under graph isomorphism (§4.6 Prop 4.6.1 Step 5 infra)

### DIFF
--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -1,6 +1,7 @@
 import IsingModel.Basic
 import IsingModel.Hamiltonian
 import IsingModel.GibbsMeasure
+import IsingModel.PartitionFunctionIso
 import IsingModel.SumGraph
 import IsingModel.SumModel
 import IsingModel.Inequalities.NonnegCorrelations

--- a/IsingModel/PartitionFunctionIso.lean
+++ b/IsingModel/PartitionFunctionIso.lean
@@ -1,0 +1,133 @@
+import IsingModel.GibbsMeasure
+import IsingModel.Hamiltonian
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Combinatorics.SimpleGraph.Finite
+import Mathlib.Combinatorics.SimpleGraph.Maps
+import Mathlib.Data.Fintype.BigOperators
+
+/-!
+# Partition function and Hamiltonian invariance under graph isomorphism
+
+For a type equivalence `e : V ≃ W` and a finite simple graph
+`G : SimpleGraph V`, the Hamiltonian and partition function of `G`
+are preserved by the pushforward `G.map e.toEmbedding` (as graph on
+`W`) up to reindexing of configurations along `e`.
+
+This is infrastructure for the Glimm–Jaffe §4.6 thermodynamic-limit
+proof: when relating `inducedGraph G (Λ₁ ∪ Λ₂)` (as a graph on
+`↑(Λ₁ ∪ Λ₂)`) to `inducedGraph G Λ₁ ⊕g inducedGraph G Λ₂`
+(as a graph on `↑Λ₁ ⊕ ↑Λ₂`) via
+`Equiv.Finset.disjUnionEquiv`, the partition function identity
+reduces to Hamiltonian invariance under the type transport proved
+here.
+
+## Main declarations
+
+* `IsingModel.edgeSpin_map_equiv_sym2Map` — per-edge spin product
+  pulls back through `Sym2.map e`.
+* `IsingModel.externalFieldEnergy_map_equiv` — external-field energy
+  invariance under `e : V ≃ W` (via `Fintype.sum_equiv`).
+* `IsingModel.interactionEnergy_map_equiv` — interaction energy
+  invariance via mathlib `edgeFinset_map`.
+* `IsingModel.hamiltonian_map_equiv` — Hamiltonian invariance,
+  combining the two.
+* `IsingModel.partitionFunction_map_equiv` — `Z` invariance under
+  `G.map e.toEmbedding`.
+* `IsingModel.log_partitionFunction_map_equiv` — logarithmic form.
+-/
+
+namespace IsingModel
+
+variable {V W : Type*}
+variable {K : Type*} [Field K]
+
+/-- Per-edge spin product is invariant under the `Sym2.map` pushforward:
+`edgeSpin τ (e.sym2Map s) = edgeSpin (τ ∘ e) s` for any `e : V ↪ W`,
+`τ : Config W`, and `s : Sym2 V`. -/
+theorem edgeSpin_map_equiv_sym2Map (e : V ↪ W) (τ : Config W) (s : Sym2 V) :
+    edgeSpin (K := K) τ (e.sym2Map s) = edgeSpin (τ ∘ e) s := by
+  refine s.ind (fun a b => ?_)
+  simp [edgeSpin, Function.Embedding.sym2Map_apply, Sym2.map_mk]
+
+/-- External field energy is invariant under the equivalence `e : V ≃ W`
+reindexing of sites. -/
+theorem externalFieldEnergy_map_equiv [Fintype V] [Fintype W]
+    (e : V ≃ W) (h : K) (τ : Config W) :
+    externalFieldEnergy (ι := W) h τ
+      = externalFieldEnergy (ι := V) h (τ ∘ e) := by
+  unfold externalFieldEnergy
+  congr 1
+  exact (Fintype.sum_equiv e _ _ (fun _ => rfl)).symm
+
+/-- Interaction energy is invariant under the `SimpleGraph.map e.toEmbedding`
+pushforward along `e : V ≃ W`: the `(G.map e).edgeFinset`
+equality to `G.edgeFinset.map e.toEmbedding.sym2Map` is derived
+from mathlib's set-level `edgeSet_map` (the finset-level
+`edgeFinset_map` cannot be used directly because the ambient
+`Fintype` instance on `(G.map e).edgeSet` is supplied as a
+hypothesis rather than the canonical one), and the per-edge spin
+then transports via `edgeSpin_map_equiv_sym2Map`. -/
+theorem interactionEnergy_map_equiv
+    (e : V ≃ W) (G : SimpleGraph V)
+    [Fintype G.edgeSet] [Fintype (G.map e.toEmbedding).edgeSet]
+    (J : K) (τ : Config W) :
+    interactionEnergy (G.map e.toEmbedding) J τ
+      = interactionEnergy G J (τ ∘ e) := by
+  have hEF : (G.map e.toEmbedding).edgeFinset
+      = G.edgeFinset.map e.toEmbedding.sym2Map := by
+    apply Finset.coe_injective
+    rw [SimpleGraph.coe_edgeFinset, Finset.coe_map, SimpleGraph.coe_edgeFinset]
+    exact SimpleGraph.edgeSet_map e.toEmbedding G
+  unfold interactionEnergy
+  rw [hEF, Finset.sum_map]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro s _
+  exact edgeSpin_map_equiv_sym2Map (K := K) e.toEmbedding τ s
+
+/-- Hamiltonian invariance under graph iso transport along `e : V ≃ W`:
+`hamiltonian (G.map e) p τ = hamiltonian G p (τ ∘ e)`. -/
+theorem hamiltonian_map_equiv [LinearOrder K] [IsStrictOrderedRing K]
+    [Fintype V] [Fintype W]
+    (e : V ≃ W) (G : SimpleGraph V)
+    [Fintype G.edgeSet] [Fintype (G.map e.toEmbedding).edgeSet]
+    (p : IsingParams K) (τ : Config W) :
+    hamiltonian (G.map e.toEmbedding) p τ
+      = hamiltonian G p (τ ∘ e) := by
+  unfold hamiltonian
+  rw [interactionEnergy_map_equiv e G p.J τ,
+      externalFieldEnergy_map_equiv e p.h τ]
+
+/-- **Partition function invariance under graph iso transport**:
+for a type equivalence `e : V ≃ W` and a finite simple graph
+`G : SimpleGraph V`, pushing forward along `e` leaves the partition
+function unchanged:
+`partitionFunction (G.map e.toEmbedding) p = partitionFunction G p`. -/
+theorem partitionFunction_map_equiv
+    [Fintype V] [Fintype W] [DecidableEq V] [DecidableEq W]
+    (e : V ≃ W) (G : SimpleGraph V)
+    [Fintype G.edgeSet] [Fintype (G.map e.toEmbedding).edgeSet]
+    (p : IsingParams ℝ) :
+    partitionFunction (G.map e.toEmbedding) p = partitionFunction G p := by
+  unfold partitionFunction boltzmannWeight
+  rw [← Equiv.sum_comp (Equiv.arrowCongr e (Equiv.refl Spin))
+        (fun τ : Config W => Real.exp (-p.β * hamiltonian (G.map e.toEmbedding) p τ))]
+  apply Finset.sum_congr rfl
+  intro σ _
+  have hτ : (Equiv.arrowCongr e (Equiv.refl Spin)) σ = σ ∘ e.symm := by
+    funext w; simp [Equiv.arrowCongr]
+  rw [hτ, hamiltonian_map_equiv e G p (σ ∘ e.symm)]
+  have hcomp : (σ ∘ e.symm) ∘ e = σ := by funext v; simp
+  rw [hcomp]
+
+/-- Logarithmic form of `partitionFunction_map_equiv`. -/
+theorem log_partitionFunction_map_equiv
+    [Fintype V] [Fintype W] [DecidableEq V] [DecidableEq W]
+    (e : V ≃ W) (G : SimpleGraph V)
+    [Fintype G.edgeSet] [Fintype (G.map e.toEmbedding).edgeSet]
+    (p : IsingParams ℝ) :
+    Real.log (partitionFunction (G.map e.toEmbedding) p)
+      = Real.log (partitionFunction G p) := by
+  rw [partitionFunction_map_equiv]
+
+end IsingModel

--- a/IsingModel/SumModel.lean
+++ b/IsingModel/SumModel.lean
@@ -1,6 +1,7 @@
 import IsingModel.FreeEnergy
 import IsingModel.GibbsMeasure
 import IsingModel.Hamiltonian
+import IsingModel.PartitionFunctionIso
 import IsingModel.SumGraph
 import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
@@ -83,25 +84,25 @@ theorem Config.sumEquiv_symm (σ₁ : Config ι) (σ₂ : Config ι') :
 
 /-- Per-edge spin pullback through `Sum.inl`: the edge product on a
 `Sum.inl`-image edge in the sum graph equals the edge product on the
-corresponding edge of the first component. -/
+corresponding edge of the first component. Specialization of the
+general iso transport `edgeSpin_map_equiv_sym2Map`. -/
 theorem edgeSpin_sumInl_sym2Map (σ₁ : Config ι) (σ₂ : Config ι')
-    (e : Sym2 ι) :
+    (s : Sym2 ι) :
     edgeSpin (K := K) (Sum.elim σ₁ σ₂)
-        ((Function.Embedding.inl : ι ↪ ι ⊕ ι').sym2Map e)
-      = edgeSpin σ₁ e := by
-  refine e.ind (fun i j => ?_)
-  simp [edgeSpin, Function.Embedding.sym2Map_apply, Sym2.map_mk,
-        Function.Embedding.inl_apply]
+        ((Function.Embedding.inl : ι ↪ ι ⊕ ι').sym2Map s)
+      = edgeSpin σ₁ s := by
+  rw [edgeSpin_map_equiv_sym2Map]
+  rfl
 
-/-- Per-edge spin pullback through `Sum.inr`. -/
+/-- Per-edge spin pullback through `Sum.inr`. Specialization of
+`edgeSpin_map_equiv_sym2Map`. -/
 theorem edgeSpin_sumInr_sym2Map (σ₁ : Config ι) (σ₂ : Config ι')
-    (e : Sym2 ι') :
+    (s : Sym2 ι') :
     edgeSpin (K := K) (Sum.elim σ₁ σ₂)
-        ((Function.Embedding.inr : ι' ↪ ι ⊕ ι').sym2Map e)
-      = edgeSpin σ₂ e := by
-  refine e.ind (fun i j => ?_)
-  simp [edgeSpin, Function.Embedding.sym2Map_apply, Sym2.map_mk,
-        Function.Embedding.inr_apply]
+        ((Function.Embedding.inr : ι' ↪ ι ⊕ ι').sym2Map s)
+      = edgeSpin σ₂ s := by
+  rw [edgeSpin_map_equiv_sym2Map]
+  rfl
 
 /-- Additivity of the external field energy on disjoint-sum
 configurations: the energy of a `Sum.elim` splits additively by

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ Named specializations at `A = {i}`:
 | `partitionFunction_sum` (§4.6 super-add. Step 4) | `Z_{G ⊕g H}(p) = Z_G(p) · Z_H(p)` | `SumModel.lean` | Ising on sum graph |
 | `log_partitionFunction_sum` | `log Z_{G ⊕g H}(p) = log Z_G(p) + log Z_H(p)` | `SumModel.lean` | Ising on sum graph |
 | `partitionFunction_mul_le_of_sum_le` / `log_partitionFunction_add_le_of_sum_le` (§4.6 super-add. Step 5 prep) | `G ⊕g H ≤ G' ⇒ Z_G · Z_H ≤ Z_{G'}` (ferromagnetic), log form | `SumModel.lean` | Ising on sum graph |
+| `partitionFunction_map_equiv` / `log_partitionFunction_map_equiv` | `e : V ≃ W ⇒ Z_{G.map e} = Z_G` (iso invariance) | `PartitionFunctionIso.lean` | Step 5 infra |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3240,4 +3240,37 @@ $\Lambda_1 \cup \Lambda_2$ with a supergraph of
 $\mathrm{inducedGraph}\,G\,\Lambda_1 \oplus_g \mathrm{inducedGraph}\,G\,\Lambda_2$,
 which is the subject of a subsequent PR.
 
+\subsection{Partition function invariance under graph isomorphism
+(\texttt{PartitionFunctionIso.lean})}
+
+\begin{proposition}[\texttt{IsingModel.partitionFunction\_map\_equiv}]
+Let $e \colon V \simeq W$ be a type equivalence and
+$G \colon \mathrm{SimpleGraph}\,V$. Then the pushforward
+$G.\mathrm{map}\,e.\mathrm{toEmbedding}$ has the same partition function:
+\[
+  Z_{G.\mathrm{map}\,e}(p) = Z_G(p).
+\]
+\end{proposition}
+
+\begin{proof}
+Reindex $\sum_{\tau : W \to \mathrm{Spin}} \exp(-\beta \mathcal{H}_{G.\mathrm{map}\,e}(\tau))$ via
+\texttt{Equiv.arrowCongr}\,$e$\,\texttt{Equiv.refl}, which puts it in
+bijection with $\sum_{\sigma : V \to \mathrm{Spin}} \exp(-\beta \mathcal{H}_G(\sigma))$
+using Hamiltonian invariance
+\texttt{hamiltonian\_map\_equiv}: for $\sigma = \tau \circ e$,
+$\mathcal{H}_{G.\mathrm{map}\,e}(\tau) = \mathcal{H}_G(\sigma)$. The
+Hamiltonian invariance itself splits into invariance of the
+interaction energy (via \texttt{edgeFinset\_map} + per-edge
+spin pullback along $\mathrm{Sym}^2$-map) and invariance of the
+external-field energy (\texttt{Fintype.sum\_equiv}).
+\end{proof}
+
+\paragraph{Purpose.} This is infrastructure for transporting an
+\texttt{inducedGraph} on a disjoint Finset union
+$\Lambda_1 \cup \Lambda_2$ back to a graph on the disjoint sum
+type $\uparrow\Lambda_1 \oplus \uparrow\Lambda_2$
+(via \texttt{Equiv.Finset.disjUnionEquiv}), so that the
+super-additivity inequality of the previous step applies to
+actual finite-volume exhaustions.
+
 \end{document}


### PR DESCRIPTION
## Summary

- Add `IsingModel/PartitionFunctionIso.lean` proving Hamiltonian and partition-function invariance under the graph pushforward `G.map e.toEmbedding` along a type equivalence `e : V ≃ W`.
- Step 5 infrastructure: needed to connect an `inducedGraph` on a Finset disjoint union `Λ₁ ∪ Λ₂` (a graph on `↑(Λ₁ ∪ Λ₂)`) to a disjoint sum graph on `↑Λ₁ ⊕ ↑Λ₂` via `Equiv.Finset.disjUnionEquiv`.

## Main declarations

- `IsingModel.edgeSpin_map_equiv_sym2Map`
- `IsingModel.externalFieldEnergy_map_equiv`, `IsingModel.interactionEnergy_map_equiv`
- `IsingModel.hamiltonian_map_equiv`
- `IsingModel.partitionFunction_map_equiv` / `IsingModel.log_partitionFunction_map_equiv`

## Refactor (codex consolidation)

`SumModel.lean`'s `edgeSpin_sumInl_sym2Map` / `edgeSpin_sumInr_sym2Map` are now thin specializations of the new generic `edgeSpin_map_equiv_sym2Map`.

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no blocking findings. Applied: doc comment clarified (the `interactionEnergy_map_equiv` proof uses `edgeSet_map` + `Finset.coe_injective`, not `edgeFinset_map` directly, because the ambient `Fintype` on the mapped edge set is a hypothesis rather than the canonical instance). Applied: SumModel consolidation via the new general lemma.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- All declarations have doc comments

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on all declarations
- [x] Cross-check applied
- [x] SumModel consolidation applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)