### PR TITLE
feat: partitionFunction ≥ 2^|ι| (ferromagnetic) + Λ/along-exhaustion lifts

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -254,6 +254,52 @@ theorem log_partitionFunctionAlongExhaustion_nonneg_of_ferromagnetic
     0 ≤ Real.log (partitionFunctionAlongExhaustion G Λ p n) :=
   IsingModel.log_partitionFunction_nonneg_of_ferromagnetic _ p hf
 
+/-- **`partitionFunctionΛ ≥ 2^|Λ|`** for ferromagnetic parameters:
+lifts `partitionFunction_ge_two_pow_card_of_ferromagnetic`
+to the `partitionFunctionΛ` API level.
+
+Strictly sharper than `partitionFunctionΛ_ge_one_of_ferromagnetic`
+for nonempty `Λ`. -/
+theorem partitionFunctionΛ_ge_two_pow_card_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (2 : ℝ) ^ Λ.card ≤ partitionFunctionΛ G Λ p := by
+  have h := IsingModel.partitionFunction_ge_two_pow_card_of_ferromagnetic
+    (inducedGraph G Λ) p hf
+  rwa [Fintype.card_coe] at h
+
+/-- Log form at `Λ` level: `|Λ| · log 2 ≤ log (partitionFunctionΛ G Λ p)`
+for ferromagnetic. -/
+theorem log_partitionFunctionΛ_ge_card_mul_log_two_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Λ.card : ℝ) * Real.log 2 ≤ Real.log (partitionFunctionΛ G Λ p) := by
+  have h := IsingModel.log_partitionFunction_ge_card_mul_log_two_of_ferromagnetic
+    (inducedGraph G Λ) p hf
+  rwa [Fintype.card_coe] at h
+
+/-- **`partitionFunctionAlongExhaustion ≥ 2^|Λ.volume n|`** for
+ferromagnetic parameters: pointwise lift. -/
+theorem partitionFunctionAlongExhaustion_ge_two_pow_card_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ) :
+    (2 : ℝ) ^ (Λ.volume n).card ≤ partitionFunctionAlongExhaustion G Λ p n :=
+  partitionFunctionΛ_ge_two_pow_card_of_ferromagnetic G (Λ.volume n) p hf
+
+/-- Log form along exhaustion: `|Λ.volume n| · log 2 ≤ log Z_n`. -/
+theorem log_partitionFunctionAlongExhaustion_ge_card_mul_log_two_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ) :
+    ((Λ.volume n).card : ℝ) * Real.log 2
+      ≤ Real.log (partitionFunctionAlongExhaustion G Λ p n) := by
+  have h := IsingModel.log_partitionFunction_ge_card_mul_log_two_of_ferromagnetic
+    (inducedGraph G (Λ.volume n)) p hf
+  rwa [Fintype.card_coe] at h
+
 /-- Wrapper of `partitionFunction_inducedGraph_disjUnion_super_multiplicative`
 at the `partitionFunctionΛ` API level. -/
 theorem partitionFunctionΛ_disjUnion_super_multiplicative

--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -646,6 +646,53 @@ theorem log_partitionFunction_nonneg_of_ferromagnetic
     0 ≤ Real.log (partitionFunction G p) :=
   Real.log_nonneg (partitionFunction_ge_one_of_ferromagnetic G p hf)
 
+/-- **Unconditional `⊥`-graph bound `Z_⊥ ≥ 2^|ι|`.**
+
+From `partitionFunction_bot = (2 · cosh(βh))^|ι|` and
+`Real.one_le_cosh`, hence `2 ≤ 2 · cosh(βh)`, hence
+`2^|ι| ≤ (2 · cosh(βh))^|ι|`. No ferromagnetic hypothesis
+required. -/
+theorem partitionFunction_bot_ge_two_pow_card (p : IsingParams ℝ) :
+    (2 : ℝ) ^ Fintype.card ι ≤ partitionFunction (⊥ : SimpleGraph ι) p := by
+  have h_cosh_ge : (2 : ℝ) ≤ 2 * Real.cosh (p.β * p.h) := by
+    have : 1 ≤ Real.cosh (p.β * p.h) := Real.one_le_cosh _
+    linarith
+  have h_pow : (2 : ℝ) ^ Fintype.card ι
+      ≤ (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι :=
+    pow_le_pow_left₀ (by norm_num) h_cosh_ge _
+  rw [partitionFunction_bot]
+  exact h_pow
+
+/-- **Strong ferromagnetic lower bound `Z_G ≥ 2^|ι|`.**
+
+Combines `partitionFunction_bot_ge_two_pow_card` with
+`partitionFunction_monotone_subgraph`: `2^|ι| ≤ Z_⊥ ≤ Z_G`.
+Strictly sharper than `partitionFunction_ge_one_of_ferromagnetic`
+when `|ι| ≥ 1`. Used to derive `log Z_G ≥ |ι| · log 2` (the
+sharp version of `≥ 0`). -/
+theorem partitionFunction_ge_two_pow_card_of_ferromagnetic
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (2 : ℝ) ^ Fintype.card ι ≤ partitionFunction G p :=
+  (partitionFunction_bot_ge_two_pow_card p).trans
+    (partitionFunction_monotone_subgraph bot_le p hf)
+
+/-- Logarithmic form: `log Z_G ≥ |ι| · log 2` for ferromagnetic.
+
+Immediate from `partitionFunction_ge_two_pow_card_of_ferromagnetic`
+via `Real.log_pow` + `Real.log_le_log`. -/
+theorem log_partitionFunction_ge_card_mul_log_two_of_ferromagnetic
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Fintype.card ι : ℝ) * Real.log 2 ≤ Real.log (partitionFunction G p) := by
+  have h_two_pow_pos : (0 : ℝ) < (2 : ℝ) ^ Fintype.card ι :=
+    pow_pos (by norm_num) _
+  have h_log :=
+    Real.log_le_log h_two_pow_pos
+      (partitionFunction_ge_two_pow_card_of_ferromagnetic G p hf)
+  rw [Real.log_pow] at h_log
+  exact h_log
+
 /-- The free energy rescaling identity in `β`:
 `f(J, h, β) = f(βJ, βh, 1)`. Follows from `partitionFunction_beta_rescale`
 (after taking `log` and multiplying by `|ι|⁻¹`). -/

--- a/docs/index.md
+++ b/docs/index.md
@@ -241,6 +241,7 @@ ambient framework:
 | `freeEnergyInfinite_zero_params` | **∞-volume lift**: `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2` (all stages nonempty) |
 | `partitionFunctionAlongExhaustion_zero_params` / `log_partitionFunctionAlongExhaustion_zero_params` | Partition-function side: `Z = 2^|Λ.volume n|`, `log Z = |Λ.volume n| · log 2` at `⟨0, 0, β⟩` |
 | `partitionFunctionAlongExhaustion_beta_zero` / `log_partitionFunctionAlongExhaustion_beta_zero` | β=0 companion: `Z = 2^|Λ.volume n|`, `log Z = |Λ.volume n| · log 2` at `⟨J, h, 0⟩` (any J, h) |
+| `partitionFunction{,Λ,AlongExhaustion}_ge_two_pow_card_of_ferromagnetic` | Strong ferromagnetic lower bound: `2^|ι| ≤ Z_G(p)` (via `⊥` + `cosh ≥ 1` + monotone); log form `|ι| · log 2 ≤ log Z` |
 | **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
 | `freeEnergy_upper_bound` (Conditioning.lean) | **Explicit upper bound** (Cor. 10.3.2 / \|ι\|): `freeEnergy G p ≤ log 2 + \|β\|·(\|J\|·\|E\| + \|h\|·\|ι\|)/\|ι\|` for nonempty ι |
 | `freeEnergyAlongExhaustion_upper_bound` | Along-exhaustion specialization of `freeEnergy_upper_bound` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1645,6 +1645,19 @@ $\beta = 0$ で Boltzmann weight $\exp(-\beta H) = 1$ を経由.
 \]
 \end{theorem}
 
+\begin{theorem}[\texttt{partitionFunction\_ge\_two\_pow\_card\_of\_ferromagnetic} 系; PR \#165]
+強磁性 $p$ で
+\[
+  2^{|\iota|} \;\le\; Z_G(p).
+\]
+\texttt{partitionFunction\_bot\_ge\_two\_pow\_card}
+($\bot$-graph + $\cosh \ge 1$) と
+\texttt{partitionFunction\_monotone\_subgraph} の合成.
+log 形 \texttt{log\_partitionFunction\_ge\_card\_mul\_log\_two\_of\_ferromagnetic}
+は $|\iota| \cdot \log 2 \le \log Z_G$, $\Lambda$ / along-exhaustion lifts
+も同 PR で提供.
+\end{theorem}
+
 \begin{theorem}[\texttt{inducedGraph\_bot}; PR \#129]
 $\texttt{inducedGraph}\,(\bot : \texttt{SimpleGraph}\,V)\,\Lambda
   = (\bot : \texttt{SimpleGraph}\,\uparrow\Lambda)$.


### PR DESCRIPTION
## Summary
Strong ferromagnetic lower bound `2^|ι| ≤ Z_G(p)` (stricter than the
existing `1 ≤ Z`), extracted from the proof body of PR #161:

- `partitionFunction_bot` + `Real.one_le_cosh` ⇒ `2^|ι| ≤ Z_⊥`
- `partitionFunction_monotone_subgraph` ⇒ `Z_⊥ ≤ Z_G`

Three levels: base (GibbsMeasure / FreeEnergy) → `Λ` → along-exhaustion.

Provides the standard API replacement for PR #161's inlined chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)