### PR TITLE
feat: GJ Prop 5.4.2 infinite-volume lift (Peierls bound in +BC limit)

### DIFF
--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -11,3 +11,4 @@ import IsingModel.Asano
 import IsingModel.AmbientLattice
 import IsingModel.AmbientLatticeSum
 import IsingModel.ComplexAnalyticity
+import IsingModel.PeierlsInfinite

--- a/IsingModel/PeierlsInfinite.lean
+++ b/IsingModel/PeierlsInfinite.lean
@@ -1,0 +1,87 @@
+import IsingModel.Peierls
+import IsingModel.AmbientLattice
+
+/-!
+# Peierls argument along an infinite-volume exhaustion
+
+This file bridges the finite-volume Peierls bound
+(`IsingModel.prop_5_4_2_self_contained`, GJ §5.4, p. 83) with the
+ambient / exhaustion framework from `IsingModel.AmbientLattice`.
+
+## Main result
+
+* `prop_5_4_2_along_exhaustion`: if, for every stage `n` of an
+  exhaustion `Λ : Exhaustion V`, the induced graph on `Λ.volume n`
+  is preconnected and the finite-volume hypotheses of
+  `prop_5_4_2_self_contained` hold with a common Peierls constant
+  `c`, then the Peierls bound holds pointwise along the exhaustion:
+  for every `n`,
+  `0 ≤ 1 - ⟨σ_{iₙ}⟩₊^{Λₙ,Bₙ} ≤ exp (-c β)`.
+
+This is a first scaffolding step toward the genuine infinite-volume
+lift of GJ Prop 5.4.2
+(`0 ≤ 1 - ⟨σᵢ⟩₊^∞ ≤ exp (-c β)`, Glimm–Jaffe §5.4, p. 83):
+subsequent PRs on the same branch will define a canonical boundary
+and basepoint choice and take the `limsup`/`liminf` of the sequence.
+
+## Reference
+
+* J. Glimm and A. Jaffe, *Quantum Physics: A Functional Integral
+  Point of View*, 2nd ed., Springer 1987, §5.4, p. 83.
+-/
+
+universe u
+
+namespace IsingModel
+
+variable {V : Type u} [DecidableEq V]
+
+set_option linter.unusedDecidableInType false in
+/-- **Prop 5.4.2 along an exhaustion** (GJ §5.4, p. 83, per-stage
+form). For a graph `G : SimpleGraph V` with an exhaustion
+`Λ : Exhaustion V`, if
+
+* each induced graph `Ambient.inducedGraph G (Λ.volume n)` is preconnected
+  and has a decidable adjacency and a `Fintype` edge set;
+* `J, β > 0`;
+* a per-stage non-empty boundary `B n : Finset ↑(Λ.volume n)` and
+  basepoint `i n : ↑(Λ.volume n)` are supplied;
+* the exponential bound condition holds uniformly with a common
+  constant `c`,
+
+then the Peierls bound holds pointwise along the exhaustion: for
+every `n`,
+
+`0 ≤ 1 - plusGibbsExpectation (Gₙ) ⟨J, 0, β⟩ (Bₙ) (σ ↦ sign (σ iₙ))
+  ≤ Real.exp (-c * β)`.
+
+The proof is a direct application of
+`prop_5_4_2_self_contained` at each stage.
+
+Subsequent PRs on this branch will (i) pick a canonical `B` and `i`
+from the ambient geometry, and (ii) take the `limsup`/`liminf` to
+express the genuine infinite-volume bound
+`0 ≤ 1 - ⟨σᵢ⟩₊^∞ ≤ exp (-c β)`. -/
+theorem prop_5_4_2_along_exhaustion
+    (G : SimpleGraph V) (Λ : Ambient.Exhaustion V)
+    [∀ n, DecidableRel (Ambient.inducedGraph G (Λ.volume n)).Adj]
+    [∀ n, Fintype (Ambient.inducedGraph G (Λ.volume n)).edgeSet]
+    (hconn : ∀ n, (Ambient.inducedGraph G (Λ.volume n)).Preconnected)
+    (J β c : ℝ) (hβ : 0 < β) (hJ : 0 < J)
+    (B : ∀ n, Finset (↑(Λ.volume n) : Type _))
+    (hB : ∀ n, (B n).Nonempty)
+    (i : ∀ n, (↑(Λ.volume n) : Type _))
+    (hexp : ∀ n,
+      2 * ((2 : ℝ) ^ Fintype.card (↑(Λ.volume n) : Type _)) *
+          Real.exp (-2 * β * J) ≤
+        Real.exp (-c * β)) :
+    ∀ n,
+      0 ≤ 1 - plusGibbsExpectation (Ambient.inducedGraph G (Λ.volume n))
+              ⟨J, 0, β⟩ (B n) (fun σ => Spin.sign ℝ (σ (i n))) ∧
+      1 - plusGibbsExpectation (Ambient.inducedGraph G (Λ.volume n))
+            ⟨J, 0, β⟩ (B n) (fun σ => Spin.sign ℝ (σ (i n))) ≤
+        Real.exp (-c * β) := fun n =>
+  prop_5_4_2_self_contained (Ambient.inducedGraph G (Λ.volume n)) (hconn n)
+    J β c hβ hJ (B n) (hB n) (i n) (hexp n)
+
+end IsingModel

--- a/IsingModel/PeierlsInfinite.lean
+++ b/IsingModel/PeierlsInfinite.lean
@@ -44,8 +44,9 @@ form). For a graph `G : SimpleGraph V` with an exhaustion
 * each induced graph `Ambient.inducedGraph G (Λ.volume n)` is preconnected
   and has a decidable adjacency and a `Fintype` edge set;
 * `J, β > 0`;
-* a per-stage non-empty boundary `B n : Finset ↑(Λ.volume n)` and
-  basepoint `i n : ↑(Λ.volume n)` are supplied;
+* a per-stage non-empty set `B n : Finset ↑(Λ.volume n)` of
+  `+`-boundary-condition sites, together with a basepoint
+  `i n : ↑(Λ.volume n)`, is supplied;
 * the exponential bound condition holds uniformly with a common
   constant `c`,
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -177,6 +177,7 @@ gives, at every `h₀ ∈ leeYangDomain`, an analytic function `f` with
 | `peierls_bound` (Prop 5.4.1) | `Pr(γ ⊆ ∂σ) ≤ exp(-2βJ|γ|)` | `Peierls.lean` | Finite |
 | `peierls_contour_sum_bound` | `Σ Pr(γ) ≤ N(r) exp(-2βJ r)` | `Peierls.lean` | Finite |
 | `prop_5_4_2_self_contained` (Prop 5.4.2) | `0 ≤ 1 − ⟨σᵢ⟩₊ ≤ exp(-cβ)` | `Peierls.lean` | Finite (+ BC) |
+| `prop_5_4_2_along_exhaustion` | **Per-stage Peierls bound along an exhaustion** `Λ : Ambient.Exhaustion V`: uniformly `0 ≤ 1 − ⟨σᵢₙ⟩₊^{Λₙ,Bₙ} ≤ exp(-cβ)` for every `n`, given per-stage preconnectedness, non-empty boundaries, and the common exponential-bound hypothesis. Direct application of `prop_5_4_2_self_contained` at each `Λ.volume n`. Scaffolding toward the genuine infinite-volume lift. | `PeierlsInfinite.lean` | Exhaustion (+ BC) |
 | `eta_nonneg_finite_vol` (§17.7) | `η ≥ 0` | `PhaseTransition.lean` | Finite |
 
 **Not yet formalized**: infinite-volume lift of Prop 5.4.2 (requires

--- a/docs/index.md
+++ b/docs/index.md
@@ -177,7 +177,7 @@ gives, at every `h₀ ∈ leeYangDomain`, an analytic function `f` with
 | `peierls_bound` (Prop 5.4.1) | `Pr(γ ⊆ ∂σ) ≤ exp(-2βJ|γ|)` | `Peierls.lean` | Finite |
 | `peierls_contour_sum_bound` | `Σ Pr(γ) ≤ N(r) exp(-2βJ r)` | `Peierls.lean` | Finite |
 | `prop_5_4_2_self_contained` (Prop 5.4.2) | `0 ≤ 1 − ⟨σᵢ⟩₊ ≤ exp(-cβ)` | `Peierls.lean` | Finite (+ BC) |
-| `prop_5_4_2_along_exhaustion` | **Per-stage Peierls bound along an exhaustion** `Λ : Ambient.Exhaustion V`: uniformly `0 ≤ 1 − ⟨σᵢₙ⟩₊^{Λₙ,Bₙ} ≤ exp(-cβ)` for every `n`, given per-stage preconnectedness, non-empty boundaries, and the common exponential-bound hypothesis. Direct application of `prop_5_4_2_self_contained` at each `Λ.volume n`. Scaffolding toward the genuine infinite-volume lift. | `PeierlsInfinite.lean` | Exhaustion (+ BC) |
+| `prop_5_4_2_along_exhaustion` | **Per-stage Peierls bound along an exhaustion** `Λ : Ambient.Exhaustion V`: uniformly `0 ≤ 1 − ⟨σᵢₙ⟩₊^{Λₙ,Bₙ} ≤ exp(-cβ)` for every `n`, given per-stage preconnectedness, non-empty sets of `+`-boundary-condition sites, and the common exponential-bound hypothesis. Direct application of `prop_5_4_2_self_contained` at each `Λ.volume n`. Scaffolding toward the genuine infinite-volume lift. | `PeierlsInfinite.lean` | Exhaustion (+ BC) |
 | `eta_nonneg_finite_vol` (§17.7) | `η ≥ 0` | `PhaseTransition.lean` | Finite |
 
 **Not yet formalized**: infinite-volume lift of Prop 5.4.2 (requires

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3959,4 +3959,35 @@ convergence of $f_\Lambda = (\log Z_\Lambda)/|\Lambda|$ along
 arbitrary exhaustions of the ambient lattice; this is the
 Prop 4.6.1 body in the next PR.
 
+\begin{theorem}[GJ \S 5.4 Prop 5.4.2 along an exhaustion (per-stage);
+PR \#202]
+For a graph $G : \mathrm{SimpleGraph}\, V$ with an exhaustion
+$\Lambda : \mathrm{Ambient.Exhaustion}\, V$, suppose that for every
+stage $n$ the induced graph $G_n := \mathrm{Ambient.inducedGraph}\,G\,(\Lambda_n)$
+is preconnected, $B_n \subseteq \Lambda_n$ is a non-empty boundary,
+$i_n \in \Lambda_n$, and the common exponential bound
+\[
+  2 \cdot 2^{\#\Lambda_n} \exp(-2\beta J) \le \exp(-c\beta)
+\]
+holds uniformly in $n$. Then, for $J, \beta > 0$ and $h = 0$, the
+Peierls bound
+\[
+  0 \;\le\; 1 - \langle \sigma_{i_n} \rangle_{+}^{G_n, B_n}
+  \;\le\; \exp(-c\beta)
+\]
+holds at every $n$.
+\end{theorem}
+
+\begin{proof}
+Direct application of \texttt{prop\_5\_4\_2\_self\_contained}
+(Glimm--Jaffe \cite{glimm-jaffe} \S 5.4 p.~83) at each stage $n$;
+the hypotheses at stage $n$ are the finite-volume hypotheses of
+that theorem specialised to $G_n$, $B_n$, $i_n$. This is a
+scaffolding step: subsequent PRs on the same branch will pick a
+canonical $(B_n, i_n)$ from the ambient geometry and take the
+$\limsup$ / $\liminf$ to recover the genuine infinite-volume
+bound $0 \le 1 - \langle\sigma_i\rangle_+^\infty \le \exp(-c\beta)$
+(Glimm--Jaffe \cite{glimm-jaffe} \S 5.4 p.~83).
+\end{proof}
+
 \end{document}

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3959,12 +3959,13 @@ convergence of $f_\Lambda = (\log Z_\Lambda)/|\Lambda|$ along
 arbitrary exhaustions of the ambient lattice; this is the
 Prop 4.6.1 body in the next PR.
 
-\begin{theorem}[GJ \S 5.4 Prop 5.4.2 along an exhaustion (per-stage);
-PR \#202]
+\begin{theorem}[Corollary/wrapper of GJ \S 5.4 Prop 5.4.2 along an
+exhaustion (per-stage); PR \#202]
 For a graph $G : \mathrm{SimpleGraph}\, V$ with an exhaustion
 $\Lambda : \mathrm{Ambient.Exhaustion}\, V$, suppose that for every
 stage $n$ the induced graph $G_n := \mathrm{Ambient.inducedGraph}\,G\,(\Lambda_n)$
-is preconnected, $B_n \subseteq \Lambda_n$ is a non-empty boundary,
+is preconnected, $B_n \subseteq \Lambda_n$ is a non-empty set of
+$+$-boundary-condition sites,
 $i_n \in \Lambda_n$, and the common exponential bound
 \[
   2 \cdot 2^{\#\Lambda_n} \exp(-2\beta J) \le \exp(-c\beta)


### PR DESCRIPTION
## Summary

Target: lift the finite-volume Peierls bound

\`\`\`
prop_5_4_2_self_contained : 0 ≤ 1 − ⟨σᵢ⟩₊(finite) ≤ exp(-cβ)
\`\`\`

from the finite-volume \`+\`-boundary-condition Gibbs expectation
\`plusGibbsExpectation\` to the genuine infinite-volume
\`+\`-boundary-condition expectation along an exhaustion \`Λₙ ↑ V\`
(GJ §5.4 / Friedli-Velenik Ch. 3).

This closes one of the items listed in \`docs/index.md\` under
"Unformalized infinite-volume theorems", row 3: "Prop 5.4.2
infinite-volume version: 0 ≤ 1 − ⟨σᵢ⟩₊∞ ≤ exp(-cβ) in the genuine +
boundary-condition infinite-volume measure."

## Test plan

- [ ] \`lake build\` succeeds
- [ ] \`lake exe GKSTest\` passes
- [ ] linter warnings 0
- [ ] \`docs/index.md\` §5.4 table row updated to "Done (finite + ∞-vol)"
- [ ] \`tex/proof-guide.tex\` gets an infinite-volume theorem block
- [ ] \`copilot -p\` cross-check clean (fallback \`codex exec\` with approval)

## Notes

This session sets up the scaffold (branch, work file, draft PR). The
full proof may span multiple sessions; per CLAUDE.local.md the PR is
one unit per GJ proposition — handoffs stay on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)