### PR TITLE
feat: freeEnergyAlongExhaustion_zero_params + ∞-vol lift (J=h=0)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3161,6 +3161,51 @@ theorem freeEnergyInfinite_beta_zero
   rw [hconst]
   exact Filter.limsup_const (Real.log 2)
 
+/-! ## J = h = 0 closed form along exhaustion -/
+
+/-- **Along-exhaustion J=h=0 closed form**:
+for nonempty `Λ.volume n` and any ambient graph `G, Λ` and any `β`,
+`freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n = log 2`.
+
+Specialization of `IsingModel.freeEnergy_zero_params` via `change` +
+definitional unfolding of `freeEnergyAlongExhaustion` through
+`freeEnergyΛ` to `IsingModel.freeEnergy (inducedGraph …)`. -/
+theorem freeEnergyAlongExhaustion_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    freeEnergyAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ) n
+      = Real.log 2 := by
+  have hcard : 0 < Fintype.card (↑(Λ.volume n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2
+  exact IsingModel.freeEnergy_zero_params _ β hcard
+
+/-- **Infinite-volume J=h=0 closed form**:
+under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2`
+for any `β, G, Λ`.
+
+The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n` is constantly
+`log 2` by `freeEnergyAlongExhaustion_zero_params`, so its `limsup` on
+`atTop` is `log 2` by `Filter.limsup_const`.
+
+Companion to `freeEnergyInfinite_beta_zero`: both give the
+maximum-entropy value `log 2` from orthogonal degeneracies
+(β=0 vs. H ≡ 0). -/
+theorem freeEnergyInfinite_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite G Λ (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2 := by
+  unfold freeEnergyInfinite
+  have hconst : freeEnergyAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ)
+      = fun _ : ℕ => Real.log 2 := by
+    funext n
+    exact freeEnergyAlongExhaustion_zero_params G Λ β n (hne n)
+  rw [hconst]
+  exact Filter.limsup_const (Real.log 2)
+
 /-! ## Free-spin identity for induced subgraph -/
 
 omit [DecidableEq V] in

--- a/docs/index.md
+++ b/docs/index.md
@@ -237,6 +237,8 @@ ambient framework:
 | `card_spin` (GibbsMeasure.lean) | `Fintype.card Spin = 2` |
 | `card_config_eq_two_pow` (GibbsMeasure.lean) | `Fintype.card (Config ι) = 2 ^ Fintype.card ι` |
 | `freeEnergy_zero_params` (FreeEnergy.lean) | `freeEnergy G ⟨0, 0, β⟩ = log 2` (for nonempty ι) |
+| `freeEnergyAlongExhaustion_zero_params` | Along-exhaustion specialization: `f_n(0, 0, β) = log 2` per nonempty stage |
+| `freeEnergyInfinite_zero_params` | **∞-volume lift**: `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2` (all stages nonempty) |
 | **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
 | `freeEnergy_upper_bound` (Conditioning.lean) | **Explicit upper bound** (Cor. 10.3.2 / \|ι\|): `freeEnergy G p ≤ log 2 + \|β\|·(\|J\|·\|E\| + \|h\|·\|ι\|)/\|ι\|` for nonempty ι |
 | `freeEnergyAlongExhaustion_upper_bound` | Along-exhaustion specialization of `freeEnergy_upper_bound` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1593,6 +1593,21 @@ $\texttt{freeEnergyInfinite}\,G\,\Lambda\,\langle J, h, 0 \rangle = \log 2$.
 Constant 列に書き直して \texttt{Filter.limsup\_const} で閉.
 \end{theorem}
 
+\begin{theorem}[\texttt{freeEnergyAlongExhaustion\_zero\_params}; PR \#162]
+Nonempty $\Lambda.\text{volume}\,n$ で
+$\texttt{freeEnergyAlongExhaustion}\,G\,\Lambda\,\langle 0, 0, \beta \rangle\,n = \log 2$.
+\texttt{change} + definitional unfolding で
+\texttt{IsingModel.freeEnergy\_zero\_params} に specialize.
+\end{theorem}
+
+\begin{theorem}[\texttt{freeEnergyInfinite\_zero\_params}; PR \#162]
+$\forall n, \Lambda.\text{volume}\,n$ nonempty を仮定:
+$\texttt{freeEnergyInfinite}\,G\,\Lambda\,\langle 0, 0, \beta \rangle = \log 2$.
+\texttt{freeEnergyInfinite\_beta\_zero} の構造を
+\texttt{freeEnergyAlongExhaustion\_zero\_params} 経由で再利用.
+最大エントロピー値を $J = h = 0$ (Hamiltonian 恒等零) から得る pair.
+\end{theorem}
+
 \begin{theorem}[\texttt{inducedGraph\_bot}; PR \#129]
 $\texttt{inducedGraph}\,(\bot : \texttt{SimpleGraph}\,V)\,\Lambda
   = (\bot : \texttt{SimpleGraph}\,\uparrow\Lambda)$.


### PR DESCRIPTION
## Summary
Along-exhaustion specialization of `IsingModel.freeEnergy_zero_params`.

For any `G : SimpleGraph V`, `Λ : Exhaustion V`, `β : ℝ`, `n : ℕ`
with `(Λ.volume n).Nonempty`:
$$
  \text{freeEnergyAlongExhaustion}\, G\, Λ\, ⟨0, 0, β⟩\, n = \log 2.
$$

PR #131/132/133 の β=0 シリーズ類推の J=h=0 版.

## Plan
- [ ] Add `freeEnergyAlongExhaustion_zero_params` to `IsingModel/AmbientLattice.lean`
- [ ] Register in `docs/index.md`
- [ ] Add to `tex/proof-guide.tex`
- [ ] `lake build` green, `lake exe GKSTest` pass
- [ ] codex cross-check
- [ ] Mark ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)