### PR TITLE
feat: freeEnergyInfinite positive / nonneg corollaries (§4.6)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -510,6 +510,35 @@ theorem freeEnergyInfinite_ge_log_two
   exact h_le.trans
     (freeEnergyInfinite_ge_log_two_cosh G Λ p hf hc)
 
+/-- **Strict positivity** of `freeEnergyInfinite` under the standard
+ferromagnetic + `BoundedEdgeDensity` + `[Nonempty V]` setup:
+`0 < freeEnergyInfinite G Λ p`.
+
+Follows from `freeEnergyInfinite_ge_log_two` together with
+`Real.log_pos` at `2 > 1`. -/
+theorem freeEnergyInfinite_pos
+    [Nonempty V] (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) ≤
+        c * Fintype.card (↑(Λ.volume n) : Type _)) :
+    0 < freeEnergyInfinite G Λ p :=
+  (Real.log_pos (by norm_num : (1 : ℝ) < 2)).trans_le
+    (freeEnergyInfinite_ge_log_two G Λ p hf hc)
+
+/-- **Nonnegativity** of `freeEnergyInfinite` under the standard
+hypotheses. Immediate from strict positivity. -/
+theorem freeEnergyInfinite_nonneg
+    [Nonempty V] (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) ≤
+        c * Fintype.card (↑(Λ.volume n) : Type _)) :
+    0 ≤ freeEnergyInfinite G Λ p :=
+  (freeEnergyInfinite_pos G Λ p hf hc).le
+
 end Ambient
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Named specializations at `A = {i}`:
 | `Ambient.card_mul_freeEnergyΛ_le_of_disjoint_union` | `Λ₁.Nonempty, Disjoint Λ₁ Λ₂ ⇒ |Λ₁|·f_{Λ₁} ≤ |Λ₁∪Λ₂|·f_{Λ₁∪Λ₂}` (ferromagnetic) | `AmbientLatticeSum.lean` | `freeEnergyΛ` weighted monotonicity |
 | `Ambient.partitionFunctionAlongExhaustion_monotone_volume` / `log_partitionFunctionAlongExhaustion_monotone_volume` | `Z_{Λ.volume n} ≤ Z_{Λ.volume (n+1)}` (ferromagnetic) along Exhaustion, log form | `AmbientLatticeSum.lean` | Fekete input |
 | `Ambient.partitionFunctionAlongExhaustion_monotone` / `log_partitionFunctionAlongExhaustion_monotone` | `Monotone` predicate form (for mathlib convergence lemmas) | `AmbientLatticeSum.lean` | Fekete input wrapper |
-| `Ambient.freeEnergyInfinite_le_uniform_upper_bound` / `freeEnergyInfinite_ge_log_two_cosh` / `freeEnergyInfinite_ge_log_two` | `log 2 ≤ log(2·cosh(β·h)) ≤ freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` two-sided bounds |
+| `Ambient.freeEnergyInfinite_{le_uniform_upper_bound,ge_log_two_cosh,ge_log_two,pos,nonneg}` | `0 < log 2 ≤ log(2·cosh(β·h)) ≤ freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` two-sided bounds + positivity |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add to `IsingModel/AmbientLatticeSum.lean`:

- `freeEnergyInfinite_pos`: `0 < freeEnergyInfinite G Λ p`.
- `freeEnergyInfinite_nonneg`: `0 ≤ freeEnergyInfinite G Λ p`.

Trivial corollaries of PR #149 `freeEnergyInfinite_ge_log_two` since `log 2 > 0`.

## Verification

- `lake build`: green
- `lake exe GKSTest`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)