### PR TITLE
feat: translation scaffolding step 6a — vaddSubtypeEquiv (bijection between Λ and its translate)

### DIFF
--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -159,6 +159,48 @@ theorem vaddFinset_disjoint_of_disjoint {T : Type u} [AddGroup T]
   subst hu_eq
   exact Finset.disjoint_left.mp h hu₁A hu₂B
 
+/-- **Subtype bijection between `↑Λ` and `↑(t +ᵥ Λ)`**: the natural
+translation-induced bijection, sending `⟨v, hv⟩ : ↑Λ` to
+`⟨t +ᵥ v, _⟩ : ↑(vaddFinset t Λ)` and vice versa via `-t`.
+
+This is the structural datum underlying partition-function
+translation invariance: summing over configurations of `↑Λ` and
+of `↑(t +ᵥ Λ)` yield the same value after the identification. -/
+def vaddSubtypeEquiv {T : Type u} [AddGroup T] {V : Type v}
+    [DecidableEq V] [AddAction T V]
+    (t : T) (Λ : Finset V) :
+    (↑Λ : Type _) ≃ (↑(vaddFinset t Λ) : Type _) where
+  toFun := fun ⟨v, hv⟩ =>
+    ⟨t +ᵥ v, by
+      rw [mem_vaddFinset]
+      exact ⟨v, hv, rfl⟩⟩
+  invFun := fun ⟨v, hv⟩ =>
+    ⟨(-t) +ᵥ v, by
+      rw [mem_vaddFinset] at hv
+      obtain ⟨u, huΛ, heq⟩ := hv
+      have : (-t) +ᵥ v = u := by
+        rw [← heq, ← add_vadd, neg_add_cancel, zero_vadd]
+      rw [this]
+      exact huΛ⟩
+  left_inv := by
+    rintro ⟨v, hv⟩
+    apply Subtype.ext
+    change (-t) +ᵥ (t +ᵥ v) = v
+    rw [← add_vadd, neg_add_cancel, zero_vadd]
+  right_inv := by
+    rintro ⟨v, hv⟩
+    apply Subtype.ext
+    change t +ᵥ ((-t) +ᵥ v) = v
+    rw [← add_vadd, add_neg_cancel, zero_vadd]
+
+/-- **`vaddSubtypeEquiv` forward map unfolds to `t +ᵥ ·`**. -/
+@[simp]
+theorem vaddSubtypeEquiv_apply_coe {T : Type u} [AddGroup T]
+    {V : Type v} [DecidableEq V] [AddAction T V]
+    (t : T) (Λ : Finset V) (x : (↑Λ : Type _)) :
+    ((vaddSubtypeEquiv t Λ) x : V) = t +ᵥ (x : V) := by
+  rfl
+
 /-! ## Translation-invariant exhaustions
 
 An exhaustion whose consecutive volumes differ by a disjoint


### PR DESCRIPTION
## Summary

Step 6a toward GJ §4.6 Prop 4.6.1 translation-invariance.

Continuation of PRs #220-#224. Introduces the subtype bijection
\`vaddSubtypeEquiv t Λ : ↑Λ ≃ ↑(vaddFinset t Λ)\` — the natural
translation-based bijection between a Finset's subtype and the
translated Finset's subtype. Needed for the subsequent step of
proving partitionFunction / log Z translation invariance.

Deliverables in \`TranslationInvariance.lean\`:

1. \`vaddSubtypeEquiv\`: Equiv definition.
2. \`vaddSubtypeEquiv_coe\`: unfolds the forward map to \`t +ᵥ ·\`.

Reference: GJ, *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1, p. 64.

## Test plan

- [ ] \`lake build\`, \`lake exe GKSTest\`, linter 0
- [ ] \`copilot -p\` cross-check (fallback codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)