### PR TITLE
feat: partitionFunction_ge_two_cosh_pow_card_of_ferromagnetic + 3-layer lift

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -290,6 +290,29 @@ theorem partitionFunctionAlongExhaustion_ge_two_pow_card_of_ferromagnetic
     (2 : ℝ) ^ (Λ.volume n).card ≤ partitionFunctionAlongExhaustion G Λ p n :=
   partitionFunctionΛ_ge_two_pow_card_of_ferromagnetic G (Λ.volume n) p hf
 
+/-- **Sharp form at `Λ` level**: `(2·cosh(βh))^|Λ| ≤ partitionFunctionΛ G Λ p`
+for ferromagnetic. Thin wrapper of
+`IsingModel.partitionFunction_ge_two_cosh_pow_card_of_ferromagnetic`. -/
+theorem partitionFunctionΛ_ge_two_cosh_pow_card_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (2 * Real.cosh (p.β * p.h)) ^ Λ.card ≤ partitionFunctionΛ G Λ p := by
+  have h := IsingModel.partitionFunction_ge_two_cosh_pow_card_of_ferromagnetic
+    (inducedGraph G Λ) p hf
+  rwa [Fintype.card_coe] at h
+
+/-- **Sharp form along exhaustion**:
+`(2·cosh(βh))^|Λ.volume n| ≤ partitionFunctionAlongExhaustion G Λ p n`
+for ferromagnetic. Pointwise lift. -/
+theorem partitionFunctionAlongExhaustion_ge_two_cosh_pow_card_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ) :
+    (2 * Real.cosh (p.β * p.h)) ^ (Λ.volume n).card
+      ≤ partitionFunctionAlongExhaustion G Λ p n :=
+  partitionFunctionΛ_ge_two_cosh_pow_card_of_ferromagnetic G (Λ.volume n) p hf
+
 /-- Log form along exhaustion: `|Λ.volume n| · log 2 ≤ log Z_n`. -/
 theorem log_partitionFunctionAlongExhaustion_ge_card_mul_log_two_of_ferromagnetic
     (G : SimpleGraph V) (Λ : Exhaustion V)

--- a/IsingModel/FreeEnergy.lean
+++ b/IsingModel/FreeEnergy.lean
@@ -696,6 +696,22 @@ theorem partitionFunction_ge_two_pow_card_of_ferromagnetic
   (partitionFunction_bot_ge_two_pow_card p).trans
     (partitionFunction_monotone_subgraph bot_le p hf)
 
+/-- **Sharp ferromagnetic lower bound (non-log form)**:
+`(2·cosh(βh))^|ι| ≤ Z_G(p)`.
+
+Direct from `partitionFunction_bot` (`Z_⊥ = (2·cosh(βh))^|ι|`) and
+`partitionFunction_monotone_subgraph` (`bot ≤ G`, ferromagnetic).
+Sharpening of `partitionFunction_ge_two_pow_card_of_ferromagnetic`
+(since `cosh ≥ 1`); the exp-image of PR #173
+`log_partitionFunction_ge_card_mul_log_two_cosh_of_ferromagnetic`. -/
+theorem partitionFunction_ge_two_cosh_pow_card_of_ferromagnetic
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι ≤ partitionFunction G p := by
+  calc (2 * Real.cosh (p.β * p.h)) ^ Fintype.card ι
+      = partitionFunction (⊥ : SimpleGraph ι) p := (partitionFunction_bot p).symm
+    _ ≤ partitionFunction G p := partitionFunction_monotone_subgraph bot_le p hf
+
 /-- Logarithmic form: `log Z_G ≥ |ι| · log 2` for ferromagnetic.
 
 Immediate from `partitionFunction_ge_two_pow_card_of_ferromagnetic`

--- a/docs/index.md
+++ b/docs/index.md
@@ -248,6 +248,7 @@ ambient framework:
 | `partitionFunctionAlongExhaustion_beta_zero` / `log_partitionFunctionAlongExhaustion_beta_zero` | β=0 companion: `Z = 2^|Λ.volume n|`, `log Z = |Λ.volume n| · log 2` at `⟨J, h, 0⟩` (any J, h) |
 | `partitionFunction{,Λ,AlongExhaustion}_ge_two_pow_card_of_ferromagnetic` | Strong ferromagnetic lower bound: `2^|ι| ≤ Z_G(p)` (via `⊥` + `cosh ≥ 1` + monotone); log form `|ι| · log 2 ≤ log Z` |
 | `log_partitionFunction{,Λ,AlongExhaustion}_ge_card_mul_log_two_cosh_of_ferromagnetic` | **Sharp log-Z lower bound**: `|ι| · log(2·cosh(βh)) ≤ log Z_G(p)` (via `Z ≥ Z_⊥ = (2 cosh(βh))^|ι|` + `Real.log_pow`) |
+| `partitionFunction{,Λ,AlongExhaustion}_ge_two_cosh_pow_card_of_ferromagnetic` | **Sharp Z lower bound (non-log)**: `(2·cosh(βh))^|ι| ≤ Z_G(p)` (direct from `partitionFunction_bot` + `monotone_subgraph`); exp-image of the log form |
 | **`freeEnergyAlongExhaustion_ge_log_two`** | **Uniform lower bound**: `log 2 ≤ freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n` for ferromagnetic + nonempty `Λ.volume n` |
 | `freeEnergy_upper_bound` (Conditioning.lean) | **Explicit upper bound** (Cor. 10.3.2 / \|ι\|): `freeEnergy G p ≤ log 2 + \|β\|·(\|J\|·\|E\| + \|h\|·\|ι\|)/\|ι\|` for nonempty ι |
 | `freeEnergyAlongExhaustion_upper_bound` | Along-exhaustion specialization of `freeEnergy_upper_bound` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -1763,6 +1763,16 @@ PR \#165 \texttt{\_ge\_card\_mul\_log\_two} の sharpening. 3 層 lift
 から $\log$ + \texttt{Real.log\_pow}.
 \end{theorem}
 
+\begin{theorem}[\texttt{partitionFunction\_ge\_two\_cosh\_pow\_card\_of\_ferromagnetic} 系; PR \#177]
+強磁性 $p$ で non-log 形
+\[
+  (2 \cosh(\beta h))^{|\iota|} \;\le\; Z_G(p).
+\]
+PR \#173 log 形の exp 画像. 証明: \texttt{partitionFunction\_bot}
++ \texttt{partitionFunction\_monotone\_subgraph}. 3 層 lift
+(base / $\Lambda$ / along-exhaustion).
+\end{theorem}
+
 \begin{theorem}[\texttt{partitionFunction\_ge\_two\_pow\_card\_of\_ferromagnetic} 系; PR \#165]
 強磁性 $p$ で
 \[


### PR DESCRIPTION
## Summary
Non-log sharp ferromagnetic lower bound `(2·cosh(βh))^|ι| ≤ Z_G(p)`.
Sharpening of PR #165 (`2^|ι| ≤ Z_G`) and exp-image of PR #173
(`|ι|·log(2·cosh(βh)) ≤ log Z_G`).

Three layers: base (FreeEnergy.lean) / Λ / along-exhaustion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)