### PR TITLE
feat: partitionFunctionAlongExhaustion monotone along Exhaustion (§4.6 Fekete input)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -294,6 +294,69 @@ theorem partitionFunctionΛ_le_of_disjoint_union
   IsingModel.partitionFunction_inducedGraph_le_of_disjoint_union
     G hd p hf
 
+/-- `partitionFunctionΛ` respects Finset equality.
+Proved by substituting the equation away and using subsingleton
+uniqueness of the Fintype instance on the (now-equal) edge set. -/
+theorem partitionFunctionΛ_congr_finset
+    (G : SimpleGraph V) {Λ₁ Λ₂ : Finset V} (h : Λ₁ = Λ₂)
+    [Fintype (inducedGraph G Λ₁).edgeSet]
+    [Fintype (inducedGraph G Λ₂).edgeSet]
+    (p : IsingParams ℝ) :
+    partitionFunctionΛ G Λ₁ p = partitionFunctionΛ G Λ₂ p := by
+  subst h
+  congr
+  exact Subsingleton.elim _ _
+
+set_option linter.unusedFintypeInType false in
+/-- **`partitionFunctionAlongExhaustion` is monotone in `n`**
+along any `Exhaustion Λ` under ferromagnetic parameters.
+
+Proof chain:
+1. `Λ.mono` gives `Λ.volume n ⊆ Λ.volume (n + 1)`;
+2. Split `Λ.volume (n + 1) = Λ.volume n ⊔ (Λ.volume (n + 1) \ Λ.volume n)`
+   using `Finset.union_sdiff_of_subset`;
+3. Apply PR #142 `partitionFunctionΛ_le_of_disjoint_union` to the
+   disjoint split;
+4. Transport the resulting RHS back via
+   `partitionFunctionΛ_congr_finset`. -/
+theorem partitionFunctionAlongExhaustion_monotone_volume
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ m, Fintype (inducedGraph G (Λ.volume m)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ)
+    [Fintype (inducedGraph G (Λ.volume (n + 1) \ Λ.volume n)).edgeSet] :
+    partitionFunctionAlongExhaustion G Λ p n
+      ≤ partitionFunctionAlongExhaustion G Λ p (n + 1) := by
+  have hsub : Λ.volume n ⊆ Λ.volume (n + 1) := Λ.mono (Nat.le_succ n)
+  have hd : Disjoint (Λ.volume n) (Λ.volume (n + 1) \ Λ.volume n) :=
+    Finset.disjoint_sdiff
+  have hunion : Λ.volume n ∪ (Λ.volume (n + 1) \ Λ.volume n)
+      = Λ.volume (n + 1) := Finset.union_sdiff_of_subset hsub
+  haveI : Fintype (inducedGraph G (Λ.volume n ∪
+      (Λ.volume (n + 1) \ Λ.volume n))).edgeSet := by
+    rw [hunion]; infer_instance
+  have key := partitionFunctionΛ_le_of_disjoint_union G hd p hf
+  have heq := partitionFunctionΛ_congr_finset G hunion p
+  -- Rewrite `partitionFunctionAlongExhaustion` to `partitionFunctionΛ`
+  -- (definitional), then chain.
+  change partitionFunctionΛ G (Λ.volume n) p
+    ≤ partitionFunctionΛ G (Λ.volume (n + 1)) p
+  calc partitionFunctionΛ G (Λ.volume n) p
+      ≤ partitionFunctionΛ G (Λ.volume n ∪
+          (Λ.volume (n + 1) \ Λ.volume n)) p := key
+    _ = partitionFunctionΛ G (Λ.volume (n + 1)) p := heq
+
+set_option linter.unusedFintypeInType false in
+/-- Log form of `partitionFunctionAlongExhaustion_monotone_volume`. -/
+theorem log_partitionFunctionAlongExhaustion_monotone_volume
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ m, Fintype (inducedGraph G (Λ.volume m)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ)
+    [Fintype (inducedGraph G (Λ.volume (n + 1) \ Λ.volume n)).edgeSet] :
+    Real.log (partitionFunctionAlongExhaustion G Λ p n)
+      ≤ Real.log (partitionFunctionAlongExhaustion G Λ p (n + 1)) :=
+  Real.log_le_log (partitionFunctionΛ_pos G (Λ.volume n) p)
+    (partitionFunctionAlongExhaustion_monotone_volume G Λ p hf n)
+
 set_option linter.unusedFintypeInType false in
 /-- `freeEnergyΛ` weighted form of the disjoint-union monotonicity:
 for nonempty `Λ₁` disjoint from `Λ₂`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,6 +99,7 @@ Named specializations at `A = {i}`:
 | `partitionFunction_ge_one_of_ferromagnetic` / `log_partitionFunction_nonneg_of_ferromagnetic` | `Z_G ≥ 1` (ferromagnetic), log form | `FreeEnergy.lean` | Step 5/Fekete infra |
 | `{log_,}partitionFunction{,Λ}_inducedGraph_le_of_disjoint_union` | `Disjoint Λ₁ Λ₂ ⇒ Z_{Λ₁} ≤ Z_{Λ₁∪Λ₂}` (ferromagnetic), log / multiplicative and generic / `Λ`-wrapped forms | `AmbientLatticeSum.lean` | Monotonicity step toward Fekete |
 | `Ambient.card_mul_freeEnergyΛ_le_of_disjoint_union` | `Λ₁.Nonempty, Disjoint Λ₁ Λ₂ ⇒ |Λ₁|·f_{Λ₁} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` weighted monotonicity |
+| `Ambient.partitionFunctionAlongExhaustion_monotone_volume` / `log_partitionFunctionAlongExhaustion_monotone_volume` | `Z_{Λ.volume n} ≤ Z_{Λ.volume (n+1)}` (ferromagnetic) along Exhaustion, log form | `AmbientLatticeSum.lean` | Fekete input |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add to `IsingModel/AmbientLatticeSum.lean`:

- `partitionFunctionΛ_congr_finset`: propagates Finset equality `Λ₁ = Λ₂` to `partitionFunctionΛ G Λ₁ p = partitionFunctionΛ G Λ₂ p` via `subst` + Subsingleton-elim on the Fintype instance. Closes the Finset-type transport gap left over from PR #142.
- `partitionFunctionAlongExhaustion_monotone_volume`: for any `Exhaustion Λ` and ferromagnetic `p`, `Z_{Λ.volume n} ≤ Z_{Λ.volume (n+1)}`.
- `log_partitionFunctionAlongExhaustion_monotone_volume`: log form.

## Proof

`Λ.mono` + `Finset.union_sdiff_of_subset` decomposes `Λ.volume (n+1)` as the disjoint union `Λ.volume n ⊔ (Λ.volume (n+1) \ Λ.volume n)`. PR #142 gives the disjoint-union inequality on the split; the congr helper transports the RHS back to `Λ.volume (n+1)`.

## Role toward Prop 4.6.1

Together with the uniform upper bound (PR #123), this gives both inputs required for Fekete-style convergence of `freeEnergyAlongExhaustion`. The remaining step — the Fekete argument proper — needs additional structural input (translation / block additivity) because `log Z_{Λ.volume n}` grows unboundedly while `f_{Λ.volume n} = log Z_{Λ.volume n} / |Λ.volume n|` is what actually converges.

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no correctness findings; Subsingleton-elim path for the Fintype-instance mismatch after `subst` is sanctioned.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass

## Test plan

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] Zero linter warnings
- [x] Doc comments on all declarations
- [x] Cross-check applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)