### PR TITLE
feat: translation scaffolding step 6d — externalFieldEnergy equivariance

### DIFF
--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -258,8 +258,9 @@ Proof: `externalFieldEnergy h σ = -h * ∑_i Spin.sign ℝ (σ i)`;
 the sum `∑_{i : ↑(vaddFinset t Λ)} Spin.sign ℝ (σ' i)` reindexes
 via `Fintype.sum_equiv (vaddSubtypeEquiv t Λ)` to
 `∑_{j : ↑Λ} Spin.sign ℝ (σ' (vaddSubtypeEquiv t Λ j))`, and the
-inner term equals `((configVaddEquiv t Λ).symm σ') j` by the
-inverse-map characterisation. -/
+inner term equals `((configVaddEquiv t Λ).symm σ') j` definitionally
+(by the definition of `Equiv.arrowCongr`, whose `.symm` applied to
+`σ'` is exactly `σ' ∘ (vaddSubtypeEquiv t Λ)`). -/
 theorem externalFieldEnergy_configVaddEquiv_symm {T : Type u}
     [AddGroup T] {V : Type v} [DecidableEq V] [AddAction T V]
     (t : T) (Λ : Finset V) (h : ℝ)

--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice
 import IsingModel.AmbientLatticeSum
+import IsingModel.Hamiltonian
 
 /-!
 # Translation invariance scaffolding for GJ §4.6 Prop 4.6.1
@@ -244,6 +245,35 @@ def configVaddEquiv {T : Type u} [AddGroup T] {V : Type v}
     (t : T) (Λ : Finset V) :
     Config (↑Λ : Type _) ≃ Config (↑(vaddFinset t Λ) : Type _) :=
   Equiv.arrowCongr (vaddSubtypeEquiv t Λ) (Equiv.refl Spin)
+
+/-- **`externalFieldEnergy` is invariant under `configVaddEquiv`**:
+for any translation `t : T` and any `Λ : Finset V`,
+
+`externalFieldEnergy h σ' = externalFieldEnergy h
+  ((configVaddEquiv t Λ).symm σ')`
+
+where `σ' : Config ↑(vaddFinset t Λ)`.
+
+Proof: `externalFieldEnergy h σ = -h * ∑_i Spin.sign ℝ (σ i)`;
+the sum `∑_{i : ↑(vaddFinset t Λ)} Spin.sign ℝ (σ' i)` reindexes
+via `Fintype.sum_equiv (vaddSubtypeEquiv t Λ)` to
+`∑_{j : ↑Λ} Spin.sign ℝ (σ' (vaddSubtypeEquiv t Λ j))`, and the
+inner term equals `((configVaddEquiv t Λ).symm σ') j` by the
+inverse-map characterisation. -/
+theorem externalFieldEnergy_configVaddEquiv_symm {T : Type u}
+    [AddGroup T] {V : Type v} [DecidableEq V] [AddAction T V]
+    (t : T) (Λ : Finset V) (h : ℝ)
+    (σ' : Config (↑(vaddFinset t Λ) : Type _)) :
+    IsingModel.externalFieldEnergy h σ'
+      = IsingModel.externalFieldEnergy h
+          ((configVaddEquiv t Λ).symm σ') := by
+  unfold IsingModel.externalFieldEnergy
+  congr 1
+  symm
+  exact Fintype.sum_equiv (vaddSubtypeEquiv t Λ)
+      (fun j => Spin.sign ℝ (((configVaddEquiv t Λ).symm σ') j))
+      (fun i => Spin.sign ℝ (σ' i))
+      (fun _ => rfl)
 
 /-! ## Translation-invariant exhaustions
 


### PR DESCRIPTION
## Summary

Step 6d toward GJ §4.6 Prop 4.6.1.

Add \`externalFieldEnergy_configVaddEquiv_symm\`: for any \`t : T\` and \`Λ : Finset V\`, the external-field energy is invariant under the Config-level translation equiv:

\`externalFieldEnergy h σ' = externalFieldEnergy h ((configVaddEquiv t Λ).symm σ')\`.

Proof: \`externalFieldEnergy h σ = -h * ∑_i σ.toSign i\`. The sum over \`↑(vaddFinset t Λ)\` rewrites to a sum over \`↑Λ\` via \`Fintype.sum_equiv (vaddSubtypeEquiv t Λ)\`, substituting the composition with the equiv for each term.

Reference: GJ, *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1, p. 64.

## Test plan

- [ ] \`lake build\`, \`lake exe GKSTest\`, linter 0
- [ ] \`copilot -p\` cross-check (fallback codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)