### PR TITLE
feat: freeEnergyInfinite monotone in ambient subgraph (§4.6)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -539,6 +539,55 @@ theorem freeEnergyInfinite_nonneg
     0 ≤ freeEnergyInfinite G Λ p :=
   (freeEnergyInfinite_pos G Λ p hf hc).le
 
+set_option linter.unusedFintypeInType false in
+/-- **`freeEnergyInfinite` is monotone in the ambient subgraph**:
+for `G₁ ≤ G₂` and ferromagnetic `p`,
+`freeEnergyInfinite G₁ Λ p ≤ freeEnergyInfinite G₂ Λ p`
+(under suitable boundedness hypotheses used internally to control
+the `limsup`).
+
+Proof: apply `Filter.limsup_le_limsup` to the per-n
+`freeEnergyAlongExhaustion_monotone_ambient_subgraph`. The
+`IsCoboundedUnder` side is discharged via the ferromagnetic lower
+bound `freeEnergyAlongExhaustion_ge_log_two_cosh`; the
+`IsBoundedUnder` side via the `BoundedEdgeDensity`-driven upper
+bound `freeEnergyAlongExhaustion_le_uniform_upper_bound`. -/
+theorem freeEnergyInfinite_monotone_ambient_subgraph
+    [Nonempty V] {G₁ G₂ : SimpleGraph V} (h : G₁ ≤ G₂)
+    (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph G₂ (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((inducedGraph G₂ (Λ.volume n)).edgeFinset.card : ℝ) ≤
+        c * Fintype.card (↑(Λ.volume n) : Type _)) :
+    freeEnergyInfinite G₁ Λ p ≤ freeEnergyInfinite G₂ Λ p := by
+  obtain ⟨v⟩ := ‹Nonempty V›
+  obtain ⟨N, hN⟩ := Λ.exhaust {v}
+  have heventually : ∀ᶠ n in Filter.atTop, (Λ.volume n).Nonempty := by
+    filter_upwards [Filter.eventually_ge_atTop N] with n hn
+    exact ⟨v, hN n hn (Finset.mem_singleton_self v)⟩
+  have hle : ∀ᶠ n in Filter.atTop,
+      freeEnergyAlongExhaustion G₁ Λ p n
+        ≤ freeEnergyAlongExhaustion G₂ Λ p n := by
+    apply Filter.Eventually.of_forall
+    intro n
+    exact freeEnergyAlongExhaustion_monotone_ambient_subgraph h Λ p hf n
+  have hbdd_below_G₁ : Filter.IsBoundedUnder (· ≥ ·) Filter.atTop
+      (freeEnergyAlongExhaustion G₁ Λ p) := by
+    refine ⟨Real.log (2 * Real.cosh (p.β * p.h)), ?_⟩
+    rw [Filter.eventually_map]
+    filter_upwards [heventually] with n hne
+    exact freeEnergyAlongExhaustion_ge_log_two_cosh
+      (J := p.J) (h := p.h) (β := p.β) G₁ Λ hf.hJ hf.hh hf.hβ n hne
+  have hbdd_above_G₂ : Filter.IsBoundedUnder (· ≤ ·) Filter.atTop
+      (freeEnergyAlongExhaustion G₂ Λ p) := by
+    refine ⟨Real.log 2 + |p.β| * (|p.J| * c + |p.h|), ?_⟩
+    rw [Filter.eventually_map]
+    filter_upwards [heventually] with n hne
+    exact freeEnergyAlongExhaustion_le_uniform_upper_bound G₂ Λ p hc n hne
+  exact Filter.limsup_le_limsup hle hbdd_below_G₁.isCoboundedUnder_le hbdd_above_G₂
+
 end Ambient
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,7 @@ Named specializations at `A = {i}`:
 | `Ambient.partitionFunctionAlongExhaustion_monotone_volume` / `log_partitionFunctionAlongExhaustion_monotone_volume` | `Z_{Λ.volume n} ≤ Z_{Λ.volume (n+1)}` (ferromagnetic) along Exhaustion, log form | `AmbientLatticeSum.lean` | Fekete input |
 | `Ambient.partitionFunctionAlongExhaustion_monotone` / `log_partitionFunctionAlongExhaustion_monotone` | `Monotone` predicate form (for mathlib convergence lemmas) | `AmbientLatticeSum.lean` | Fekete input wrapper |
 | `Ambient.freeEnergyInfinite_{le_uniform_upper_bound,ge_log_two_cosh,ge_log_two,pos,nonneg}` | `0 < log 2 ≤ log(2·cosh(β·h)) ≤ freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` two-sided bounds + positivity |
+| `Ambient.freeEnergyInfinite_monotone_ambient_subgraph` | `G₁ ≤ G₂ ⇒ freeEnergyInfinite G₁ Λ p ≤ freeEnergyInfinite G₂ Λ p` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` ambient subgraph monotonicity |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add `Ambient.freeEnergyInfinite_monotone_ambient_subgraph`:

`G₁ ≤ G₂ ⇒ freeEnergyInfinite G₁ Λ p ≤ freeEnergyInfinite G₂ Λ p` (ferromagnetic + BoundedEdgeDensity on G₂ + `[Nonempty V]`).

Proof: `Filter.limsup_le_limsup` applied to the per-n `freeEnergyAlongExhaustion_monotone_ambient_subgraph`, with coboundedness/boundedness from the PR #147/#148 setup.

## Verification

- `lake build`: green
- `lake exe GKSTest`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)