### PR TITLE
feat: freeEnergyΛ weighted super-additivity wrapper (§4.6 Prop 4.6.1 toward Fekete)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -24,6 +24,15 @@ Finset disjoint union `Λ₁ ∪ Λ₂` of the ambient lattice `V`.
   — the log form
   `log Z_{inducedGraph G Λ₁} + log Z_{inducedGraph G Λ₂}
     ≤ log Z_{inducedGraph G (Λ₁ ∪ Λ₂)}` for ferromagnetic `p`.
+* `IsingModel.Ambient.partitionFunctionΛ_disjUnion_super_multiplicative` /
+  `IsingModel.Ambient.log_partitionFunctionΛ_disjUnion_super_additive` —
+  wrappers expressed in the `partitionFunctionΛ` / log form.
+* `IsingModel.Ambient.card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty`
+  — the identity `|Λ| · freeEnergyΛ Λ = log Z_Λ` for nonempty `Λ`.
+* `IsingModel.Ambient.freeEnergyΛ_weighted_super_additive_of_nonempty`
+  — weighted super-additivity
+  `|Λ₁| · f_{Λ₁} + |Λ₂| · f_{Λ₂} ≤ |Λ₁ ∪ Λ₂| · f_{Λ₁ ∪ Λ₂}`
+  for disjoint nonempty `Λ₁, Λ₂`.
 -/
 
 namespace IsingModel
@@ -133,5 +142,86 @@ theorem log_partitionFunction_inducedGraph_disjUnion_super_additive
     _ ≤ Real.log (partitionFunction (inducedGraph G (Λ₁ ∪ Λ₂)) p) :=
         log_partitionFunction_monotone_subgraph
           (inducedGraph_sum_map_le_union G hd) p hf
+
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- Wrapper of `partitionFunction_inducedGraph_disjUnion_super_multiplicative`
+at the `partitionFunctionΛ` API level. -/
+theorem partitionFunctionΛ_disjUnion_super_multiplicative
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunctionΛ G Λ₁ p * partitionFunctionΛ G Λ₂ p
+      ≤ partitionFunctionΛ G (Λ₁ ∪ Λ₂) p :=
+  IsingModel.partitionFunction_inducedGraph_disjUnion_super_multiplicative
+    G hd p hf
+
+/-- Wrapper of
+`log_partitionFunction_inducedGraph_disjUnion_super_additive` at the
+`partitionFunctionΛ` API level. -/
+theorem log_partitionFunctionΛ_disjUnion_super_additive
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Real.log (partitionFunctionΛ G Λ₁ p)
+      + Real.log (partitionFunctionΛ G Λ₂ p)
+    ≤ Real.log (partitionFunctionΛ G (Λ₁ ∪ Λ₂) p) :=
+  IsingModel.log_partitionFunction_inducedGraph_disjUnion_super_additive
+    G hd p hf
+
+/-- Identity `|Λ| · freeEnergyΛ G Λ p = log (partitionFunctionΛ G Λ p)`
+for nonempty `Λ`. Unfolds `freeEnergy = |ι|⁻¹ · log Z` and cancels
+`(Λ.card : ℝ) > 0` against its inverse via `field_simp`. The
+`Nonempty` hypothesis is needed at the proof level to rule out the
+`|Λ| = 0` degenerate case (where the identity still holds but the
+cancellation step does not apply uniformly). -/
+theorem card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty
+    (G : SimpleGraph V) {Λ : Finset V} (hne : Λ.Nonempty)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (p : IsingParams ℝ) :
+    (Λ.card : ℝ) * freeEnergyΛ G Λ p
+      = Real.log (partitionFunctionΛ G Λ p) := by
+  unfold freeEnergyΛ IsingModel.freeEnergy
+  rw [Fintype.card_coe]
+  have hne_card : (Λ.card : ℝ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (Finset.card_ne_zero.mpr hne)
+  -- Clear `(Λ.card : ℝ)⁻¹` against the outer `Λ.card` using `hne_card`.
+  field_simp
+  rfl
+
+/-- **Weighted super-additivity of the free energy density** on
+disjoint Finset unions (nonempty case):
+```
+|Λ₁| · freeEnergyΛ G Λ₁ p + |Λ₂| · freeEnergyΛ G Λ₂ p
+  ≤ |Λ₁ ∪ Λ₂| · freeEnergyΛ G (Λ₁ ∪ Λ₂) p
+```
+for disjoint nonempty `Λ₁, Λ₂` and ferromagnetic `p`.
+
+This is the Finset-weighted form of the Step 5 super-additivity
+inequality, suitable as input for a Fekete-style convergence
+argument. -/
+theorem freeEnergyΛ_weighted_super_additive_of_nonempty
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V}
+    (hne₁ : Λ₁.Nonempty) (hne₂ : Λ₂.Nonempty) (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Λ₁.card : ℝ) * freeEnergyΛ G Λ₁ p
+      + (Λ₂.card : ℝ) * freeEnergyΛ G Λ₂ p
+    ≤ ((Λ₁ ∪ Λ₂).card : ℝ) * freeEnergyΛ G (Λ₁ ∪ Λ₂) p := by
+  have hne_union : (Λ₁ ∪ Λ₂).Nonempty := hne₁.mono Finset.subset_union_left
+  rw [card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne₁,
+      card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne₂,
+      card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne_union]
+  exact log_partitionFunctionΛ_disjUnion_super_additive G hd p hf
+
+end Ambient
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,7 @@ Named specializations at `A = {i}`:
 | `partitionFunction_mul_le_of_sum_le` / `log_partitionFunction_add_le_of_sum_le` (§4.6 super-add. Step 5 prep) | `G ⊕g H ≤ G' ⇒ Z_G · Z_H ≤ Z_{G'}` (ferromagnetic), log form | `SumModel.lean` | Ising on sum graph |
 | `partitionFunction_map_equiv` / `log_partitionFunction_map_equiv` | `e : V ≃ W ⇒ Z_{G.map e} = Z_G` (iso invariance) | `PartitionFunctionIso.lean` | Step 5 infra |
 | `log_partitionFunction_inducedGraph_disjUnion_super_additive` (§4.6 Prop 4.6.1 Step 5 body) | `Disjoint Λ₁ Λ₂ ⇒ log Z_{inducedGraph Λ₁} + log Z_{inducedGraph Λ₂} ≤ log Z_{inducedGraph (Λ₁ ∪ Λ₂)}` (ferromagnetic) | `AmbientLatticeSum.lean` | Step 5 body |
+| `Ambient.freeEnergyΛ_weighted_super_additive_of_nonempty` | `|Λ₁|·f_{Λ₁} + |Λ₂|·f_{Λ₂} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (disjoint nonempty, ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` wrapper |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

- Extend `IsingModel/AmbientLatticeSum.lean` with `partitionFunctionΛ` and `freeEnergyΛ` wrappers of PR #139's super-additivity inequality, in the canonical `AmbientLattice.lean` API.

## Main declarations (all in `namespace IsingModel.Ambient`)

- `partitionFunctionΛ_disjUnion_super_multiplicative`
- `log_partitionFunctionΛ_disjUnion_super_additive`
- `card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty` (bridge)
- `freeEnergyΛ_weighted_super_additive_of_nonempty`: `|Λ₁|·f_{Λ₁} + |Λ₂|·f_{Λ₂} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` for disjoint nonempty `Λ₁, Λ₂` and ferromagnetic `p`.

## Notes

The `Nonempty` restriction is a proof artifact — the weighted inequality itself remains true when one or both of `Λ₁, Λ₂` are empty (weights vanish and the union reduces), but the Lean proof would require a separate `partitionFunctionΛ_empty = 1` lemma. Left as a natural follow-up.

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no blocking findings. Applied: proof comment clarifying `field_simp` cancellation, doc-string phrasing tightened.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- All declarations have doc comments

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on all declarations
- [x] Cross-check applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)