### PR TITLE
feat: log_partitionFunction_ge_card_mul_log_two_cosh + 3-layer lift

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -301,6 +301,29 @@ theorem log_partitionFunctionAlongExhaustion_ge_card_mul_log_two_of_ferromagneti
     (inducedGraph G (Λ.volume n)) p hf
   rwa [Fintype.card_coe] at h
 
+/-- Sharp form at `Λ` level: `|Λ| · log(2·cosh(βh)) ≤ log (partitionFunctionΛ G Λ p)`
+for ferromagnetic. Thin wrapper of
+`log_partitionFunction_ge_card_mul_log_two_cosh_of_ferromagnetic`. -/
+theorem log_partitionFunctionΛ_ge_card_mul_log_two_cosh_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Λ.card : ℝ) * Real.log (2 * Real.cosh (p.β * p.h))
+      ≤ Real.log (partitionFunctionΛ G Λ p) := by
+  have h := IsingModel.log_partitionFunction_ge_card_mul_log_two_cosh_of_ferromagnetic
+    (inducedGraph G Λ) p hf
+  rwa [Fintype.card_coe] at h
+
+/-- Sharp form along exhaustion:
+`|Λ.volume n| · log(2·cosh(βh)) ≤ log Z_n`. Pointwise lift. -/
+theorem log_partitionFunctionAlongExhaustion_ge_card_mul_log_two_cosh_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ) :
+    ((Λ.volume n).card : ℝ) * Real.log (2 * Real.cosh (p.β * p.h))
+      ≤ Real.log (partitionFunctionAlongExhaustion G Λ p n) :=
+  log_partitionFunctionΛ_ge_card_mul_log_two_cosh_of_ferromagnetic G (Λ.volume n) p hf
+
 /-- Wrapper of `partitionFunction_inducedGraph_disjUnion_super_multiplicative`
 at the `partitionFunctionΛ` API level. -/
 theorem partitionFunctionΛ_disjUnion_super_multiplicative

--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -712,6 +712,30 @@ theorem log_partitionFunction_ge_card_mul_log_two_of_ferromagnetic
   rw [Real.log_pow] at h_log
   exact h_log
 
+/-- **Sharp ferromagnetic log-Z lower bound**:
+`|ι| · log(2·cosh(βh)) ≤ log Z_G(p)`.
+
+Sharpening of `log_partitionFunction_ge_card_mul_log_two_of_ferromagnetic`
+via `Z_⊥ = (2·cosh(βh))^|ι|` (from `partitionFunction_bot`) and
+`Z_⊥ ≤ Z_G` (ferromagnetic `partitionFunction_monotone_subgraph`);
+take `log` + `Real.log_pow`. -/
+theorem log_partitionFunction_ge_card_mul_log_two_cosh_of_ferromagnetic
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Fintype.card ι : ℝ) * Real.log (2 * Real.cosh (p.β * p.h))
+      ≤ Real.log (partitionFunction G p) := by
+  have h_cosh_pos : (0 : ℝ) < 2 * Real.cosh (p.β * p.h) := by
+    have := Real.one_le_cosh (p.β * p.h); linarith
+  have h_pow_pos : (0 : ℝ) < (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι :=
+    pow_pos h_cosh_pos _
+  have h_ge : (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι
+      ≤ partitionFunction G p := by
+    rw [← partitionFunction_bot (p := p)]
+    exact partitionFunction_monotone_subgraph bot_le p hf
+  have h_log := Real.log_le_log h_pow_pos h_ge
+  rw [Real.log_pow] at h_log
+  exact h_log
+
 /-- The free energy rescaling identity in `β`:
 `f(J, h, β) = f(βJ, βh, 1)`. Follows from `partitionFunction_beta_rescale`
 (after taking `log` and multiplying by `|ι|⁻¹`). -/

--- a/docs/index.md
+++ b/docs/index.md
@@ -246,6 +246,7 @@ ambient framework:
 | `partitionFunctionAlongExhaustion_zero_params` / `log_partitionFunctionAlongExhaustion_zero_params` | Partition-function side: `Z = 2^|Λ.volume n|`, `log Z = |Λ.volume n| · log 2` at `⟨0, 0, β⟩` |
 | `partitionFunctionAlongExhaustion_beta_zero` / `log_partitionFunctionAlongExhaustion_beta_zero` | β=0 companion: `Z = 2^|Λ.volume n|`, `log Z = |Λ.volume n| · log 2` at `⟨J, h, 0⟩` (any J, h) |
 | `partitionFunction{,Λ,AlongExhaustion}_ge_two_pow_card_of_ferromagnetic` | Strong ferromagnetic lower bound: `2^|ι| ≤ Z_G(p)` (via `⊥` + `cosh ≥ 1` + monotone); log form `|ι| · log 2 ≤ log Z` |
+| `log_partitionFunction{,Λ,AlongExhaustion}_ge_card_mul_log_two_cosh_of_ferromagnetic` | **Sharp log-Z lower bound**: `|ι| · log(2·cosh(βh)) ≤ log Z_G(p)` (via `Z ≥ Z_⊥ = (2 cosh(βh))^|ι|` + `Real.log_pow`) |
 | **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
 | `freeEnergy_upper_bound` (Conditioning.lean) | **Explicit upper bound** (Cor. 10.3.2 / \|ι\|): `freeEnergy G p ≤ log 2 + \|β\|·(\|J\|·\|E\| + \|h\|·\|ι\|)/\|ι\|` for nonempty ι |
 | `freeEnergyAlongExhaustion_upper_bound` | Along-exhaustion specialization of `freeEnergy_upper_bound` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1709,6 +1709,16 @@ $|\iota| > 0$ で
 (PR \#119) の base layer; 同 $\Lambda$ 版は本 PR で薄い wrapper に refactor.
 \end{theorem}
 
+\begin{theorem}[\texttt{log\_partitionFunction\_ge\_card\_mul\_log\_two\_cosh\_of\_ferromagnetic} 系; PR \#173]
+強磁性 $p$ で
+\[
+  |\iota| \cdot \log(2 \cosh(\beta h)) \;\le\; \log Z_G(p).
+\]
+PR \#165 \texttt{\_ge\_card\_mul\_log\_two} の sharpening. 3 層 lift
+(base / $\Lambda$ / along-exhaustion). 証明: $Z_G \ge Z_\bot = (2 \cosh(\beta h))^{|\iota|}$
+から $\log$ + \texttt{Real.log\_pow}.
+\end{theorem}
+
 \begin{theorem}[\texttt{partitionFunction\_ge\_two\_pow\_card\_of\_ferromagnetic} 系; PR \#165]
 強磁性 $p$ で
 \[


### PR DESCRIPTION
## Summary
Sharp ferromagnetic lower bound at log-Z level:
$$|\iota| \cdot \log(2 \cosh(\beta h)) \le \log Z_G(p)$$

Sharpening of PR #165 `log_partitionFunction_ge_card_mul_log_two`
(via `log(2·cosh) ≥ log 2`).

Three levels: base (FreeEnergy.lean) / Λ / along-exhaustion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)