### PR TITLE
feat: freeEnergy_ge_log_two_of_ferromagnetic at base + Λ wrapper refactor

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -203,17 +203,17 @@ theorem freeEnergyΛ_ge_log_two_cosh
   exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hcard
 
 /-- **`freeEnergyΛ ≥ log 2`** for ferromagnetic on nonempty `Λ`.
-Follows from `freeEnergyΛ_ge_log_two_cosh` and `cosh ≥ 1`. -/
+Thin wrapper of base-layer
+`IsingModel.freeEnergy_ge_log_two_of_ferromagnetic`. -/
 theorem freeEnergyΛ_ge_log_two
     (G : SimpleGraph V) {Λ : Finset V} (hne : Λ.Nonempty)
     [Fintype (inducedGraph G Λ).edgeSet]
     {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
     Real.log 2 ≤ freeEnergyΛ G Λ (⟨J, h, β⟩ : IsingParams ℝ) := by
-  have h_cosh : 1 ≤ Real.cosh (β * h) := Real.one_le_cosh _
-  have h_log : Real.log 2 ≤ Real.log (2 * Real.cosh (β * h)) := by
-    apply Real.log_le_log (by norm_num : (0 : ℝ) < 2)
-    linarith
-  exact h_log.trans (freeEnergyΛ_ge_log_two_cosh G hne hJ hh hβ)
+  have hcard : 0 < Fintype.card (↑Λ : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_of_ferromagnetic
+    (inducedGraph G Λ) _ ⟨hJ, hh, hβ⟩ hcard
 
 /-- **`freeEnergyΛ ≥ 0`** for ferromagnetic on nonempty `Λ`.
 Follows from `freeEnergyΛ_ge_log_two` and `log 2 > 0`. -/

--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -905,4 +905,24 @@ theorem freeEnergy_ge_log_two_cosh (G : SimpleGraph ι) [Fintype G.edgeSet]
     _ ≤ freeEnergy G (⟨J, h, β⟩ : IsingParams ℝ) :=
         freeEnergy_monotone_subgraph bot_le _ hferm
 
+/-- **Free energy lower bound `log 2 ≤ f_G(p)` for ferromagnetic.**
+
+Weaker than `freeEnergy_ge_log_two_cosh` (which uses the sharp
+`log (2 · cosh(β h))` bound) but doesn't depend on the specific form of
+`p`; takes a `Ferromagnetic p` hypothesis uniformly.
+
+Via `Real.one_le_cosh`, `2 · cosh(β h) ≥ 2`, so
+`log 2 ≤ log (2 · cosh(β h))` by log-monotonicity; then compose with
+`freeEnergy_ge_log_two_cosh`. -/
+theorem freeEnergy_ge_log_two_of_ferromagnetic
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (hne : 0 < Fintype.card ι) :
+    Real.log 2 ≤ freeEnergy G p := by
+  obtain ⟨J, h, β⟩ := p
+  have h_cosh : 1 ≤ Real.cosh (β * h) := Real.one_le_cosh _
+  have h_log : Real.log 2 ≤ Real.log (2 * Real.cosh (β * h)) := by
+    apply Real.log_le_log (by norm_num : (0 : ℝ) < 2)
+    linarith
+  exact h_log.trans (freeEnergy_ge_log_two_cosh G hf.hJ hf.hh hf.hβ hne)
+
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -259,6 +259,7 @@ ambient framework:
 | `freeEnergyAlongExhaustion_beta_zero` | Along-exhaustion specialization: `f_n(J, h, 0) = log 2` per nonempty stage |
 | `freeEnergyInfinite_beta_zero` | **∞-volume lift**: `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2` (all stages nonempty) |
 | `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) | **Sharp ferromagnetic lower bound**: `log(2 cosh(β h)) ≤ freeEnergy G p` (via `freeEnergy_bot` + `freeEnergy_monotone_subgraph`) |
+| `freeEnergy_ge_log_two_of_ferromagnetic` (FreeEnergy.lean) | **Unconditional lower bound**: `log 2 ≤ freeEnergy G p` for ferromagnetic + `0 < |ι|` (weakening of `_cosh` via `Real.one_le_cosh`) |
 | `freeEnergyAlongExhaustion_ge_log_two_cosh` | Along-exhaustion specialization of the sharp ferromagnetic lower bound |
 | `hamiltonian_neg_h` (Hamiltonian.lean) | `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)` (spin-flip / h-sign identity) |
 | `partitionFunction_neg_h` (GibbsMeasure.lean) | **Z h-symmetry**: `Z(J, -h, β) = Z(J, h, β)` via flip involution |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1645,6 +1645,16 @@ $\beta = 0$ で Boltzmann weight $\exp(-\beta H) = 1$ を経由.
 \]
 \end{theorem}
 
+\begin{theorem}[\texttt{freeEnergy\_ge\_log\_two\_of\_ferromagnetic}; PR \#168]
+$0 < |\iota|$, 強磁性 $p$ で
+\[
+  \log 2 \;\le\; f_G(p).
+\]
+\texttt{freeEnergy\_ge\_log\_two\_cosh} + \texttt{Real.one\_le\_cosh}
++ log 単調. 既存 $\Lambda$ 版 \texttt{freeEnergyΛ\_ge\_log\_two}
+(PR \#125) は本 PR で base 恒等への薄い wrapper に refactor.
+\end{theorem}
+
 \begin{theorem}[\texttt{card\_mul\_freeEnergy\_eq\_log\_partitionFunction}; PR \#167]
 $|\iota| > 0$ で
 \[


### PR DESCRIPTION
## Summary
Add `log 2 ≤ f_G(p)` at the `FreeEnergy.lean` base layer (ferromagnetic
companion to `freeEnergy_ge_log_two_cosh`). Refactor existing
Λ-level `freeEnergyΛ_ge_log_two` (AmbientLatticeSum.lean) to
a thin wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)