### PR TITLE
feat: freeEnergyΛ weighted disjoint-union monotonicity (§4.6 toward Fekete)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -294,6 +294,29 @@ theorem partitionFunctionΛ_le_of_disjoint_union
   IsingModel.partitionFunction_inducedGraph_le_of_disjoint_union
     G hd p hf
 
+set_option linter.unusedFintypeInType false in
+/-- `freeEnergyΛ` weighted form of the disjoint-union monotonicity:
+for nonempty `Λ₁` disjoint from `Λ₂`,
+`|Λ₁| · freeEnergyΛ Λ₁ ≤ |Λ₁ ∪ Λ₂| · freeEnergyΛ (Λ₁ ∪ Λ₂)`
+under ferromagnetic parameters.
+
+Derived from `card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty`
+(PR #140) together with `log_partitionFunctionΛ_le_of_disjoint_union`
+(PR #142). -/
+theorem card_mul_freeEnergyΛ_le_of_disjoint_union
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V}
+    (hne₁ : Λ₁.Nonempty) (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    [Fintype (inducedGraph G (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Λ₁.card : ℝ) * freeEnergyΛ G Λ₁ p
+      ≤ ((Λ₁ ∪ Λ₂).card : ℝ) * freeEnergyΛ G (Λ₁ ∪ Λ₂) p := by
+  have hne_union : (Λ₁ ∪ Λ₂).Nonempty := hne₁.mono Finset.subset_union_left
+  rw [card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne₁,
+      card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne_union]
+  exact log_partitionFunctionΛ_le_of_disjoint_union G hd p hf
+
 end Ambient
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,6 +98,7 @@ Named specializations at `A = {i}`:
 | `Ambient.freeEnergyΛ_weighted_super_additive_of_nonempty` | `|Λ₁|·f_{Λ₁} + |Λ₂|·f_{Λ₂} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (disjoint nonempty, ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` wrapper |
 | `partitionFunction_ge_one_of_ferromagnetic` / `log_partitionFunction_nonneg_of_ferromagnetic` | `Z_G ≥ 1` (ferromagnetic), log form | `FreeEnergy.lean` | Step 5/Fekete infra |
 | `{log_,}partitionFunction{,Λ}_inducedGraph_le_of_disjoint_union` | `Disjoint Λ₁ Λ₂ ⇒ Z_{Λ₁} ≤ Z_{Λ₁∪Λ₂}` (ferromagnetic), log / multiplicative and generic / `Λ`-wrapped forms | `AmbientLatticeSum.lean` | Monotonicity step toward Fekete |
+| `Ambient.card_mul_freeEnergyΛ_le_of_disjoint_union` | `Λ₁.Nonempty, Disjoint Λ₁ Λ₂ ⇒ |Λ₁|·f_{Λ₁} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` weighted monotonicity |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add `Ambient.card_mul_freeEnergyΛ_le_of_disjoint_union` to `IsingModel/AmbientLatticeSum.lean`:

`Λ₁.Nonempty, Disjoint Λ₁ Λ₂ ⇒ |Λ₁|·freeEnergyΛ Λ₁ ≤ |Λ₁∪Λ₂|·freeEnergyΛ (Λ₁∪Λ₂)` (ferromagnetic).

Transport via PR #140 `card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty` applied to PR #142 `log_partitionFunctionΛ_le_of_disjoint_union`.

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no blocking findings; hypotheses minimal relative to current API.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass
- Doc comments present

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on declaration
- [x] Cross-check applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)