### PR TITLE
feat: translation scaffolding step 2 — Finset.card preservation and translated-Finset API

### DIFF
--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -85,6 +85,69 @@ instance isTranslationInvariant_top
     have := congrArg (fun x : V => (-t) +ᵥ x) heq
     simpa [add_vadd, neg_add_cancel, zero_vadd] using this
 
+/-! ## Translated Finset API
+
+Translating a `Finset V` by `t : T` gives another `Finset V` with the
+same cardinality (translations are injective on `V` via cancellation
+in the `AddAction` on an `AddGroup`). These are the elementary
+facts needed for the next step toward `DisjointTowerHypotheses`
+under translation invariance. -/
+
+/-- **Translation is injective on `V`**: `t +ᵥ u = t +ᵥ v ↔ u = v`
+for any `t : T` and `u, v : V`, via cancellation in the `AddAction`
+on an `AddGroup` (applying `(-t) +ᵥ ·` to both sides). -/
+theorem vadd_injective {T : Type u} [AddGroup T] {V : Type v}
+    [AddAction T V] (t : T) :
+    Function.Injective (t +ᵥ · : V → V) := by
+  intro u v heq
+  have : (-t) +ᵥ (t +ᵥ u) = (-t) +ᵥ (t +ᵥ v) := congrArg _ heq
+  simpa [← add_vadd, neg_add_cancel, zero_vadd] using this
+
+/-- **Translated Finset**: `t +ᵥ A := A.image (t +ᵥ ·)`; a `Finset V`
+obtained by translating every element of `A` by `t`. -/
+noncomputable def vaddFinset {T : Type u} [AddGroup T] {V : Type v}
+    [DecidableEq V] [AddAction T V]
+    (t : T) (A : Finset V) : Finset V :=
+  A.image (t +ᵥ ·)
+
+/-- **Cardinality is preserved by translation**:
+`(t +ᵥ A).card = A.card`, via injectivity of translation. -/
+@[simp]
+theorem vaddFinset_card {T : Type u} [AddGroup T] {V : Type v}
+    [DecidableEq V] [AddAction T V]
+    (t : T) (A : Finset V) :
+    (vaddFinset t A).card = A.card := by
+  unfold vaddFinset
+  exact Finset.card_image_of_injective _ (vadd_injective t)
+
+/-- **Membership in a translated Finset**: `v ∈ t +ᵥ A ↔ ∃ u ∈ A, t +ᵥ u = v`. -/
+theorem mem_vaddFinset {T : Type u} [AddGroup T] {V : Type v}
+    [DecidableEq V] [AddAction T V]
+    (t : T) (A : Finset V) (v : V) :
+    v ∈ vaddFinset t A ↔ ∃ u ∈ A, t +ᵥ u = v := by
+  unfold vaddFinset
+  simp [Finset.mem_image]
+
+/-- **Disjointness is preserved by translation**:
+if `A` and `B` are disjoint as `Finset V`, then `t +ᵥ A` and
+`t +ᵥ B` are also disjoint.
+
+Proof: if `v ∈ (t +ᵥ A) ∩ (t +ᵥ B)` then `v = t +ᵥ u₁ = t +ᵥ u₂`
+for some `u₁ ∈ A`, `u₂ ∈ B`; by `vadd_injective`, `u₁ = u₂`, so
+`u₁ ∈ A ∩ B`, contradicting disjointness. -/
+theorem vaddFinset_disjoint_of_disjoint {T : Type u} [AddGroup T]
+    {V : Type v} [DecidableEq V] [AddAction T V]
+    (t : T) {A B : Finset V} (h : Disjoint A B) :
+    Disjoint (vaddFinset t A) (vaddFinset t B) := by
+  rw [Finset.disjoint_left]
+  intro v hvA hvB
+  rw [mem_vaddFinset] at hvA hvB
+  obtain ⟨u₁, hu₁A, heq₁⟩ := hvA
+  obtain ⟨u₂, hu₂B, heq₂⟩ := hvB
+  have hu_eq : u₁ = u₂ := vadd_injective t (heq₁.trans heq₂.symm)
+  subst hu_eq
+  exact Finset.disjoint_left.mp h hu₁A hu₂B
+
 end Ambient
 
 end IsingModel

--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -105,7 +105,7 @@ theorem vadd_injective {T : Type u} [AddGroup T] {V : Type v}
 
 /-- **Translated Finset**: `t +ᵥ A := A.image (t +ᵥ ·)`; a `Finset V`
 obtained by translating every element of `A` by `t`. -/
-noncomputable def vaddFinset {T : Type u} [AddGroup T] {V : Type v}
+def vaddFinset {T : Type u} [AddGroup T] {V : Type v}
     [DecidableEq V] [AddAction T V]
     (t : T) (A : Finset V) : Finset V :=
   A.image (t +ᵥ ·)


### PR DESCRIPTION
## Summary

Step 2 toward GJ §4.6 Prop 4.6.1 translation-invariance (continuation of PR #220).

Adds to \`TranslationInvariance.lean\`:

1. \`vadd_Finset\`: translated Finset \`t +ᵥ A := A.image (t +ᵥ ·)\`.
2. \`vadd_Finset_card\`: \`(t +ᵥ A).card = A.card\` via injectivity of translation (from \`AddAction\` on \`AddGroup\`).
3. \`vadd_Finset_disjoint\`: if \`A \\cap B = ∅\` as sets of raw vertices, then \`(t +ᵥ A) \\cap (t +ᵥ B) = ∅\` as Finsets.

These are the structural tools for the next step: defining translation-invariant exhaustions where \`Λ.volume (m+1) = Λ.volume m ⊔ (translate of Λ.volume 1)\`, from which \`hcard_add\` will follow.

Reference: GJ, *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1, p. 64.

## Test plan

- [ ] \`lake build\` succeeds
- [ ] \`lake exe GKSTest\` passes
- [ ] linter warnings 0
- [ ] \`copilot -p\` cross-check (fallback codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)