### PR TITLE
feat: partitionFunctionAlongExhaustion_zero_params + log form (J=h=0)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3206,6 +3206,40 @@ theorem freeEnergyInfinite_zero_params
   rw [hconst]
   exact Filter.limsup_const (Real.log 2)
 
+/-! ## J = h = 0 closed form for `partitionFunctionAlongExhaustion` -/
+
+/-- **Along-exhaustion J=h=0 partition function closed form**:
+`partitionFunctionAlongExhaustion G Λ ⟨0, 0, β⟩ n = 2 ^ |Λ.volume n|`
+for any ambient graph `G, Λ` and any `β`.
+
+Specialization of `IsingModel.partitionFunction_zero_params`
+(`Z_G ⟨0,0,β⟩ = Fintype.card (Config ι)`) with `card_config_eq_two_pow`
+(`|Config ι| = 2^|ι|`) and `Fintype.card_coe` (`|↑Λ| = |Λ|`). -/
+theorem partitionFunctionAlongExhaustion_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) :
+    partitionFunctionAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ) n
+      = (2 : ℝ) ^ (Λ.volume n).card := by
+  change partitionFunction (inducedGraph G (Λ.volume n))
+      (⟨0, 0, β⟩ : IsingParams ℝ) = (2 : ℝ) ^ (Λ.volume n).card
+  rw [IsingModel.partitionFunction_zero_params, IsingModel.card_config_eq_two_pow,
+      Fintype.card_coe]
+  push_cast
+  rfl
+
+/-- **Log form**: `log (partitionFunctionAlongExhaustion G Λ ⟨0, 0, β⟩ n)
+= |Λ.volume n| · log 2`. Follows from
+`partitionFunctionAlongExhaustion_zero_params` via `Real.log_pow`. -/
+theorem log_partitionFunctionAlongExhaustion_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) :
+    Real.log (partitionFunctionAlongExhaustion G Λ
+        (⟨0, 0, β⟩ : IsingParams ℝ) n)
+      = ((Λ.volume n).card : ℝ) * Real.log 2 := by
+  rw [partitionFunctionAlongExhaustion_zero_params, Real.log_pow]
+
 /-! ## Free-spin identity for induced subgraph -/
 
 omit [DecidableEq V] in

--- a/docs/index.md
+++ b/docs/index.md
@@ -239,6 +239,7 @@ ambient framework:
 | `freeEnergy_zero_params` (FreeEnergy.lean) | `freeEnergy G ⟨0, 0, β⟩ = log 2` (for nonempty ι) |
 | `freeEnergyAlongExhaustion_zero_params` | Along-exhaustion specialization: `f_n(0, 0, β) = log 2` per nonempty stage |
 | `freeEnergyInfinite_zero_params` | **∞-volume lift**: `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2` (all stages nonempty) |
+| `partitionFunctionAlongExhaustion_zero_params` / `log_partitionFunctionAlongExhaustion_zero_params` | Partition-function side: `Z = 2^|Λ.volume n|`, `log Z = |Λ.volume n| · log 2` at `⟨0, 0, β⟩` |
 | **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
 | `freeEnergy_upper_bound` (Conditioning.lean) | **Explicit upper bound** (Cor. 10.3.2 / \|ι\|): `freeEnergy G p ≤ log 2 + \|β\|·(\|J\|·\|E\| + \|h\|·\|ι\|)/\|ι\|` for nonempty ι |
 | `freeEnergyAlongExhaustion_upper_bound` | Along-exhaustion specialization of `freeEnergy_upper_bound` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1608,6 +1608,25 @@ $\texttt{freeEnergyInfinite}\,G\,\Lambda\,\langle 0, 0, \beta \rangle = \log 2$.
 最大エントロピー値を $J = h = 0$ (Hamiltonian 恒等零) から得る pair.
 \end{theorem}
 
+\begin{theorem}[\texttt{partitionFunctionAlongExhaustion\_zero\_params}; PR \#163]
+任意の $n$ で
+\[
+  \texttt{partitionFunctionAlongExhaustion}\,G\,\Lambda\,\langle 0, 0, \beta \rangle\,n
+    = 2^{|\Lambda_n|}.
+\]
+\texttt{IsingModel.partitionFunction\_zero\_params} 直接 specialize +
+\texttt{card\_config\_eq\_two\_pow} + \texttt{Fintype.card\_coe}.
+\end{theorem}
+
+\begin{theorem}[\texttt{log\_partitionFunctionAlongExhaustion\_zero\_params}; PR \#163]
+任意の $n$ で
+\[
+  \log \texttt{partitionFunctionAlongExhaustion}\,G\,\Lambda\,\langle 0, 0, \beta \rangle\,n
+    = |\Lambda_n| \cdot \log 2.
+\]
+上記と \texttt{Real.log\_pow} の合成.
+\end{theorem}
+
 \begin{theorem}[\texttt{inducedGraph\_bot}; PR \#129]
 $\texttt{inducedGraph}\,(\bot : \texttt{SimpleGraph}\,V)\,\Lambda
   = (\bot : \texttt{SimpleGraph}\,\uparrow\Lambda)$.


### PR DESCRIPTION
## Summary
Along-exhaustion lift of `IsingModel.partitionFunction_zero_params`:
- `partitionFunctionAlongExhaustion G Λ ⟨0, 0, β⟩ n = 2^|Λ.volume n|`
- `log (partitionFunctionAlongExhaustion G Λ ⟨0, 0, β⟩ n) = |Λ.volume n| · log 2`

Companion to the free-energy pair `freeEnergy{AlongExhaustion,Infinite}_zero_params` (PR #162).

PR #131/132/133 の β=0 シリーズ partitionFunction 側類推の J=h=0 版.

🤖 Generated with [Claude Code](https://claude.com/claude-code)