### PR TITLE
feat: freeEnergyΛ ferromagnetic lower bound wrappers

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -190,6 +190,42 @@ namespace Ambient
 
 variable {V : Type*} [DecidableEq V]
 
+/-- **`freeEnergyΛ ≥ log(2·cosh(β·h))`** for ferromagnetic on nonempty `Λ`.
+Wrapper of `IsingModel.freeEnergy_ge_log_two_cosh`. -/
+theorem freeEnergyΛ_ge_log_two_cosh
+    (G : SimpleGraph V) {Λ : Finset V} (hne : Λ.Nonempty)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+      ≤ freeEnergyΛ G Λ (⟨J, h, β⟩ : IsingParams ℝ) := by
+  have hcard : 0 < Fintype.card (↑Λ : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hcard
+
+/-- **`freeEnergyΛ ≥ log 2`** for ferromagnetic on nonempty `Λ`.
+Follows from `freeEnergyΛ_ge_log_two_cosh` and `cosh ≥ 1`. -/
+theorem freeEnergyΛ_ge_log_two
+    (G : SimpleGraph V) {Λ : Finset V} (hne : Λ.Nonempty)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2 ≤ freeEnergyΛ G Λ (⟨J, h, β⟩ : IsingParams ℝ) := by
+  have h_cosh : 1 ≤ Real.cosh (β * h) := Real.one_le_cosh _
+  have h_log : Real.log 2 ≤ Real.log (2 * Real.cosh (β * h)) := by
+    apply Real.log_le_log (by norm_num : (0 : ℝ) < 2)
+    linarith
+  exact h_log.trans (freeEnergyΛ_ge_log_two_cosh G hne hJ hh hβ)
+
+/-- **`freeEnergyΛ ≥ 0`** for ferromagnetic on nonempty `Λ`.
+Follows from `freeEnergyΛ_ge_log_two` and `log 2 > 0`. -/
+theorem freeEnergyΛ_nonneg_of_ferromagnetic
+    (G : SimpleGraph V) {Λ : Finset V} (hne : Λ.Nonempty)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    0 ≤ freeEnergyΛ G Λ p := by
+  obtain ⟨J, h, β⟩ := p
+  exact (Real.log_pos (by norm_num : (1 : ℝ) < 2)).le.trans
+    (freeEnergyΛ_ge_log_two G hne hf.hJ hf.hh hf.hβ)
+
 /-- **`partitionFunctionΛ ≥ 1`** for ferromagnetic parameters:
 lifts PR #141 `partitionFunction_ge_one_of_ferromagnetic` to the
 `partitionFunctionΛ` API level. -/


### PR DESCRIPTION
## Summary

Add trivial wrappers of `freeEnergy_ge_log_two_cosh` at the `partitionFunctionΛ` API level:

- `freeEnergyΛ_ge_log_two_cosh`: `log(2·cosh(β·h)) ≤ freeEnergyΛ` (nonempty Λ, J, h ≥ 0, β > 0).
- `freeEnergyΛ_ge_log_two`: `log 2 ≤ freeEnergyΛ` (via `cosh ≥ 1`).
- `freeEnergyΛ_nonneg_of_ferromagnetic`: `0 ≤ freeEnergyΛ` (via `log 2 > 0`).

## Verification

- `lake build`: green
- `lake exe GKSTest`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)