### PR TITLE
feat: freeEnergyInfinite |h|-monotonicity (§4.6 limsup lift)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -750,6 +750,26 @@ theorem freeEnergyInfinite_monotone_beta
     exact freeEnergyAlongExhaustion_le_uniform_upper_bound G Λ _ hc n hne
   exact Filter.limsup_le_limsup hle hbdd_below_β₁.isCoboundedUnder_le hbdd_above_β₂
 
+set_option linter.unusedFintypeInType false in
+/-- **`|h|`-monotonicity of `freeEnergyInfinite`**: for fixed
+`J ≥ 0`, `β > 0`, `freeEnergyInfinite` is monotone in `|h|`.
+Composition of `freeEnergyInfinite_eq_abs_h` and
+`freeEnergyInfinite_monotone_h` on `Set.Ici 0`. -/
+theorem freeEnergyInfinite_monotone_abs_h
+    [Nonempty V] (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J β : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((inducedGraph G (Λ.volume n)).edgeFinset.card : ℝ) ≤
+        c * Fintype.card (↑(Λ.volume n) : Type _))
+    {h₁ h₂ : ℝ} (hh : |h₁| ≤ |h₂|) :
+    freeEnergyInfinite G Λ (⟨J, h₁, β⟩ : IsingParams ℝ)
+      ≤ freeEnergyInfinite G Λ (⟨J, h₂, β⟩ : IsingParams ℝ) := by
+  rw [freeEnergyInfinite_eq_abs_h G Λ J h₁ β,
+      freeEnergyInfinite_eq_abs_h G Λ J h₂ β]
+  exact freeEnergyInfinite_monotone_h G Λ hJ hβ hc
+    (Set.mem_Ici.mpr (abs_nonneg h₁)) (Set.mem_Ici.mpr (abs_nonneg h₂)) hh
+
 end Ambient
 
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ Named specializations at `A = {i}`:
 | `Ambient.freeEnergyInfinite_{le_uniform_upper_bound,ge_log_two_cosh,ge_log_two,pos,nonneg}` | `0 < log 2 ≤ log(2·cosh(β·h)) ≤ freeEnergyInfinite G Λ p ≤ log 2 + |β|·(|J|·c + |h|)` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` two-sided bounds + positivity |
 | `Ambient.freeEnergyInfinite_monotone_ambient_subgraph` | `G₁ ≤ G₂ ⇒ freeEnergyInfinite G₁ Λ p ≤ freeEnergyInfinite G₂ Λ p` (ferromagnetic + BoundedEdgeDensity + `[Nonempty V]`) | `AmbientLatticeSum.lean` | `limsup` ambient subgraph monotonicity |
 | `Ambient.freeEnergyInfinite_neg_h` / `freeEnergyInfinite_eq_abs_h` | `h`-evenness: `freeEnergyInfinite G Λ ⟨J, -h, β⟩ = freeEnergyInfinite G Λ ⟨J, h, β⟩ = freeEnergyInfinite G Λ ⟨J, |h|, β⟩` | `AmbientLatticeSum.lean` | `limsup` h-symmetry |
-| `Ambient.freeEnergyInfinite_monotone_{J,h,beta}` | `MonotoneOn (X ↦ freeEnergyInfinite ...) (Set.Ici 0 / Set.Ioi 0)` in each parameter (ferromagnetic-style + BoundedEdgeDensity + Nonempty V) | `AmbientLatticeSum.lean` | `limsup` three-parameter monotonicity |
+| `Ambient.freeEnergyInfinite_monotone_{J,h,beta,abs_h}` | `MonotoneOn (X ↦ freeEnergyInfinite ...)` in each parameter (ferromagnetic-style + BoundedEdgeDensity + Nonempty V), plus `|h|`-monotonicity | `AmbientLatticeSum.lean` | `limsup` monotonicity package |
 
 **Not yet formalized**: the infinite-volume analyticity of `f(h)` via
 Vitali convergence (GJ Thm 4.6.2 full statement).


### PR DESCRIPTION
## Summary

Add `Ambient.freeEnergyInfinite_monotone_abs_h`: `|h₁| ≤ |h₂| ⇒ freeEnergyInfinite G Λ ⟨J, h₁, β⟩ ≤ freeEnergyInfinite G Λ ⟨J, h₂, β⟩` under ferromagnetic-style + BoundedEdgeDensity + `[Nonempty V]`.

Pure composition of PR #152 `freeEnergyInfinite_eq_abs_h` with PR #154 `freeEnergyInfinite_monotone_h` on `Set.Ici 0`.

## Verification

- `lake build`: green
- `lake exe GKSTest`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)