### PR TITLE
feat: partitionFunctionAlongExhaustion_beta_zero + log form

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3206,6 +3206,40 @@ theorem freeEnergyInfinite_zero_params
   rw [hconst]
   exact Filter.limsup_const (Real.log 2)
 
+/-! ## β = 0 closed form for `partitionFunctionAlongExhaustion` -/
+
+/-- **Along-exhaustion β=0 partition function closed form**:
+`partitionFunctionAlongExhaustion G Λ ⟨J, h, 0⟩ n = 2 ^ |Λ.volume n|`
+for any `J, h` and any ambient graph `G, Λ`.
+
+Specialization of `IsingModel.partitionFunction_beta_zero` (every
+Boltzmann weight collapses to `exp 0 = 1`) with
+`card_config_eq_two_pow` and `Fintype.card_coe`. -/
+theorem partitionFunctionAlongExhaustion_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (n : ℕ) :
+    partitionFunctionAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ) n
+      = (2 : ℝ) ^ (Λ.volume n).card := by
+  change partitionFunction (inducedGraph G (Λ.volume n))
+      (⟨J, h, 0⟩ : IsingParams ℝ) = (2 : ℝ) ^ (Λ.volume n).card
+  rw [IsingModel.partitionFunction_beta_zero, IsingModel.card_config_eq_two_pow,
+      Fintype.card_coe]
+  push_cast
+  rfl
+
+/-- **Log form**: `log (partitionFunctionAlongExhaustion G Λ ⟨J, h, 0⟩ n)
+= |Λ.volume n| · log 2`. Follows from
+`partitionFunctionAlongExhaustion_beta_zero` via `Real.log_pow`. -/
+theorem log_partitionFunctionAlongExhaustion_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (n : ℕ) :
+    Real.log (partitionFunctionAlongExhaustion G Λ
+        (⟨J, h, 0⟩ : IsingParams ℝ) n)
+      = ((Λ.volume n).card : ℝ) * Real.log 2 := by
+  rw [partitionFunctionAlongExhaustion_beta_zero, Real.log_pow]
+
 /-! ## J = h = 0 closed form for `partitionFunctionAlongExhaustion` -/
 
 /-- **Along-exhaustion J=h=0 partition function closed form**:

--- a/docs/index.md
+++ b/docs/index.md
@@ -240,6 +240,7 @@ ambient framework:
 | `freeEnergyAlongExhaustion_zero_params` | Along-exhaustion specialization: `f_n(0, 0, β) = log 2` per nonempty stage |
 | `freeEnergyInfinite_zero_params` | **∞-volume lift**: `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2` (all stages nonempty) |
 | `partitionFunctionAlongExhaustion_zero_params` / `log_partitionFunctionAlongExhaustion_zero_params` | Partition-function side: `Z = 2^|Λ.volume n|`, `log Z = |Λ.volume n| · log 2` at `⟨0, 0, β⟩` |
+| `partitionFunctionAlongExhaustion_beta_zero` / `log_partitionFunctionAlongExhaustion_beta_zero` | β=0 companion: `Z = 2^|Λ.volume n|`, `log Z = |Λ.volume n| · log 2` at `⟨J, h, 0⟩` (any J, h) |
 | **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
 | `freeEnergy_upper_bound` (Conditioning.lean) | **Explicit upper bound** (Cor. 10.3.2 / \|ι\|): `freeEnergy G p ≤ log 2 + \|β\|·(\|J\|·\|E\| + \|h\|·\|ι\|)/\|ι\|` for nonempty ι |
 | `freeEnergyAlongExhaustion_upper_bound` | Along-exhaustion specialization of `freeEnergy_upper_bound` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1627,6 +1627,24 @@ $\texttt{freeEnergyInfinite}\,G\,\Lambda\,\langle 0, 0, \beta \rangle = \log 2$.
 上記と \texttt{Real.log\_pow} の合成.
 \end{theorem}
 
+\begin{theorem}[\texttt{partitionFunctionAlongExhaustion\_beta\_zero}; PR \#164]
+任意の $n$ および任意の $J, h \in \mathbb R$ で
+\[
+  \texttt{partitionFunctionAlongExhaustion}\,G\,\Lambda\,\langle J, h, 0 \rangle\,n
+    = 2^{|\Lambda_n|}.
+\]
+\texttt{IsingModel.partitionFunction\_beta\_zero} を specialize.
+$\beta = 0$ で Boltzmann weight $\exp(-\beta H) = 1$ を経由.
+\end{theorem}
+
+\begin{theorem}[\texttt{log\_partitionFunctionAlongExhaustion\_beta\_zero}; PR \#164]
+同条件で
+\[
+  \log \texttt{partitionFunctionAlongExhaustion}\,G\,\Lambda\,\langle J, h, 0 \rangle\,n
+    = |\Lambda_n| \cdot \log 2.
+\]
+\end{theorem}
+
 \begin{theorem}[\texttt{inducedGraph\_bot}; PR \#129]
 $\texttt{inducedGraph}\,(\bot : \texttt{SimpleGraph}\,V)\,\Lambda
   = (\bot : \texttt{SimpleGraph}\,\uparrow\Lambda)$.


### PR DESCRIPTION
## Summary
β=0 companion to `partitionFunctionAlongExhaustion_zero_params` (PR #163):

- `partitionFunctionAlongExhaustion G Λ ⟨J, h, 0⟩ n = 2^|Λ.volume n|`
- `log (...) = |Λ.volume n| · log 2`

Specialize `IsingModel.partitionFunction_beta_zero` to along-exhaustion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)