### PR TITLE
feat: translation scaffolding step 5 — Fekete convergence from TranslationInvariantExhaustion

### DIFF
--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -273,6 +273,43 @@ def disjointTowerHypotheses_of_translationInvariant
   super := hsuper
   card_one := hcard_one
 
+/-- **Fekete convergence from a `TranslationInvariantExhaustion`**:
+given a translation-invariant exhaustion, a bounded-edge-density
+hypothesis, user-supplied `log Z` super-additivity `hsuper`, and
+non-degenerate base step `hcard_one`, the exhaustion free-energy
+density converges to the infinite-volume free energy:
+`freeEnergyAlongExhaustion G Λ.toExhaustion p →
+freeEnergyInfinite G Λ.toExhaustion p`.
+
+Thin wrapper over
+`freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses`
+(PR #204) + `disjointTowerHypotheses_of_translationInvariant`
+(step 4 / PR #223). `card_add` is supplied automatically by the
+exhaustion structure; once `hsuper` is derived from full
+translation invariance (subsequent PR), this theorem will become
+an unconditional-in-`hsuper` corollary.
+
+Reference: Glimm–Jaffe *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1,
+p. 64. -/
+theorem freeEnergyAlongExhaustion_tendsto_of_translationInvariant
+    (Λ : TranslationInvariantExhaustion T V)
+    (G : SimpleGraph V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ)
+    (hBED : BoundedEdgeDensity G Λ.toExhaustion)
+    (hsuper : ∀ m n,
+      Real.log (partitionFunctionΛ G (Λ.volume m) p)
+        + Real.log (partitionFunctionΛ G (Λ.volume n) p)
+        ≤ Real.log (partitionFunctionΛ G (Λ.volume (m + n)) p))
+    (hcard_one : (Λ.volume 1).card ≠ 0) :
+    Filter.Tendsto (freeEnergyAlongExhaustion G Λ.toExhaustion p)
+      Filter.atTop
+      (nhds (freeEnergyInfinite G Λ.toExhaustion p)) :=
+  freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses G
+    Λ.toExhaustion p hBED
+    (disjointTowerHypotheses_of_translationInvariant Λ G p
+      hsuper hcard_one)
+
 end TranslationInvariantExhaustion
 
 end Ambient

--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -277,9 +277,10 @@ def disjointTowerHypotheses_of_translationInvariant
 given a translation-invariant exhaustion, a bounded-edge-density
 hypothesis, user-supplied `log Z` super-additivity `hsuper`, and
 non-degenerate base step `hcard_one`, the exhaustion free-energy
-density converges to the infinite-volume free energy:
-`freeEnergyAlongExhaustion G Λ.toExhaustion p →
-freeEnergyInfinite G Λ.toExhaustion p`.
+density tends (in the sense of `Filter.Tendsto` at `Filter.atTop`)
+to the infinite-volume free energy: `freeEnergyAlongExhaustion
+G Λ.toExhaustion p` converges to `freeEnergyInfinite G
+Λ.toExhaustion p`.
 
 Thin wrapper over
 `freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses`


### PR DESCRIPTION
## Summary

Step 5 toward GJ §4.6 Prop 4.6.1 translation-invariance. Caps the abstract chain of steps 1–4:

- step 1 (#220): IsTranslationInvariant G class.
- step 2 (#221): vaddFinset API, vadd_injective.
- step 3 (#222): TranslationInvariantExhaustion + volume_card_add.
- step 4 (#223): disjointTowerHypotheses_of_translationInvariant.

This PR adds \`freeEnergyAlongExhaustion_tendsto_of_translationInvariant\`: given a TranslationInvariantExhaustion + BoundedEdgeDensity + hsuper (still user-supplied) + hcard_one, the Fekete convergence follows directly, threading through the step 4 assembly + PR #204's bundled wrapper.

Subsequent PRs will remove the hsuper input by deriving it from log-Z translation invariance.

Reference: GJ, *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1, p. 64.

## Test plan

- [ ] \`lake build\`, \`lake exe GKSTest\`, linter 0
- [ ] \`copilot -p\` cross-check (fallback codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)