### PR TITLE
feat: freeEnergyInfinite h-symmetry lifts (§4.6)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -588,6 +588,34 @@ theorem freeEnergyInfinite_monotone_ambient_subgraph
     exact freeEnergyAlongExhaustion_le_uniform_upper_bound G₂ Λ p hc n hne
   exact Filter.limsup_le_limsup hle hbdd_below_G₁.isCoboundedUnder_le hbdd_above_G₂
 
+/-- **Along-exhaustion h-evenness at limsup**:
+`freeEnergyInfinite G Λ ⟨J, -h, β⟩ = freeEnergyInfinite G Λ ⟨J, h, β⟩`.
+Lifts `freeEnergyAlongExhaustion_neg_h` pointwise to `limsup`. -/
+theorem freeEnergyInfinite_neg_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) :
+    freeEnergyInfinite G Λ (⟨J, -h, β⟩ : IsingParams ℝ)
+      = freeEnergyInfinite G Λ (⟨J, h, β⟩ : IsingParams ℝ) := by
+  unfold freeEnergyInfinite
+  congr 1
+  funext n
+  exact freeEnergyAlongExhaustion_neg_h G Λ J h β n
+
+/-- **`|h|`-form at limsup**:
+`freeEnergyInfinite G Λ ⟨J, h, β⟩ = freeEnergyInfinite G Λ ⟨J, |h|, β⟩`.
+Lifts `freeEnergyAlongExhaustion_eq_abs_h` pointwise to `limsup`. -/
+theorem freeEnergyInfinite_eq_abs_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) :
+    freeEnergyInfinite G Λ (⟨J, h, β⟩ : IsingParams ℝ)
+      = freeEnergyInfinite G Λ (⟨J, |h|, β⟩ : IsingParams ℝ) := by
+  unfold freeEnergyInfinite
+  congr 1
+  funext n
+  exact freeEnergyAlongExhaustion_eq_abs_h G Λ J h β n
+
 end Ambient
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,7 @@ Named specializations at `A = {i}`:
 | `Ambient.partitionFunctionAlongExhaustion_monotone` / `log_partitionFunctionAlongExhaustion_monotone` | `Monotone` predicate form (for mathlib convergence lemmas) | `AmbientLatticeSum.lean` | Fekete input wrapper |
 | `Ambient.freeEnergyInfinite_{le_uniform_upper_bound,ge_log_two_cosh,ge_log_two,pos,nonneg}` | `0 < log 2 ≤ log(2·cosh(β·h)) ≤ freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` two-sided bounds + positivity |
 | `Ambient.freeEnergyInfinite_monotone_ambient_subgraph` | `G₁ ≤ G₂ ⇒ freeEnergyInfinite G₁ Λ p ≤ freeEnergyInfinite G₂ Λ p` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` ambient subgraph monotonicity |
+| `Ambient.freeEnergyInfinite_neg_h` / `freeEnergyInfinite_eq_abs_h` | `h`-evenness: `freeEnergyInfinite G Λ ⟨J, -h, β⟩ = freeEnergyInfinite G Λ ⟨J, h, β⟩ = freeEnergyInfinite G Λ ⟨J, |h|, β⟩` | `AmbientLatticeSum.lean` | `limsup` h-symmetry |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add to `IsingModel/AmbientLatticeSum.lean`:

- `freeEnergyInfinite_neg_h`: `freeEnergyInfinite G Λ ⟨J, -h, β⟩ = freeEnergyInfinite G Λ ⟨J, h, β⟩`.
- `freeEnergyInfinite_eq_abs_h`: `freeEnergyInfinite G Λ ⟨J, h, β⟩ = freeEnergyInfinite G Λ ⟨J, |h|, β⟩`.

Both lift the existing along-exhaustion forms pointwise to `limsup` via `congr; funext`.

## Verification

- `lake build`: green
- `lake exe GKSTest`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)