### PR TITLE
feat: freeEnergyInfinite ≥ log 2 corollary (§4.6)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -488,6 +488,28 @@ theorem freeEnergyInfinite_ge_log_two_cosh
     exact freeEnergyAlongExhaustion_le_uniform_upper_bound G Λ p hc n hne
   exact Filter.le_limsup_of_frequently_le hlower.frequently hbdd_above
 
+/-- **Corollary**: `log 2 ≤ freeEnergyInfinite G Λ p` under the same
+hypotheses as `freeEnergyInfinite_ge_log_two_cosh`.
+
+Follows from `cosh (β h) ≥ cosh 0 = 1` (`Real.one_le_cosh`), which
+gives `2 · cosh (β h) ≥ 2` and hence
+`log (2 · cosh (β h)) ≥ log 2`. -/
+theorem freeEnergyInfinite_ge_log_two
+    [Nonempty V] (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) ≤
+        c * Fintype.card (↑(Λ.volume n) : Type _)) :
+    Real.log 2 ≤ freeEnergyInfinite G Λ p := by
+  have h_cosh_ge_one : (1 : ℝ) ≤ Real.cosh (p.β * p.h) :=
+    Real.one_le_cosh _
+  have h_le : Real.log 2 ≤ Real.log (2 * Real.cosh (p.β * p.h)) := by
+    apply Real.log_le_log (by norm_num : (0 : ℝ) < 2)
+    linarith
+  exact h_le.trans
+    (freeEnergyInfinite_ge_log_two_cosh G Λ p hf hc)
+
 end Ambient
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Named specializations at `A = {i}`:
 | `Ambient.card_mul_freeEnergyΛ_le_of_disjoint_union` | `Λ₁.Nonempty, Disjoint Λ₁ Λ₂ ⇒ |Λ₁|·f_{Λ₁} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` weighted monotonicity |
 | `Ambient.partitionFunctionAlongExhaustion_monotone_volume` / `log_partitionFunctionAlongExhaustion_monotone_volume` | `Z_{Λ.volume n} ≤ Z_{Λ.volume (n+1)}` (ferromagnetic) along Exhaustion, log form | `AmbientLatticeSum.lean` | Fekete input |
 | `Ambient.partitionFunctionAlongExhaustion_monotone` / `log_partitionFunctionAlongExhaustion_monotone` | `Monotone` predicate form (for mathlib convergence lemmas) | `AmbientLatticeSum.lean` | Fekete input wrapper |
-| `Ambient.freeEnergyInfinite_le_uniform_upper_bound` / `freeEnergyInfinite_ge_log_two_cosh` | `log(2·cosh(β·h)) ≤ freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` two-sided bounds |
+| `Ambient.freeEnergyInfinite_le_uniform_upper_bound` / `freeEnergyInfinite_ge_log_two_cosh` / `freeEnergyInfinite_ge_log_two` | `log 2 ≤ log(2·cosh(β·h)) ≤ freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` two-sided bounds |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add `Ambient.freeEnergyInfinite_ge_log_two` as clean weaker corollary of PR #148 `freeEnergyInfinite_ge_log_two_cosh`:

`log 2 ≤ freeEnergyInfinite G Λ p` under ferromagnetic, BoundedEdgeDensity, `[Nonempty V]`.

Follows from `Real.one_le_cosh` + `Real.log_le_log` composed with PR #148.

## Verification

- `lake build`: green
- `lake exe GKSTest`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)