### PR TITLE
feat: Monotone (partitionFunctionAlongExhaustion ...) predicate wrapper (§4.6 Fekete input)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -358,6 +358,32 @@ theorem log_partitionFunctionAlongExhaustion_monotone_volume
     (partitionFunctionAlongExhaustion_monotone_volume G Λ p hf n)
 
 set_option linter.unusedFintypeInType false in
+/-- **`partitionFunctionAlongExhaustion` is `Monotone`** along any
+Exhaustion for ferromagnetic parameters. Packages the step-wise
+`partitionFunctionAlongExhaustion_monotone_volume` as a
+`Monotone` predicate, ready for use with mathlib convergence
+lemmas (`Monotone.tendsto_atTop_of_bddAbove`, etc.). -/
+theorem partitionFunctionAlongExhaustion_monotone
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ m, Fintype (inducedGraph G (Λ.volume m)).edgeSet]
+    [∀ n, Fintype (inducedGraph G (Λ.volume (n + 1) \ Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Monotone (partitionFunctionAlongExhaustion G Λ p) :=
+  monotone_nat_of_le_succ fun n =>
+    partitionFunctionAlongExhaustion_monotone_volume G Λ p hf n
+
+set_option linter.unusedFintypeInType false in
+/-- `Monotone` form for `log Z` along an Exhaustion. -/
+theorem log_partitionFunctionAlongExhaustion_monotone
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ m, Fintype (inducedGraph G (Λ.volume m)).edgeSet]
+    [∀ n, Fintype (inducedGraph G (Λ.volume (n + 1) \ Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Monotone (fun n => Real.log (partitionFunctionAlongExhaustion G Λ p n)) :=
+  monotone_nat_of_le_succ fun n =>
+    log_partitionFunctionAlongExhaustion_monotone_volume G Λ p hf n
+
+set_option linter.unusedFintypeInType false in
 /-- `freeEnergyΛ` weighted form of the disjoint-union monotonicity:
 for nonempty `Λ₁` disjoint from `Λ₂`,
 `|Λ₁| · freeEnergyΛ Λ₁ ≤ |Λ₁ ∪ Λ₂| · freeEnergyΛ (Λ₁ ∪ Λ₂)`

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,7 @@ Named specializations at `A = {i}`:
 | `{log_,}partitionFunction{,Λ}_inducedGraph_le_of_disjoint_union` | `Disjoint Λ₁ Λ₂ ⇒ Z_{Λ₁} ≤ Z_{Λ₁∪Λ₂}` (ferromagnetic), log / multiplicative and generic / `Λ`-wrapped forms | `AmbientLatticeSum.lean` | Monotonicity step toward Fekete |
 | `Ambient.card_mul_freeEnergyΛ_le_of_disjoint_union` | `Λ₁.Nonempty, Disjoint Λ₁ Λ₂ ⇒ |Λ₁|·f_{Λ₁} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` weighted monotonicity |
 | `Ambient.partitionFunctionAlongExhaustion_monotone_volume` / `log_partitionFunctionAlongExhaustion_monotone_volume` | `Z_{Λ.volume n} ≤ Z_{Λ.volume (n+1)}` (ferromagnetic) along Exhaustion, log form | `AmbientLatticeSum.lean` | Fekete input |
+| `Ambient.partitionFunctionAlongExhaustion_monotone` / `log_partitionFunctionAlongExhaustion_monotone` | `Monotone` predicate form (for mathlib convergence lemmas) | `AmbientLatticeSum.lean` | Fekete input wrapper |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add to `IsingModel/AmbientLatticeSum.lean`:
- `partitionFunctionAlongExhaustion_monotone`: `Monotone (partitionFunctionAlongExhaustion G Λ p)`.
- `log_partitionFunctionAlongExhaustion_monotone`: log form.

Packages PR #145's step-wise inequality via `monotone_nat_of_le_succ` into the canonical `Monotone` predicate, ready for `Monotone.tendsto_atTop_of_bddAbove` style mathlib convergence lemmas.

## Cross-check

- `copilot -p` quota exhausted. Pure composition wrapper; codex review omitted.

## Verification

- `lake build`: green, zero warnings (uses `set_option linter.unusedFintypeInType false in` following project convention)
- `lake exe GKSTest`: all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)