### PR TITLE
feat: freeEnergyInfinite ≤ uniform upper bound under ferromagnetic + BoundedEdgeDensity (§4.6)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -406,6 +406,48 @@ theorem card_mul_freeEnergyΛ_le_of_disjoint_union
       card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne_union]
   exact log_partitionFunctionΛ_le_of_disjoint_union G hd p hf
 
+/-- **Uniform upper bound on `freeEnergyInfinite` under bounded edge density**:
+the per-n bound of PR #123 lifts to `limsup`:
+`freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` for ferromagnetic `p`.
+
+Proof outline.
+1. By `Exhaustion.exhaust`, any vertex of a nonempty `V` is
+   eventually in `Λ.volume n`, so `(Λ.volume n).Nonempty` holds
+   eventually (atTop).
+2. Apply the per-n upper bound
+   `freeEnergyAlongExhaustion_le_uniform_upper_bound` under the
+   eventual hypothesis — this gives the `∀ᶠ`-form of the bound.
+3. For `Filter.IsCoboundedUnder (· ≤ ·)`, use the (ferromagnetic)
+   lower bound `freeEnergyAlongExhaustion_ge_log_two_cosh`.
+4. `Filter.limsup_le_of_le` concludes. -/
+theorem freeEnergyInfinite_le_uniform_upper_bound
+    [Nonempty V] (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) ≤
+        c * Fintype.card (↑(Λ.volume n) : Type _)) :
+    freeEnergyInfinite G Λ p ≤ Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
+  -- Eventual nonemptiness from exhaust.
+  obtain ⟨v⟩ := ‹Nonempty V›
+  obtain ⟨N, hN⟩ := Λ.exhaust {v}
+  have heventually : ∀ᶠ n in Filter.atTop, (Λ.volume n).Nonempty := by
+    filter_upwards [Filter.eventually_ge_atTop N] with n hn
+    exact ⟨v, hN n hn (Finset.mem_singleton_self v)⟩
+  have hbound : ∀ᶠ n in Filter.atTop,
+      freeEnergyAlongExhaustion G Λ p n
+        ≤ Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
+    filter_upwards [heventually] with n hne
+    exact freeEnergyAlongExhaustion_le_uniform_upper_bound G Λ p hc n hne
+  have hbdd_below : Filter.IsBoundedUnder (· ≥ ·) Filter.atTop
+      (freeEnergyAlongExhaustion G Λ p) := by
+    refine ⟨Real.log (2 * Real.cosh (p.β * p.h)), ?_⟩
+    rw [Filter.eventually_map]
+    filter_upwards [heventually] with n hne
+    exact freeEnergyAlongExhaustion_ge_log_two_cosh
+      (J := p.J) (h := p.h) (β := p.β) G Λ hf.hJ hf.hh hf.hβ n hne
+  exact Filter.limsup_le_of_le hbdd_below.isCoboundedUnder_le hbound
+
 end Ambient
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,7 @@ Named specializations at `A = {i}`:
 | `Ambient.card_mul_freeEnergyΛ_le_of_disjoint_union` | `Λ₁.Nonempty, Disjoint Λ₁ Λ₂ ⇒ |Λ₁|·f_{Λ₁} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` weighted monotonicity |
 | `Ambient.partitionFunctionAlongExhaustion_monotone_volume` / `log_partitionFunctionAlongExhaustion_monotone_volume` | `Z_{Λ.volume n} ≤ Z_{Λ.volume (n+1)}` (ferromagnetic) along Exhaustion, log form | `AmbientLatticeSum.lean` | Fekete input |
 | `Ambient.partitionFunctionAlongExhaustion_monotone` / `log_partitionFunctionAlongExhaustion_monotone` | `Monotone` predicate form (for mathlib convergence lemmas) | `AmbientLatticeSum.lean` | Fekete input wrapper |
+| `Ambient.freeEnergyInfinite_le_uniform_upper_bound` | `freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` upper bound |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add `Ambient.freeEnergyInfinite_le_uniform_upper_bound` to `IsingModel/AmbientLatticeSum.lean`:

`freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` under ferromagnetic `p`, bounded edge density (constant `c`), and `[Nonempty V]`.

## Proof

1. `Exhaustion.exhaust {v}` → eventual `(Λ.volume n).Nonempty`.
2. PR #123 `freeEnergyAlongExhaustion_le_uniform_upper_bound` → eventual upper bound.
3. `freeEnergyAlongExhaustion_ge_log_two_cosh` (ferromagnetic) → `IsBoundedUnder (· ≥ ·)` → `IsCoboundedUnder (· ≤ ·)` for `limsup`.
4. `Filter.limsup_le_of_le` combines.

## Cross-check

- `copilot -p` quota exhausted; per `RESUME.md §0` codex is pre-approved.
- codex review: no correctness findings. Noted hypotheses are slightly stronger than strictly needed (ferromagnetic for the coboundedness side; `[Nonempty V]` could be weakened to eventual nonemptiness of `Λ.volume n`); kept as-is for readability.

## Verification

- `lake build`: green, zero warnings
- `lake exe GKSTest`: all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)