### PR TITLE
feat: translation scaffolding step 6c — configVaddEquiv for translated Finset

### DIFF
--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -230,14 +230,15 @@ theorem inducedGraph_vaddFinset_adj_iff {T : Type u} [AddGroup T]
 `Config ↑Λ ≃ Config ↑(vaddFinset t Λ)`, obtained by pre-composing
 spin configurations with `(vaddSubtypeEquiv t Λ).symm`.
 
-Explicit direction:
-- `configVaddEquiv t Λ σ := σ ∘ (vaddSubtypeEquiv t Λ).symm`.
-- Inverse: `σ' := σ' ∘ vaddSubtypeEquiv t Λ`.
+Explicit directions:
+- `configVaddEquiv t Λ σ = σ ∘ (vaddSubtypeEquiv t Λ).symm`.
+- `(configVaddEquiv t Λ).symm σ' = σ' ∘ vaddSubtypeEquiv t Λ`.
 
 This is the reindexing isomorphism used in the subsequent
 partition-function translation-invariance step (rewrite
-`∑_{σ' : Config ↑(t+ᵥΛ)} f(σ')` as `∑_{σ : Config ↑Λ}
-f(configVaddEquiv t Λ σ)` via `Fintype.sum_equiv`). -/
+`∑_{σ' : Config ↑(vaddFinset t Λ)} f(σ')` as
+`∑_{σ : Config ↑Λ} f(configVaddEquiv t Λ σ)` via
+`Fintype.sum_equiv`). -/
 def configVaddEquiv {T : Type u} [AddGroup T] {V : Type v}
     [DecidableEq V] [AddAction T V]
     (t : T) (Λ : Finset V) :

--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -226,6 +226,24 @@ theorem inducedGraph_vaddFinset_adj_iff {T : Type u} [AddGroup T]
   rw [vaddSubtypeEquiv_apply_coe, vaddSubtypeEquiv_apply_coe]
   exact IsTranslationInvariant.adj_vadd t (u : V) (v : V)
 
+/-- **Config-level translation equiv**:
+`Config ↑Λ ≃ Config ↑(vaddFinset t Λ)`, obtained by pre-composing
+spin configurations with `(vaddSubtypeEquiv t Λ).symm`.
+
+Explicit direction:
+- `configVaddEquiv t Λ σ := σ ∘ (vaddSubtypeEquiv t Λ).symm`.
+- Inverse: `σ' := σ' ∘ vaddSubtypeEquiv t Λ`.
+
+This is the reindexing isomorphism used in the subsequent
+partition-function translation-invariance step (rewrite
+`∑_{σ' : Config ↑(t+ᵥΛ)} f(σ')` as `∑_{σ : Config ↑Λ}
+f(configVaddEquiv t Λ σ)` via `Fintype.sum_equiv`). -/
+def configVaddEquiv {T : Type u} [AddGroup T] {V : Type v}
+    [DecidableEq V] [AddAction T V]
+    (t : T) (Λ : Finset V) :
+    Config (↑Λ : Type _) ≃ Config (↑(vaddFinset t Λ) : Type _) :=
+  Equiv.arrowCongr (vaddSubtypeEquiv t Λ) (Equiv.refl Spin)
+
 /-! ## Translation-invariant exhaustions
 
 An exhaustion whose consecutive volumes differ by a disjoint


### PR DESCRIPTION
## Summary

Step 6c toward GJ §4.6 Prop 4.6.1.

Lift \`vaddSubtypeEquiv\` (PR #226) to the spin-configuration level:

\`configVaddEquiv t Λ : Config ↑Λ ≃ Config ↑(vaddFinset t Λ)\`

via \`Equiv.arrowCongr\` with the identity on \`Spin\`. Needed for the subsequent step: rewriting \`∑_{σ' : Config ↑(t+ᵥΛ)} f(σ')\` as \`∑_{σ : Config ↑Λ} f(σ ∘ (...))\` via \`Fintype.sum_equiv\`, en route to \`partitionFunctionΛ\` translation invariance.

Reference: GJ, *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1, p. 64.

## Test plan

- [ ] \`lake build\`, \`lake exe GKSTest\`, linter 0
- [ ] \`copilot -p\` cross-check (fallback codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)