### PR TITLE
feat: partitionFunction ≥ 1 (ferromagnetic) infrastructure (§4.6 toward Fekete)

### DIFF
--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -603,6 +603,49 @@ theorem freeEnergy_monotone_subgraph
     (log_partitionFunction_monotone_subgraph h₁₂ p hf)
     (inv_nonneg.mpr (Nat.cast_nonneg _))
 
+/-- **Unconditional lower bound `Z_⊥ ≥ 1` on the empty graph.**
+
+Since `partitionFunction_bot` gives `Z_⊥ = (2·cosh(β h))^|ι|` and
+`Real.one_le_cosh` is unconditional, we have `2·cosh(β h) ≥ 2 ≥ 1`,
+and `(...)^|ι| ≥ 1`. No ferromagnetic hypothesis required. -/
+theorem partitionFunction_bot_ge_one (p : IsingParams ℝ) :
+    (1 : ℝ) ≤ partitionFunction (⊥ : SimpleGraph ι) p := by
+  have h_cosh_ge : 1 ≤ 2 * Real.cosh (p.β * p.h) := by
+    have : 1 ≤ Real.cosh (p.β * p.h) := Real.one_le_cosh _
+    linarith
+  have h_pow : 1 ≤ (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι :=
+    one_le_pow₀ h_cosh_ge
+  rw [partitionFunction_bot]
+  exact h_pow
+
+/-- **Lower bound `Z_G ≥ 1` for ferromagnetic parameters.**
+
+The ferromagnetic hypothesis is used only to transport the
+unconditional `⊥`-graph bound to `G` via
+`partitionFunction_monotone_subgraph`:
+`Z_G ≥ Z_⊥ ≥ 1`. Used downstream as the companion to the §4.6
+super-additivity inequality: because `log Z_G ≥ 0` (ferromagnetic),
+the disjoint-sum chain
+`log Z_{Λ₁} + log Z_{Δ} ≤ log Z_{Λ₁ ∪ Δ}` upgrades to subset-wise
+monotonicity `log Z_{Λ₁} ≤ log Z_{Λ₁ ∪ Δ}` for any `Δ` disjoint
+from `Λ₁`. -/
+theorem partitionFunction_ge_one_of_ferromagnetic
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    1 ≤ partitionFunction G p :=
+  (partitionFunction_bot_ge_one p).trans
+    (partitionFunction_monotone_subgraph bot_le p hf)
+
+/-- Logarithmic form: `log Z_G ≥ 0` for ferromagnetic parameters.
+
+Immediate from `partitionFunction_ge_one_of_ferromagnetic` and
+`Real.log_nonneg`. -/
+theorem log_partitionFunction_nonneg_of_ferromagnetic
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    0 ≤ Real.log (partitionFunction G p) :=
+  Real.log_nonneg (partitionFunction_ge_one_of_ferromagnetic G p hf)
+
 /-- The free energy rescaling identity in `β`:
 `f(J, h, β) = f(βJ, βh, 1)`. Follows from `partitionFunction_beta_rescale`
 (after taking `log` and multiplying by `|ι|⁻¹`). -/

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,7 @@ Named specializations at `A = {i}`:
 | `partitionFunction_map_equiv` / `log_partitionFunction_map_equiv` | `e : V ≃ W ⇒ Z_{G.map e} = Z_G` (iso invariance) | `PartitionFunctionIso.lean` | Step 5 infra |
 | `log_partitionFunction_inducedGraph_disjUnion_super_additive` (§4.6 Prop 4.6.1 Step 5 body) | `Disjoint Λ₁ Λ₂ ⇒ log Z_{inducedGraph Λ₁} + log Z_{inducedGraph Λ₂} ≤ log Z_{inducedGraph (Λ₁ ∪ Λ₂)}` (ferromagnetic) | `AmbientLatticeSum.lean` | Step 5 body |
 | `Ambient.freeEnergyΛ_weighted_super_additive_of_nonempty` | `|Λ₁|·f_{Λ₁} + |Λ₂|·f_{Λ₂} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (disjoint nonempty, ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` wrapper |
+| `partitionFunction_ge_one_of_ferromagnetic` / `log_partitionFunction_nonneg_of_ferromagnetic` | `Z_G ≥ 1` (ferromagnetic), log form | `FreeEnergy.lean` | Step 5/Fekete infra |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add to `IsingModel/FreeEnergy.lean`:

- `partitionFunction_bot_ge_one`: unconditional `1 ≤ Z_⊥`.
- `partitionFunction_ge_one_of_ferromagnetic`: `1 ≤ Z_G` (ferromagnetic).
- `log_partitionFunction_nonneg_of_ferromagnetic`: `0 ≤ log Z_G`.

Companion to the Step 5 super-additivity of PRs #139/#140: together they yield subset-wise monotonicity of `log Z` (input for Fekete-style convergence in a later PR).

## Proof

`partitionFunction_bot` gives `Z_⊥ = (2·cosh(β h))^|ι|`. `Real.one_le_cosh` is unconditional, so `2·cosh ≥ 2 ≥ 1` and `(...)^|ι| ≥ 1`. For general `G`, ferromagnetic subgraph monotonicity `⊥ ≤ G` transports the bound.

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no blocking findings. Applied: extract unconditional `partitionFunction_bot_ge_one` as base lemma; ferromagnetic form as one-line corollary; doc comment clarified (cosh estimate is unconditional).

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- All declarations have doc comments

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on all declarations
- [x] Cross-check applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)