### PR TITLE
feat: freeEnergy_nonneg_of_ferromagnetic at base + Λ wrapper refactor

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -216,15 +216,16 @@ theorem freeEnergyΛ_ge_log_two
     (inducedGraph G Λ) _ ⟨hJ, hh, hβ⟩ hcard
 
 /-- **`freeEnergyΛ ≥ 0`** for ferromagnetic on nonempty `Λ`.
-Follows from `freeEnergyΛ_ge_log_two` and `log 2 > 0`. -/
+Thin wrapper of base-layer
+`IsingModel.freeEnergy_nonneg_of_ferromagnetic`. -/
 theorem freeEnergyΛ_nonneg_of_ferromagnetic
     (G : SimpleGraph V) {Λ : Finset V} (hne : Λ.Nonempty)
     [Fintype (inducedGraph G Λ).edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p) :
     0 ≤ freeEnergyΛ G Λ p := by
-  obtain ⟨J, h, β⟩ := p
-  exact (Real.log_pos (by norm_num : (1 : ℝ) < 2)).le.trans
-    (freeEnergyΛ_ge_log_two G hne hf.hJ hf.hh hf.hβ)
+  have hcard : 0 < Fintype.card (↑Λ : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_nonneg_of_ferromagnetic (inducedGraph G Λ) p hf hcard
 
 /-- **`partitionFunctionΛ ≥ 1`** for ferromagnetic parameters:
 lifts PR #141 `partitionFunction_ge_one_of_ferromagnetic` to the

--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -925,4 +925,15 @@ theorem freeEnergy_ge_log_two_of_ferromagnetic
     linarith
   exact h_log.trans (freeEnergy_ge_log_two_cosh G hf.hJ hf.hh hf.hβ hne)
 
+/-- **Nonnegativity `0 ≤ f_G(p)` for ferromagnetic parameters** on
+nonempty `ι`. Immediate from
+`freeEnergy_ge_log_two_of_ferromagnetic` and `Real.log_pos`
+(`0 < log 2`). -/
+theorem freeEnergy_nonneg_of_ferromagnetic
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (hne : 0 < Fintype.card ι) :
+    0 ≤ freeEnergy G p :=
+  (Real.log_pos (by norm_num : (1 : ℝ) < 2)).le.trans
+    (freeEnergy_ge_log_two_of_ferromagnetic G p hf hne)
+
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -260,6 +260,7 @@ ambient framework:
 | `freeEnergyInfinite_beta_zero` | **∞-volume lift**: `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2` (all stages nonempty) |
 | `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) | **Sharp ferromagnetic lower bound**: `log(2 cosh(β h)) ≤ freeEnergy G p` (via `freeEnergy_bot` + `freeEnergy_monotone_subgraph`) |
 | `freeEnergy_ge_log_two_of_ferromagnetic` (FreeEnergy.lean) | **Unconditional lower bound**: `log 2 ≤ freeEnergy G p` for ferromagnetic + `0 < |ι|` (weakening of `_cosh` via `Real.one_le_cosh`) |
+| `freeEnergy_nonneg_of_ferromagnetic` (FreeEnergy.lean) | **Nonnegativity**: `0 ≤ freeEnergy G p` for ferromagnetic + `0 < |ι|` (weakening of `_ge_log_two_of_ferromagnetic` via `Real.log_pos`) |
 | `freeEnergyAlongExhaustion_ge_log_two_cosh` | Along-exhaustion specialization of the sharp ferromagnetic lower bound |
 | `hamiltonian_neg_h` (Hamiltonian.lean) | `H_G(σ; J, -h, β) = H_G(σ.flip; J, h, β)` (spin-flip / h-sign identity) |
 | `partitionFunction_neg_h` (GibbsMeasure.lean) | **Z h-symmetry**: `Z(J, -h, β) = Z(J, h, β)` via flip involution |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1655,6 +1655,16 @@ $0 < |\iota|$, 強磁性 $p$ で
 (PR \#125) は本 PR で base 恒等への薄い wrapper に refactor.
 \end{theorem}
 
+\begin{theorem}[\texttt{freeEnergy\_nonneg\_of\_ferromagnetic}; PR \#169]
+$0 < |\iota|$, 強磁性 $p$ で
+\[
+  0 \;\le\; f_G(p).
+\]
+PR \#168 と \texttt{Real.log\_pos} ($0 < \log 2$) の推移.
+既存 $\Lambda$ 版 \texttt{freeEnergyΛ\_nonneg\_of\_ferromagnetic}
+(PR \#125) は本 PR で base への薄い wrapper に refactor.
+\end{theorem}
+
 \begin{theorem}[\texttt{card\_mul\_freeEnergy\_eq\_log\_partitionFunction}; PR \#167]
 $|\iota| > 0$ で
 \[


### PR DESCRIPTION
## Summary
Add `0 ≤ f_G(p)` at `FreeEnergy.lean` base layer (weakening of
PR #168 via `log 2 > 0`). Refactor Λ-level
`freeEnergyΛ_nonneg_of_ferromagnetic` (PR #125) to thin wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)