### PR TITLE
refactor: use _ge_card_mul_log_two API in log Z tendsto_atTop proof

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -865,13 +865,12 @@ theorem freeEnergyInfinite_monotone_abs_h
 /-- **`log Z` tends to `∞` along any exhaustion of an infinite ambient
 type**, under ferromagnetic parameters.
 
-Proof: eventually `Λ.volume n` is nonempty
-(`Exhaustion.eventually_volume_nonempty`), and on those stages the
-existing API gives `|Λ.volume n| · log 2 ≤ |Λ.volume n| · freeEnergyΛ
-= log Z_n` via `freeEnergyΛ_ge_log_two` and
-`card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty`.
-Since `|Λ.volume n| → ∞` (`Exhaustion.tendsto_card_atTop`) and
-`log 2 > 0`, the lower bound tends to `∞`. -/
+Direct application of the pointwise bound
+`log_partitionFunctionAlongExhaustion_ge_card_mul_log_two_of_ferromagnetic`
+(PR #165): `|Λ.volume n| · log 2 ≤ log Z_n` for every `n`. Combined
+with `Exhaustion.tendsto_card_atTop` (|Λ.volume n| → ∞) and
+`log 2 > 0`, the lower bound tends to `∞`; `Filter.tendsto_atTop_mono`
+lifts this to `log Z_n → ∞`. -/
 theorem log_partitionFunctionAlongExhaustion_tendsto_atTop
     [Infinite V] (G : SimpleGraph V) (Λ : Exhaustion V)
     [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
@@ -879,29 +878,17 @@ theorem log_partitionFunctionAlongExhaustion_tendsto_atTop
     Filter.Tendsto
       (fun n => Real.log (partitionFunctionAlongExhaustion G Λ p n))
       Filter.atTop Filter.atTop := by
-  obtain ⟨J, h, β⟩ := p
   have hlog2_pos : (0 : ℝ) < Real.log 2 :=
     Real.log_pos (by norm_num : (1 : ℝ) < 2)
-  have hbound : ∀ᶠ n in Filter.atTop,
-      ((Λ.volume n).card : ℝ) * Real.log 2
-        ≤ Real.log (partitionFunctionAlongExhaustion G Λ ⟨J, h, β⟩ n) := by
-    filter_upwards [Λ.eventually_volume_nonempty] with n hne
-    have h_flog2 : Real.log 2 ≤ freeEnergyΛ G (Λ.volume n) ⟨J, h, β⟩ :=
-      freeEnergyΛ_ge_log_two G hne hf.hJ hf.hh hf.hβ
-    have h_card_nn : (0 : ℝ) ≤ ((Λ.volume n).card : ℝ) := Nat.cast_nonneg _
-    calc ((Λ.volume n).card : ℝ) * Real.log 2
-        ≤ ((Λ.volume n).card : ℝ) * freeEnergyΛ G (Λ.volume n) ⟨J, h, β⟩ :=
-          mul_le_mul_of_nonneg_left h_flog2 h_card_nn
-      _ = Real.log (partitionFunctionAlongExhaustion G Λ ⟨J, h, β⟩ n) :=
-          card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty G hne _
   have h_card_tendsto :
       Filter.Tendsto (fun n => ((Λ.volume n).card : ℝ) * Real.log 2)
-        Filter.atTop Filter.atTop := by
-    have h1 : Filter.Tendsto (fun n => ((Λ.volume n).card : ℝ))
         Filter.atTop Filter.atTop :=
-      tendsto_natCast_atTop_atTop.comp Λ.tendsto_card_atTop
-    exact h1.atTop_mul_const hlog2_pos
-  exact Filter.tendsto_atTop_mono' _ hbound h_card_tendsto
+    (tendsto_natCast_atTop_atTop.comp Λ.tendsto_card_atTop).atTop_mul_const
+      hlog2_pos
+  exact Filter.tendsto_atTop_mono
+    (fun n => log_partitionFunctionAlongExhaustion_ge_card_mul_log_two_of_ferromagnetic
+      G Λ p hf n)
+    h_card_tendsto
 
 /-- **`Z` tends to `∞` along any exhaustion of an infinite ambient
 type**, under ferromagnetic parameters. Follows from


### PR DESCRIPTION
## Summary
Refactor `log_partitionFunctionAlongExhaustion_tendsto_atTop` (PR #161)
to use `log_partitionFunctionAlongExhaustion_ge_card_mul_log_two_of_ferromagnetic`
(PR #165) directly.

No mathematical content change; proof body ~20 → ~10 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)