### PR TITLE
feat: Prop 4.6.1 DisjointTowerHypotheses bundle + docs: correct stale §4.2 correlation-convergence unformalized entry

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -805,6 +805,58 @@ theorem freeEnergyAlongExhaustion_tendsto_of_disjoint_tower
     (BddAbove_freeEnergyAlongExhaustion_range G Λ p hBED)
     hcard_one
 
+/-- **Bundle of disjoint-tower hypotheses** for `freeEnergyAlongExhaustion`
+Fekete convergence (GJ §4.6 Prop 4.6.1 p. 64).
+
+Packages the three exhaustion-structural hypotheses required by
+`freeEnergyAlongExhaustion_tendsto_of_disjoint_tower`:
+
+* `card_add`: `|Λ_{m+n}| = |Λ_m| + |Λ_n|` (additive cardinality).
+* `super`: `log Z_{Λ_m} + log Z_{Λ_n} ≤ log Z_{Λ_{m+n}}`
+  (super-additivity of `log Z` along the tower).
+* `card_one`: `|Λ_1| ≠ 0` (non-degenerate base step).
+
+The bundle is indexed by a `SimpleGraph V`, an `Exhaustion V`, and
+`IsingParams ℝ`; it does not depend on any probabilistic / ferromagnetic
+content — that enters separately through `BoundedEdgeDensity` when
+needed.
+
+Intended use: future PRs will provide concrete instances under
+translation invariance (GJ §4.6 p. 64 style) so that the user does
+not need to supply the three hypotheses by hand. -/
+structure DisjointTowerHypotheses
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) : Prop where
+  /-- Additive cardinality along the tower:
+  `|Λ_{m+n}| = |Λ_m| + |Λ_n|` for all `m, n`. -/
+  card_add : ∀ m n, (Λ.volume (m + n)).card
+                      = (Λ.volume m).card + (Λ.volume n).card
+  /-- Super-additivity of `log Z` along the tower:
+  `log Z_{Λ_m} + log Z_{Λ_n} ≤ log Z_{Λ_{m+n}}`. -/
+  super : ∀ m n, Real.log (partitionFunctionΛ G (Λ.volume m) p)
+                  + Real.log (partitionFunctionΛ G (Λ.volume n) p)
+                  ≤ Real.log (partitionFunctionΛ G (Λ.volume (m + n)) p)
+  /-- Non-degenerate base step: `|Λ_1| ≠ 0`. -/
+  card_one : (Λ.volume 1).card ≠ 0
+
+/-- **Bundled-hypothesis wrapper for Prop 4.6.1 (disjoint-tower +
+`BoundedEdgeDensity`)** (GJ §4.6 Prop 4.6.1 p. 64).
+
+Same content as `freeEnergyAlongExhaustion_tendsto_of_disjoint_tower`,
+but takes the three structural hypotheses as a single
+`DisjointTowerHypotheses` record for API-site convenience. -/
+theorem freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ)
+    (hBED : BoundedEdgeDensity G Λ)
+    (h : DisjointTowerHypotheses G Λ p) :
+    Filter.Tendsto (freeEnergyAlongExhaustion G Λ p) Filter.atTop
+      (nhds (freeEnergyInfinite G Λ p)) :=
+  freeEnergyAlongExhaustion_tendsto_of_disjoint_tower G Λ p
+    hBED h.card_add h.super h.card_one
+
 /-- **Eventually constant ⇒ `freeEnergyInfinite` equals the constant.**
 
 If `∀ᶠ n in atTop, freeEnergyAlongExhaustion G Λ p n = c`, then

--- a/docs/index.md
+++ b/docs/index.md
@@ -413,7 +413,7 @@ inventory (2026-04-17).
 | §4.3 | Cor 4.3.5 (inductive n-point at h=0) | **Done (finite + infinite)** | Finite: `cor_4_3_5_h0` (axioms); Infinite: `correlationInfinite_cor_4_3_5_h0` |
 | §4.4 | FKG inequality (spinProduct case) | **Done (finite + infinite)** | Finite: `fkg_ising`; ∞-vol spinProduct: `correlationInfinite_fkg_spinProduct` (≡ GKS-II). General monotone fn at ∞-vol: out of scope |
 | §4.5 | Lee–Yang circle theorem | **Done** | `lee_yang_circle` |
-| §4.6 | **Prop 4.6.1 (`f_Λ` convergence)** | **Done (disjoint-tower + `BoundedEdgeDensity`)** | Base form: `freeEnergyAlongExhaustion_tendsto_of_superadditive` (4 bundled hypotheses — `hcard_add`, `hsuper`, `hbdd`, `hcard_one`). Relaxed form: `freeEnergyAlongExhaustion_tendsto_of_disjoint_tower` (3 hypotheses: `hcard_add`, `hsuper`, `hcard_one` + the structural `BoundedEdgeDensity G Λ`). The explicit `hbdd` is discharged automatically via `BddAbove_freeEnergyAlongExhaustion_range`. Proof: apply mathlib `Subadditive.tendsto_lim` to `u_n := -log Z_{Λ_n}`, translate via `card_n = n · card_1` to `freeEnergyAlongExhaustion`. The super-additivity input is provided by `log_partitionFunctionΛ_disjUnion_super_additive`. Supporting: `freeEnergy_convergent_subgraph`, `freeEnergyInfinite_eq_of_tendsto`. |
+| §4.6 | **Prop 4.6.1 (`f_Λ` convergence)** | **Done (disjoint-tower + `BoundedEdgeDensity`)** | Base form: `freeEnergyAlongExhaustion_tendsto_of_superadditive` (4 bundled hypotheses — `hcard_add`, `hsuper`, `hbdd`, `hcard_one`). Relaxed form: `freeEnergyAlongExhaustion_tendsto_of_disjoint_tower` (3 hypotheses: `hcard_add`, `hsuper`, `hcard_one` + the structural `BoundedEdgeDensity G Λ`). The explicit `hbdd` is discharged automatically via `BddAbove_freeEnergyAlongExhaustion_range`. Bundled form: `DisjointTowerHypotheses` record (`card_add`/`super`/`card_one`) + `freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses` wrapper. Proof: apply mathlib `Subadditive.tendsto_lim` to `u_n := -log Z_{Λ_n}`, translate via `card_n = n · card_1` to `freeEnergyAlongExhaustion`. The super-additivity input is provided by `log_partitionFunctionΛ_disjUnion_super_additive`. Supporting: `freeEnergy_convergent_subgraph`, `freeEnergyInfinite_eq_of_tendsto`. |
 | §4.6 | **Thm 4.6.2 (analyticity)** | **Partial (merged through PR #200, `52ea2f1`): finite-real + real-basepoint finite-complex + Friedli-Velenik factorisation + Z ≠ 0 on Lee-Yang domain + local analytic log-Z branch pointwise on Lee-Yang + Lee-Yang subdomain slitPlane + Vitali bridge + modulus bounds. ∞-vol locally uniform convergence TODO (no Montel in mathlib)** | Finite-real free energy analyticity: `freeEnergyH_analyticOn` etc. Finite-complex support: `partitionFunctionComplex_analyticAt_{h,J,beta}` (Z entire in each parameter) + `freeEnergyComplex_analyticAt_{h,J,beta}` under `Z ∈ Complex.slitPlane` (log via mathlib `AnalyticAt.clog`). Joint analyticity: `partitionFunctionComplex_analyticAt_joint` / `freeEnergyComplex_analyticAt_joint` (3-variable `(J,h,β) ∈ ℂ³`, slitPlane hypothesis for `f`). Real-complex compat: `partitionFunction_ofReal_eq_partitionFunctionComplex` + `freeEnergy_ofReal_eq_freeEnergyComplex`. Real-slice slitPlane: `partitionFunctionComplex_mem_slitPlane_of_real`; real-slice corollary `freeEnergyComplex_analyticAt_h_ofReal` (analyticity of `freeEnergyComplex` at any real basepoint `(h₀:ℂ)`, via slitPlane membership; no Lee-Yang or ferromagnetic hypothesis). Lee-Yang domain infrastructure: `leeYangDomain` (open, `⊆ slitPlane`, contains positive real axis), `leeYangFugacity(Vec)` (entire, maps domain into unit ball), `leeYangNormalization` (entire, non-vanishing, `ofReal_pos`). **Friedli-Velenik factorisation**: `partitionFunctionComplex_eq_normalization_mul_isingEdgePoly` — `Z(J, h, β) = exp(βJ|E| + βh|ι|) · P_E(z)` (FV (3.63)–(3.65) pp. 122–123). **Z ≠ 0 on Lee-Yang domain** (Thm 4.6.2 non-vanishing half): `partitionFunctionComplex_ne_zero_on_leeYangDomain`. (All in `ComplexAnalyticity.lean`.) **Not yet**: slitPlane-membership on the full complex Lee-Yang domain (needs branch-selection / winding-number argument from real-positive basepoint), infinite-volume Vitali lift. |
 | §4.6 | Lee–Yang nonvanishing (Ising) | **Done** | `isingEdgePoly_nonvanishing_of_graph` |
 | §4.7 | Two-component spins | Out of scope | XY model |
@@ -487,24 +487,26 @@ inventory (2026-04-17).
 The following GJ Ising infinite-volume discussions are **not yet
 formalized**, per the full inventory above:
 
-1. **Genuine thermodynamic limit of cylinder correlations** along an
-   exhaustion `Λₙ ↑ V` of an infinite ambient `V`. The
-   `AmbientLattice.lean` framework introduces the types and
-   `correlationAlongExhaustion`; the convergence theorem itself (i.e.,
-   that `correlationAlongExhaustion` is Cauchy / tends to a limit) is
-   not yet proved in this setting.
-2. **Prop 4.6.1 (free energy convergence) Fekete completion**:
+1. **Prop 4.6.1 (free energy convergence) Fekete completion**:
    Fekete-style convergence of `freeEnergyAlongExhaustion` is now
    available in two forms:
    `freeEnergyAlongExhaustion_tendsto_of_superadditive` (base, 4
    bundled hypotheses) and
    `freeEnergyAlongExhaustion_tendsto_of_disjoint_tower` (relaxed,
    `BoundedEdgeDensity` replaces the explicit `BddAbove`
-   hypothesis), both in `AmbientLatticeSum.lean`. Dropping the
-   remaining disjoint-tower hypotheses (`hcard_add`, `hsuper`,
-   `hcard_one`) requires translation invariance and is a
-   follow-up step.
-3. **Thm 4.6.2 (full form)**: complex analyticity of the
+   hypothesis), both in `AmbientLatticeSum.lean`. A
+   `DisjointTowerHypotheses` bundle + wrapper
+   `freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses`
+   are also provided. Dropping the remaining disjoint-tower
+   hypotheses (`hcard_add`, `hsuper`, `hcard_one`) requires
+   translation invariance and is a follow-up step.
+   *(The `correlationAlongExhaustion` convergence side, originally
+   listed here as "not yet proved", is in fact discharged by
+   `correlationAlongExhaustion_tendsto_ciSup` +
+   `correlationAlongExhaustion_convergent` in
+   `AmbientLattice.lean`, and is now covered by the §4.2 Thm 4.2.3
+   row in the progress table.)*
+2. **Thm 4.6.2 (full form)**: complex analyticity of the
    infinite-volume free energy via Vitali convergence.
 3. **Prop 5.4.2 infinite-volume version**: `0 ≤ 1 − ⟨σᵢ⟩₊∞ ≤ exp(-cβ)`
    in the genuine `+` boundary-condition infinite-volume measure.

--- a/docs/index.md
+++ b/docs/index.md
@@ -489,17 +489,18 @@ formalized**, per the full inventory above:
 
 1. **Prop 4.6.1 (free energy convergence) Fekete completion**:
    Fekete-style convergence of `freeEnergyAlongExhaustion` is now
-   available in two forms:
+   available through three API entry points (all in
+   `AmbientLatticeSum.lean`):
    `freeEnergyAlongExhaustion_tendsto_of_superadditive` (base, 4
-   bundled hypotheses) and
+   bundled hypotheses);
    `freeEnergyAlongExhaustion_tendsto_of_disjoint_tower` (relaxed,
    `BoundedEdgeDensity` replaces the explicit `BddAbove`
-   hypothesis), both in `AmbientLatticeSum.lean`. A
-   `DisjointTowerHypotheses` bundle + wrapper
+   hypothesis); and
    `freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses`
-   are also provided. Dropping the remaining disjoint-tower
-   hypotheses (`hcard_add`, `hsuper`, `hcard_one`) requires
-   translation invariance and is a follow-up step.
+   (bundled form taking a `DisjointTowerHypotheses` record).
+   Dropping the remaining disjoint-tower hypotheses (`hcard_add`,
+   `hsuper`, `hcard_one`) requires translation invariance and is
+   a follow-up step.
    *(The `correlationAlongExhaustion` convergence side, originally
    listed here as "not yet proved", is in fact discharged by
    `correlationAlongExhaustion_tendsto_ciSup` +

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4001,6 +4001,26 @@ with $f_\infty = \limsup f_{\Lambda_n}$ via
 Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1, p.~64.
 \end{proof}
 
+\begin{theorem}[GJ \S 4.6 Prop 4.6.1,
+\texttt{DisjointTowerHypotheses} bundle; PR \#204]
+The three structural hypotheses $|\Lambda_{m+n}| = |\Lambda_m|
++ |\Lambda_n|$, $\log Z_{\Lambda_m} + \log Z_{\Lambda_n} \le
+\log Z_{\Lambda_{m+n}}$, and $|\Lambda_1| \neq 0$ are packaged
+as a single \texttt{DisjointTowerHypotheses} record. Given
+\texttt{BoundedEdgeDensity}$\,G\,\Lambda$ and such a record,
+$f_{\Lambda_n}(p) \to f_\infty(p)$.
+\end{theorem}
+
+\begin{proof}
+Definitional unpack of the
+\texttt{DisjointTowerHypotheses} record into the three
+hypotheses of
+\texttt{freeEnergyAlongExhaustion\_tendsto\_of\_disjoint\_tower}.
+Reference: Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1,
+p.~64. This is an API-site convenience wrapper; no new
+mathematical content.
+\end{proof}
+
 \begin{theorem}[Corollary/wrapper of GJ \S 5.4 Prop 5.4.2 along an
 exhaustion (per-stage); PR \#202]
 For a graph $G : \mathrm{SimpleGraph}\, V$ with an exhaustion


### PR DESCRIPTION
## Summary

Two related, small GJ-early cleanups, bundled per CLAUDE.local.md
"PR は定理・命題などの完結した単位":

1. **§4.2 docs fix**: \`docs/index.md\` "Unformalized infinite-volume
   theorems" list item 1 asserts that
   "the convergence theorem [for \`correlationAlongExhaustion\`] is
   not yet proved in this setting"; in fact
   \`correlationAlongExhaustion_tendsto_ciSup\` +
   \`correlationAlongExhaustion_convergent\` (in
   \`AmbientLattice.lean\`) prove exactly this via
   mathlib \`tendsto_atTop_ciSup\`. The entry is removed /
   rewritten.

2. **§4.6 Prop 4.6.1 API polish**: introduce a lightweight
   hypothesis-bundle structure \`DisjointTowerHypotheses\` wrapping
   the three remaining external hypotheses of
   \`freeEnergyAlongExhaustion_tendsto_of_disjoint_tower\`
   (\`hcard_add\`, \`hsuper\`, \`hcard_one\`), and give a wrapper
   theorem taking this bundle + \`BoundedEdgeDensity\`. This
   prepares the ground for a later PR that provides concrete
   \`DisjointTowerHypotheses\` instances under translation
   invariance (GJ §4.6 p. 64 style).

Reference: GJ, *Quantum Physics* 2nd ed., §4.2 Thm 4.2.3 p. 52;
§4.6 Prop 4.6.1 p. 64.

## Test plan

- [ ] \`lake build\` succeeds
- [ ] \`lake exe GKSTest\` passes
- [ ] linter warnings 0
- [ ] \`docs/index.md\` unformalized list item 1 removed; item
  numbering refreshed
- [ ] \`tex/proof-guide.tex\` gets a theorem block for the
  bundled form
- [ ] \`copilot -p\` cross-check clean (fallback \`codex exec\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)