### PR TITLE
feat: log Z monotonicity on disjoint union (§4.6 toward Fekete)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -143,6 +143,49 @@ theorem log_partitionFunction_inducedGraph_disjUnion_super_additive
         log_partitionFunction_monotone_subgraph
           (inducedGraph_sum_map_le_union G hd) p hf
 
+set_option linter.unusedFintypeInType false in
+/-- **Monotonicity step `log Z_Λ₁ ≤ log Z_{Λ₁ ∪ Λ₂}`** for disjoint
+`Λ₁, Λ₂` under ferromagnetic parameters.
+
+Proof: `log Z_Λ₁ ≤ log Z_Λ₁ + log Z_Λ₂` (since `log Z_Λ₂ ≥ 0` by
+`log_partitionFunction_nonneg_of_ferromagnetic`), and the right-hand
+side is `≤ log Z_{Λ₁ ∪ Λ₂}` by the Step 5 super-additivity
+(`log_partitionFunction_inducedGraph_disjUnion_super_additive`). The
+`[Fintype (inducedGraph G Λ₂).edgeSet]` instance is used internally
+via the super-additivity lemma even though it does not appear in the
+conclusion. -/
+theorem log_partitionFunction_inducedGraph_le_of_disjoint_union
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Real.log (partitionFunction (inducedGraph G Λ₁) p)
+      ≤ Real.log (partitionFunction (inducedGraph G (Λ₁ ∪ Λ₂)) p) := by
+  calc Real.log (partitionFunction (inducedGraph G Λ₁) p)
+      ≤ Real.log (partitionFunction (inducedGraph G Λ₁) p)
+          + Real.log (partitionFunction (inducedGraph G Λ₂) p) :=
+        le_add_of_nonneg_right
+          (log_partitionFunction_nonneg_of_ferromagnetic _ p hf)
+    _ ≤ Real.log (partitionFunction (inducedGraph G (Λ₁ ∪ Λ₂)) p) :=
+        log_partitionFunction_inducedGraph_disjUnion_super_additive
+          G hd p hf
+
+set_option linter.unusedFintypeInType false in
+/-- Multiplicative form: `Z_{Λ₁} ≤ Z_{Λ₁ ∪ Λ₂}` for disjoint
+`Λ₁, Λ₂` under ferromagnetic parameters. -/
+theorem partitionFunction_inducedGraph_le_of_disjoint_union
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunction (inducedGraph G Λ₁) p
+      ≤ partitionFunction (inducedGraph G (Λ₁ ∪ Λ₂)) p :=
+  (Real.log_le_log_iff (partitionFunction_pos _ _)
+    (partitionFunction_pos _ _)).mp
+    (log_partitionFunction_inducedGraph_le_of_disjoint_union G hd p hf)
+
 namespace Ambient
 
 variable {V : Type*} [DecidableEq V]
@@ -221,6 +264,35 @@ theorem freeEnergyΛ_weighted_super_additive_of_nonempty
       card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne₂,
       card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne_union]
   exact log_partitionFunctionΛ_disjUnion_super_additive G hd p hf
+
+set_option linter.unusedFintypeInType false in
+/-- Wrapper at the `partitionFunctionΛ` API level:
+for disjoint `Λ₁, Λ₂`, `log Z_{Λ₁} ≤ log Z_{Λ₁ ∪ Λ₂}` under
+ferromagnetic parameters. -/
+theorem log_partitionFunctionΛ_le_of_disjoint_union
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Real.log (partitionFunctionΛ G Λ₁ p)
+      ≤ Real.log (partitionFunctionΛ G (Λ₁ ∪ Λ₂) p) :=
+  IsingModel.log_partitionFunction_inducedGraph_le_of_disjoint_union
+    G hd p hf
+
+set_option linter.unusedFintypeInType false in
+/-- Multiplicative form at the `partitionFunctionΛ` API level:
+for disjoint `Λ₁, Λ₂`, `Z_{Λ₁} ≤ Z_{Λ₁ ∪ Λ₂}` under ferromagnetic
+parameters. -/
+theorem partitionFunctionΛ_le_of_disjoint_union
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunctionΛ G Λ₁ p ≤ partitionFunctionΛ G (Λ₁ ∪ Λ₂) p :=
+  IsingModel.partitionFunction_inducedGraph_le_of_disjoint_union
+    G hd p hf
 
 end Ambient
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,7 @@ Named specializations at `A = {i}`:
 | `log_partitionFunction_inducedGraph_disjUnion_super_additive` (§4.6 Prop 4.6.1 Step 5 body) | `Disjoint Λ₁ Λ₂ ⇒ log Z_{inducedGraph Λ₁} + log Z_{inducedGraph Λ₂} ≤ log Z_{inducedGraph (Λ₁ ∪ Λ₂)}` (ferromagnetic) | `AmbientLatticeSum.lean` | Step 5 body |
 | `Ambient.freeEnergyΛ_weighted_super_additive_of_nonempty` | `|Λ₁|·f_{Λ₁} + |Λ₂|·f_{Λ₂} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (disjoint nonempty, ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` wrapper |
 | `partitionFunction_ge_one_of_ferromagnetic` / `log_partitionFunction_nonneg_of_ferromagnetic` | `Z_G ≥ 1` (ferromagnetic), log form | `FreeEnergy.lean` | Step 5/Fekete infra |
+| `{log_,}partitionFunction{,Λ}_inducedGraph_le_of_disjoint_union` | `Disjoint Λ₁ Λ₂ ⇒ Z_{Λ₁} ≤ Z_{Λ₁∪Λ₂}` (ferromagnetic), log / multiplicative and generic / `Λ`-wrapped forms | `AmbientLatticeSum.lean` | Monotonicity step toward Fekete |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add to `IsingModel/AmbientLatticeSum.lean`:

- `log_partitionFunction_inducedGraph_le_of_disjoint_union`: for disjoint `Λ₁, Λ₂`, `log Z_{Λ₁} ≤ log Z_{Λ₁ ∪ Λ₂}` (ferromagnetic).
- `partitionFunction_inducedGraph_le_of_disjoint_union`: multiplicative form.
- `Ambient.log_partitionFunctionΛ_le_of_disjoint_union` / `partitionFunctionΛ_le_of_disjoint_union`: wrappers.

## Proof

Straight composition of PR #139 (super-additivity) and PR #141 (`log Z ≥ 0` in ferromagnetic): `log Z_{Λ₁} ≤ log Z_{Λ₁} + log Z_{Λ₂} ≤ log Z_{Λ₁ ∪ Λ₂}`. Multiplicative form via `Real.log_le_log_iff`.

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no correctness findings. Non-blocking suggestion for a follow-up subset-form `Λ₁ ⊆ Λ₂ ⇒ log Z_{Λ₁} ≤ log Z_{Λ₂}`; current disjoint-union form is the building block.

## Verification

- `lake build`: green, zero warnings (uses `set_option linter.unusedFintypeInType false in` locally, following project convention)
- `lake exe GKSTest`: all tests pass
- All declarations have doc comments

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on all declarations
- [x] Cross-check applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)