### PR TITLE
feat: susceptibility_beta_zero — vanishing at β=0

### DIFF
--- a/IsingModel/PhaseTransition.lean
+++ b/IsingModel/PhaseTransition.lean
@@ -203,6 +203,23 @@ theorem susceptibility_J_zero (G : SimpleGraph ι) [Fintype G.edgeSet]
     intro hi
     exact absurd (Finset.mem_univ i) hi
 
+/-- **Susceptibility vanishes at `β = 0`**: for any ambient graph
+`G`, any `J, h`, and any site `i`, `susceptibility G ⟨J, h, 0⟩ i = 0`.
+
+Proof: every summand in `∑_j truncated2 G ⟨J, h, 0⟩ i j` vanishes
+by `truncated2_beta_zero` (PR #208). Companion to
+`susceptibility_J_zero`.
+
+Reference: Glimm–Jaffe *Quantum Physics* 2nd ed., §4.1
+infinite-temperature slice; §5.1 pp. 76–77. -/
+theorem susceptibility_beta_zero (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J h : ℝ) (i : ι) :
+    susceptibility G (⟨J, h, 0⟩ : IsingParams ℝ) i = 0 := by
+  unfold susceptibility
+  refine Finset.sum_eq_zero ?_
+  intro j _
+  exact truncated2_beta_zero G J h i j
+
 /-- The magnetization vanishes at `h = 0` (Z₂ symmetry, finite volume).
 This is the finite-volume counterpart of the statement that the Z₂
 symmetry is unbroken in finite volume. Symmetry breaking occurs only

--- a/docs/index.md
+++ b/docs/index.md
@@ -172,6 +172,7 @@ gives, at every `h₀ ∈ leeYangDomain`, an analytic function `f` with
 | `tanh_odd` | `tanh(-x) = -tanh(x)` | `PhaseTransition.lean` | Algebraic |
 | `susceptibility_nonneg` (§5.3) | `χᵢ = Σⱼ⟨σᵢ;σⱼ⟩ ≥ 0` | `PhaseTransition.lean` | Finite |
 | `susceptibility_J_zero` | **J=0 closed form** (Finset-based) `χᵢ = tanh(β·h)·(1 − tanh(β·h))`: at `J = 0` off-diagonal terms vanish (`truncated2_J_zero_of_ne`); diagonal term uses the Finset collapse `{i,i} = {i}` to give `⟨σ_i⟩ − ⟨σ_i⟩² = t − t²`. Differs from the physics response-function `dM/dh = β·(1 − t²)` at the diagonal (which uses `σ_i² = 1`). | `PhaseTransition.lean` | Complements the trivial-slice sweep at the susceptibility level |
+| `susceptibility_beta_zero` | **β=0 vanishing** `χᵢ = 0`: every `truncated2 i j` is zero at `β = 0` (PR #208), so the sum vanishes. | `PhaseTransition.lean` | Companion to `susceptibility_J_zero` |
 | `susceptibility_convergent_{J,h,beta,subgraph}` | convergence | `PhaseTransition.lean` | Finite / Discretized Λ↑ |
 | `magnetization_zero_at_h_zero` | `Mᵢ = 0` at `h = 0` (Z₂) | `PhaseTransition.lean` | Finite |
 | `magnetization_monotone_{h,beta}` | monotone in `h`, `β` | `PhaseTransition.lean` | Finite |


### PR DESCRIPTION
## Summary

Complement to PR #231 (J=0 closed form). At β=0 the susceptibility vanishes identically: every \`truncated2 i j\` is zero at β=0 (PR #208 \`truncated2_beta_zero\`), so the sum vanishes.

## Test plan

- [ ] lake build, GKSTest, linter 0
- [ ] copilot/codex cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)