### PR TITLE
feat: super-additivity of log Z on inducedGraph over Finset disjoint union (§4.6 Prop 4.6.1 Step 5 body)

### DIFF
--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -9,3 +9,4 @@ import IsingModel.Inequalities.GKS
 import IsingModel.Inequalities.FKG
 import IsingModel.Asano
 import IsingModel.AmbientLattice
+import IsingModel.AmbientLatticeSum

--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -1,0 +1,137 @@
+import IsingModel.AmbientLattice
+import IsingModel.PartitionFunctionIso
+import IsingModel.SumModel
+import Mathlib.Data.Finset.Basic
+
+/-!
+# Super-additivity of `log Z` on `inducedGraph` over Finset disjoint union
+
+Combining the disjoint-sum super-additivity machinery (PRs #134–#137)
+with the graph isomorphism invariance (PR #138), we lift the
+super-additivity inequality to `inducedGraph` on an actual
+Finset disjoint union `Λ₁ ∪ Λ₂` of the ambient lattice `V`.
+
+## Main declarations
+
+* `IsingModel.inducedGraph_sum_map_le_union` — the transported
+  disjoint sum of induced subgraphs is a subgraph of the induced
+  subgraph on the union.
+* `IsingModel.partitionFunction_inducedGraph_disjUnion_super_multiplicative`
+  — the multiplicative form
+  `Z_{inducedGraph G Λ₁} · Z_{inducedGraph G Λ₂}
+    ≤ Z_{inducedGraph G (Λ₁ ∪ Λ₂)}` for ferromagnetic `p`.
+* `IsingModel.log_partitionFunction_inducedGraph_disjUnion_super_additive`
+  — the log form
+  `log Z_{inducedGraph G Λ₁} + log Z_{inducedGraph G Λ₂}
+    ≤ log Z_{inducedGraph G (Λ₁ ∪ Λ₂)}` for ferromagnetic `p`.
+-/
+
+namespace IsingModel
+
+open Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- For disjoint `Λ₁, Λ₂ : Finset V`, the `Sum.inl`/`Sum.inr`
+pushforward of the disjoint sum of induced subgraphs on `Λ₁, Λ₂`
+(viewed as a graph on `↑Λ₁ ⊕ ↑Λ₂`) sits inside the induced
+subgraph on `Λ₁ ∪ Λ₂` (after transport along
+`Equiv.Finset.union`). -/
+theorem inducedGraph_sum_map_le_union (G : SimpleGraph V)
+    {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂) :
+    ((inducedGraph G Λ₁).sum (inducedGraph G Λ₂)).map
+        (Equiv.Finset.union Λ₁ Λ₂ hd).toEmbedding
+      ≤ inducedGraph G (Λ₁ ∪ Λ₂) := by
+  intro a b hab
+  rw [SimpleGraph.map_adj'] at hab
+  obtain ⟨_hne, x, y, hxy, hx, hy⟩ := hab
+  rcases x with ⟨x, hx₁⟩ | ⟨x, hx₂⟩ <;>
+    rcases y with ⟨y, hy₁⟩ | ⟨y, hy₂⟩
+  · -- inl, inl
+    subst hx; subst hy
+    simpa [inducedGraph, SimpleGraph.induce] using hxy
+  · -- inl, inr: disjoint sum graph has no such edge
+    simp [SimpleGraph.sum_adj] at hxy
+  · -- inr, inl: disjoint sum graph has no such edge
+    simp [SimpleGraph.sum_adj] at hxy
+  · -- inr, inr
+    subst hx; subst hy
+    simpa [inducedGraph, SimpleGraph.induce] using hxy
+
+/-- **Super-multiplicative form** of `Z` on `inducedGraph` over
+Finset disjoint union (Glimm–Jaffe §4.6 Prop 4.6.1 Step 5 body,
+multiplicative form): for disjoint `Λ₁, Λ₂ : Finset V` and
+ferromagnetic `p`,
+```
+Z_{inducedGraph G Λ₁}(p) · Z_{inducedGraph G Λ₂}(p)
+  ≤ Z_{inducedGraph G (Λ₁ ∪ Λ₂)}(p).
+```
+
+Mirrors `partitionFunction_mul_le_of_sum_le` (PR #137) in the
+ambient-lattice setting. -/
+theorem partitionFunction_inducedGraph_disjUnion_super_multiplicative
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunction (inducedGraph G Λ₁) p
+        * partitionFunction (inducedGraph G Λ₂) p
+      ≤ partitionFunction (inducedGraph G (Λ₁ ∪ Λ₂)) p := by
+  classical
+  calc partitionFunction (inducedGraph G Λ₁) p
+          * partitionFunction (inducedGraph G Λ₂) p
+      = partitionFunction
+          ((inducedGraph G Λ₁).sum (inducedGraph G Λ₂)) p :=
+        (partitionFunction_sum _ _ _).symm
+    _ = partitionFunction
+          (((inducedGraph G Λ₁).sum (inducedGraph G Λ₂)).map
+            (Equiv.Finset.union Λ₁ Λ₂ hd).toEmbedding) p :=
+        (partitionFunction_map_equiv _ _ _).symm
+    _ ≤ partitionFunction (inducedGraph G (Λ₁ ∪ Λ₂)) p :=
+        partitionFunction_monotone_subgraph
+          (inducedGraph_sum_map_le_union G hd) p hf
+
+/-- **Super-additivity of `log Z` on `inducedGraph` over Finset
+disjoint union** (Glimm–Jaffe §4.6 Prop 4.6.1 Step 5 body):
+for disjoint `Λ₁, Λ₂ : Finset V` and ferromagnetic `p`,
+```
+log Z_{inducedGraph G Λ₁}(p) + log Z_{inducedGraph G Λ₂}(p)
+  ≤ log Z_{inducedGraph G (Λ₁ ∪ Λ₂)}(p).
+```
+
+Proof chain.
+1. By PR #136 `log_partitionFunction_sum`, the LHS equals
+   `log Z_{(inducedGraph G Λ₁).sum (inducedGraph G Λ₂)}`.
+2. By PR #138 `log_partitionFunction_map_equiv`, pushing the
+   disjoint sum along `(Equiv.Finset.union Λ₁ Λ₂ hd).toEmbedding`
+   leaves `log Z` unchanged.
+3. The pushforward is a subgraph of `inducedGraph G (Λ₁ ∪ Λ₂)`
+   by `inducedGraph_sum_map_le_union`.
+4. Ferromagnetic subgraph monotonicity of `log Z`
+   (`log_partitionFunction_monotone_subgraph`, PR #137 refactor)
+   closes. -/
+theorem log_partitionFunction_inducedGraph_disjUnion_super_additive
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Real.log (partitionFunction (inducedGraph G Λ₁) p)
+      + Real.log (partitionFunction (inducedGraph G Λ₂) p)
+    ≤ Real.log (partitionFunction (inducedGraph G (Λ₁ ∪ Λ₂)) p) := by
+  classical
+  calc Real.log (partitionFunction (inducedGraph G Λ₁) p)
+          + Real.log (partitionFunction (inducedGraph G Λ₂) p)
+      = Real.log (partitionFunction
+          ((inducedGraph G Λ₁).sum (inducedGraph G Λ₂)) p) :=
+        (log_partitionFunction_sum _ _ _).symm
+    _ = Real.log (partitionFunction
+          (((inducedGraph G Λ₁).sum (inducedGraph G Λ₂)).map
+            (Equiv.Finset.union Λ₁ Λ₂ hd).toEmbedding) p) :=
+        (log_partitionFunction_map_equiv _ _ _).symm
+    _ ≤ Real.log (partitionFunction (inducedGraph G (Λ₁ ∪ Λ₂)) p) :=
+        log_partitionFunction_monotone_subgraph
+          (inducedGraph_sum_map_le_union G hd) p hf
+
+end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,7 @@ Named specializations at `A = {i}`:
 | `log_partitionFunction_sum` | `log Z_{G ⊕g H}(p) = log Z_G(p) + log Z_H(p)` | `SumModel.lean` | Ising on sum graph |
 | `partitionFunction_mul_le_of_sum_le` / `log_partitionFunction_add_le_of_sum_le` (§4.6 super-add. Step 5 prep) | `G ⊕g H ≤ G' ⇒ Z_G · Z_H ≤ Z_{G'}` (ferromagnetic), log form | `SumModel.lean` | Ising on sum graph |
 | `partitionFunction_map_equiv` / `log_partitionFunction_map_equiv` | `e : V ≃ W ⇒ Z_{G.map e} = Z_G` (iso invariance) | `PartitionFunctionIso.lean` | Step 5 infra |
+| `log_partitionFunction_inducedGraph_disjUnion_super_additive` (§4.6 Prop 4.6.1 Step 5 body) | `Disjoint Λ₁ Λ₂ ⇒ log Z_{inducedGraph Λ₁} + log Z_{inducedGraph Λ₂} ≤ log Z_{inducedGraph (Λ₁ ∪ Λ₂)}` (ferromagnetic) | `AmbientLatticeSum.lean` | Step 5 body |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3273,4 +3273,47 @@ type $\uparrow\Lambda_1 \oplus \uparrow\Lambda_2$
 super-additivity inequality of the previous step applies to
 actual finite-volume exhaustions.
 
+\subsection{Super-additivity on Finset disjoint union
+(\texttt{AmbientLatticeSum.lean})}
+
+\begin{theorem}[\texttt{IsingModel.log\_partitionFunction\_inducedGraph\_disjUnion\_super\_additive}]
+For $G \colon \mathrm{SimpleGraph}\,V$, disjoint
+$\Lambda_1, \Lambda_2 : \mathrm{Finset}\,V$, and ferromagnetic $p$,
+\[
+  \log Z_{\mathrm{inducedGraph}\,G\,\Lambda_1}(p)
+  + \log Z_{\mathrm{inducedGraph}\,G\,\Lambda_2}(p)
+  \le \log Z_{\mathrm{inducedGraph}\,G\,(\Lambda_1 \cup \Lambda_2)}(p).
+\]
+\end{theorem}
+
+\begin{proof}
+Let $e = \mathrm{Equiv.Finset.union}\,\Lambda_1\,\Lambda_2\,\mathrm{hd}
+  \colon \uparrow\!\Lambda_1 \oplus \uparrow\!\Lambda_2
+     \simeq \uparrow\!(\Lambda_1 \cup \Lambda_2)$.
+\begin{align*}
+  \log Z_{\mathrm{inducedGraph}\,\Lambda_1}
+  + \log Z_{\mathrm{inducedGraph}\,\Lambda_2}
+  &= \log Z_{\mathrm{inducedGraph}\,\Lambda_1
+      \oplus_g \mathrm{inducedGraph}\,\Lambda_2}
+     & \text{(\S 0101 \texttt{log\_partitionFunction\_sum})} \\
+  &= \log Z_{(\mathrm{inducedGraph}\,\Lambda_1
+      \oplus_g \mathrm{inducedGraph}\,\Lambda_2).\mathrm{map}\,e}
+     & \text{(\S 0103 \texttt{log\_partitionFunction\_map\_equiv})} \\
+  &\le \log Z_{\mathrm{inducedGraph}\,(\Lambda_1 \cup \Lambda_2)}
+     & \text{(ferromagnetic subgraph monotonicity,}
+\end{align*}
+using the key subgraph relation \texttt{inducedGraph\_sum\_map\_le\_union}:
+every edge of $(\mathrm{inducedGraph}\,\Lambda_1
+\oplus_g \mathrm{inducedGraph}\,\Lambda_2)\,.\mathrm{map}\,e$ is
+either an $\mathrm{inl}$-image edge (both endpoints in $\Lambda_1$)
+or an $\mathrm{inr}$-image edge (both in $\Lambda_2$), and in either
+case it is an edge of $\mathrm{inducedGraph}\,G\,(\Lambda_1 \cup \Lambda_2)$.
+\end{proof}
+
+\paragraph{Closing Prop 4.6.1.} Combined with the uniform upper
+bound (PR \#122, \#123), Fekete's lemma now yields
+convergence of $f_\Lambda = (\log Z_\Lambda)/|\Lambda|$ along
+arbitrary exhaustions of the ambient lattice; this is the
+Prop 4.6.1 body in the next PR.
+
 \end{document}


### PR DESCRIPTION
## Summary

- Add `IsingModel/AmbientLatticeSum.lean` with the core §4.6 Step 5 inequality: on any ambient lattice `V`, for disjoint `Λ₁, Λ₂ : Finset V` and ferromagnetic `p`,
  - `Z_{inducedGraph G Λ₁} · Z_{inducedGraph G Λ₂} ≤ Z_{inducedGraph G (Λ₁ ∪ Λ₂)}`
  - `log Z_{inducedGraph G Λ₁} + log Z_{inducedGraph G Λ₂} ≤ log Z_{inducedGraph G (Λ₁ ∪ Λ₂)}`

## Main declarations

- `IsingModel.inducedGraph_sum_map_le_union`
- `IsingModel.partitionFunction_inducedGraph_disjUnion_super_multiplicative`
- `IsingModel.log_partitionFunction_inducedGraph_disjUnion_super_additive`

## Proof

Pushes the disjoint sum graph of induced subgraphs along `Equiv.Finset.union Λ₁ Λ₂ hd : ↑Λ₁ ⊕ ↑Λ₂ ≃ ↑(Λ₁ ∪ Λ₂)`, shows the pushforward is a subgraph of the induced graph on the union (by case analysis on the `Sum.inl`/`Sum.inr` constructor of the witness edge), and combines with:
- PR #136 `log_partitionFunction_sum` (exact additivity on disjoint sums)
- PR #138 `log_partitionFunction_map_equiv` (iso invariance)
- PR #137 refactor `log_partitionFunction_monotone_subgraph` (ferromagnetic subgraph monotonicity).

## Dependencies

- PRs #134–#138 (entire super-additivity chain through iso invariance)
- Existing `inducedGraph` / `partitionFunctionΛ` (`AmbientLattice.lean`)

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no blocking findings. Applied: doc typo `Equiv.Finset.union Λ₁ Λ₂ hd.toEmbedding` → `(Equiv.Finset.union Λ₁ Λ₂ hd).toEmbedding`; API parity with `SumModel.lean` by exposing the multiplicative form alongside the log form.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- All declarations have doc comments

## Remaining

Prop 4.6.1 body: combine this super-additivity with the uniform upper bound of PRs #122, #123 and Fekete's lemma to yield convergence of `freeEnergyAlongExhaustion` along arbitrary exhaustions.

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on all declarations
- [x] Cross-check applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)