### PR TITLE
fix: unify §4.6 Prop 4.6.1 page reference (p. 64 → p. 68)

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -784,7 +784,7 @@ neither this theorem nor `BddAbove_freeEnergyAlongExhaustion_range`
 needs `Ferromagnetic p`.
 
 Reference: Glimm–Jaffe, *Quantum Physics*, 2nd ed., Springer 1987,
-§4.6 Prop 4.6.1, p. 64. This is a formal weaker variant of the
+§4.6 Prop 4.6.1, p. 68. This is a formal weaker variant of the
 proposition as stated in GJ: the bundled hypotheses replace the
 translation-invariance framework that GJ uses implicitly. -/
 theorem freeEnergyAlongExhaustion_tendsto_of_disjoint_tower
@@ -806,7 +806,7 @@ theorem freeEnergyAlongExhaustion_tendsto_of_disjoint_tower
     hcard_one
 
 /-- **Bundle of disjoint-tower hypotheses** for `freeEnergyAlongExhaustion`
-Fekete convergence (GJ §4.6 Prop 4.6.1 p. 64).
+Fekete convergence (GJ §4.6 Prop 4.6.1 p. 68).
 
 Packages the three exhaustion-structural hypotheses required by
 `freeEnergyAlongExhaustion_tendsto_of_disjoint_tower`:
@@ -822,7 +822,7 @@ content — that enters separately through `BoundedEdgeDensity` when
 needed.
 
 Intended use: future PRs will provide concrete instances under
-translation invariance (GJ §4.6 p. 64 style) so that the user does
+translation invariance (GJ §4.6 p. 68 style) so that the user does
 not need to supply the three hypotheses by hand. -/
 structure DisjointTowerHypotheses
     (G : SimpleGraph V) (Λ : Exhaustion V)
@@ -841,7 +841,7 @@ structure DisjointTowerHypotheses
   card_one : (Λ.volume 1).card ≠ 0
 
 /-- **Bundled-hypothesis wrapper for Prop 4.6.1 (disjoint-tower +
-`BoundedEdgeDensity`)** (GJ §4.6 Prop 4.6.1 p. 64).
+`BoundedEdgeDensity`)** (GJ §4.6 Prop 4.6.1 p. 68).
 
 Same content as `freeEnergyAlongExhaustion_tendsto_of_disjoint_tower`,
 but takes the three structural hypotheses as a single
@@ -923,7 +923,7 @@ def DisjointTowerHypotheses.of_log_linear_card
   card_one := hcard_one
 
 /-- **Concrete `DisjointTowerHypotheses` instance at `J = 0`**
-(GJ §4.6 Prop 4.6.1, p. 64): given `hcard_add` (cardinality additive
+(GJ §4.6 Prop 4.6.1, p. 68): given `hcard_add` (cardinality additive
 exhaustion) and `hcard_one` (non-degenerate base step) as inputs, the
 remaining super-additivity field of `DisjointTowerHypotheses` at
 `J = 0` is discharged automatically via
@@ -943,7 +943,7 @@ def DisjointTowerHypotheses.of_J_zero
     hcard_add hcard_one
 
 /-- **Concrete `DisjointTowerHypotheses` instance at `β = 0`**
-(GJ §4.6 Prop 4.6.1, p. 64): given `hcard_add` (cardinality additive
+(GJ §4.6 Prop 4.6.1, p. 68): given `hcard_add` (cardinality additive
 exhaustion) and `hcard_one` (non-degenerate base step) as inputs, the
 remaining super-additivity field of `DisjointTowerHypotheses` at
 `β = 0` is discharged automatically via
@@ -963,7 +963,7 @@ def DisjointTowerHypotheses.of_beta_zero
     hcard_add hcard_one
 
 /-- **Fekete convergence of `freeEnergyAlongExhaustion` at `J = 0`**
-(GJ §4.6 Prop 4.6.1, p. 64, concrete `J = 0` instance).
+(GJ §4.6 Prop 4.6.1, p. 68, concrete `J = 0` instance).
 
 Given a cardinality-additive exhaustion with non-degenerate base step
 and bounded edge density, the free-energy density sequence
@@ -997,7 +997,7 @@ theorem freeEnergyAlongExhaustion_J_zero_tendsto_of_hcard_add
     hBED (DisjointTowerHypotheses.of_J_zero G Λ h β hcard_add hcard_one)
 
 /-- **Fekete convergence of `freeEnergyAlongExhaustion` at `β = 0`**
-(GJ §4.6 Prop 4.6.1, p. 64, concrete `β = 0` instance).
+(GJ §4.6 Prop 4.6.1, p. 68, concrete `β = 0` instance).
 
 Given a cardinality-additive exhaustion with non-degenerate base step
 and bounded edge density, the free-energy density sequence

--- a/IsingModel/Concrete/IntLattice.lean
+++ b/IsingModel/Concrete/IntLattice.lean
@@ -36,7 +36,7 @@ delivers only the translation-invariance datum.
 
 ## References
 
-* Glimm–Jaffe, *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1, p. 64.
+* Glimm–Jaffe, *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1, p. 68.
 -/
 
 namespace IsingModel
@@ -55,7 +55,7 @@ which reduces to the pointwise identity `(t + u) i - (t + v) i = u i - v i`.
 
 This is the first non-trivial `Ambient.IsTranslationInvariant`
 instance (the prior ones are `⊥` and `⊤`). It is groundwork toward
-GJ §4.6 Prop 4.6.1 (p. 64): the class is the structural datum
+GJ §4.6 Prop 4.6.1 (p. 68): the class is the structural datum
 feeding into the automatic super-additivity of `log Z` along a
 translation-invariant exhaustion; this file does not yet assemble a
 concrete `TranslationInvariantExhaustion` (see the design note

--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -32,7 +32,7 @@ starting definitions.
 ## References
 
 * Glimm, J. and Jaffe, A., *Quantum Physics: A Functional Integral
-  Point of View*, 2nd ed., Springer 1987, §4.6 Prop 4.6.1, p. 64.
+  Point of View*, 2nd ed., Springer 1987, §4.6 Prop 4.6.1, p. 68.
 -/
 
 universe u v
@@ -51,7 +51,7 @@ iff the original is; the graph looks the same everywhere.
 
 This is the minimal structural datum behind the automatic
 super-additivity of `log Z` along translation-invariant exhaustions
-(GJ §4.6 Prop 4.6.1 p. 64). The translation-invariance-driven
+(GJ §4.6 Prop 4.6.1 p. 68). The translation-invariance-driven
 derivation of `DisjointTowerHypotheses.super` from this predicate is
 deferred to a subsequent PR. -/
 class IsTranslationInvariant (T : Type u) [AddGroup T]
@@ -511,7 +511,7 @@ This structure concerns only the **exhaustion geometry**. It does
 or of the Ising Hamiltonian — those are separate conditions.
 
 Reference: Glimm–Jaffe *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1,
-p. 64. -/
+p. 68. -/
 structure TranslationInvariantExhaustion (T : Type u) [AddGroup T]
     (V : Type v) [DecidableEq V] [AddAction T V]
     extends Exhaustion V where
@@ -721,7 +721,7 @@ provides the scaffold so that, once `hsuper` is derived, it
 plugs directly into `freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses`.
 
 Reference: Glimm–Jaffe *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1,
-p. 64. -/
+p. 68. -/
 def disjointTowerHypotheses_of_translationInvariant
     (Λ : TranslationInvariantExhaustion T V)
     (G : SimpleGraph V)
@@ -755,7 +755,7 @@ translation invariance (subsequent PR), this theorem will become
 an unconditional-in-`hsuper` corollary.
 
 Reference: Glimm–Jaffe *Quantum Physics* 2nd ed., §4.6 Prop 4.6.1,
-p. 64. -/
+p. 68. -/
 theorem freeEnergyAlongExhaustion_tendsto_of_translationInvariant
     (Λ : TranslationInvariantExhaustion T V)
     (G : SimpleGraph V)
@@ -777,7 +777,7 @@ theorem freeEnergyAlongExhaustion_tendsto_of_translationInvariant
 
 set_option linter.unusedFintypeInType false in
 /-- **Automatic Fekete convergence under full translation
-invariance** (GJ §4.6 Prop 4.6.1, p. 64): final step of the
+invariance** (GJ §4.6 Prop 4.6.1, p. 68): final step of the
 translation scaffolding. Given
 
 * a translation-invariant exhaustion `Λ` (step 3 / PR #222 +

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3998,7 +3998,7 @@ n\cdot|\Lambda_1|$ (from \texttt{hcard\_add}) to obtain
 $f_{\Lambda_n} = -u_n/(n\,|\Lambda_1|)$, and identify the limit
 with $f_\infty = \limsup f_{\Lambda_n}$ via
 \texttt{freeEnergyInfinite\_eq\_of\_tendsto}. Reference:
-Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1, p.~64.
+Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1, p.~68.
 \end{proof}
 
 \paragraph{Translation-invariance scaffolding for GJ \S 4.6
@@ -4036,7 +4036,7 @@ of \texttt{freeEnergyAlongExhaustion\_tendsto\_of\_disjoint\_tower}
 invariance. Requires Ising-Hamiltonian translation equivariance
 (separate multi-PR step).
 Reference: Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1,
-p.~64.
+p.~68.
 
 \begin{theorem}[Finset-based susceptibility at $J = 0$ closed form;
 PR \#231]
@@ -4401,7 +4401,7 @@ equality reduction, not a monotonicity argument.
 \texttt{card\_config\_eq\_two\_pow} + \texttt{Real.log\_pow} give
 $\log Z_\Lambda = |\Lambda| \cdot \log 2$. The rest is
 \texttt{of\_log\_linear\_card} applied with $c = \log 2$.
-Reference: Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1, p.~64.
+Reference: Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1, p.~68.
 \end{proof}
 
 \begin{theorem}[GJ \S 4.6 Prop 4.6.1, concrete $J = 0$ instance; PR \#205]
@@ -4429,7 +4429,7 @@ which holds with equality under \texttt{hcard\_add}. Combined with
 \texttt{BoundedEdgeDensity}, the bundled Fekete theorem
 \texttt{freeEnergyAlongExhaustion\_tendsto\_of\_disjointTowerHypotheses}
 closes the proof.  Reference: Glimm--Jaffe \cite{glimm-jaffe} \S 4.6
-Prop 4.6.1, p.~64. This is the first concrete
+Prop 4.6.1, p.~68. This is the first concrete
 \texttt{DisjointTowerHypotheses} instance; non-$J\!=\!0$ instances
 require translation invariance and remain follow-up.
 \end{proof}
@@ -4450,7 +4450,7 @@ Definitional unpack of the
 hypotheses of
 \texttt{freeEnergyAlongExhaustion\_tendsto\_of\_disjoint\_tower}.
 Reference: Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1,
-p.~64. This is an API-site convenience wrapper; no new
+p.~68. This is an API-site convenience wrapper; no new
 mathematical content.
 \end{proof}
 
@@ -4542,7 +4542,7 @@ homomorphism $\mathbb{N} \to T$. Assembling a compatible concrete
 exhaustion requires either relaxing the single-block constraint or
 altering the \texttt{Exhaustion} interface, and is deferred to a
 subsequent PR.
-Reference: Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1, p.~64.
+Reference: Glimm--Jaffe \cite{glimm-jaffe} \S 4.6 Prop 4.6.1, p.~68.
 
 \begin{theorem}[GJ \S 4.6 concrete: cubic \texttt{Ambient.Exhaustion} on
 $\mathbb{Z}^d$; PR \#245]


### PR DESCRIPTION
## Summary

Unify Glimm–Jaffe §4.6 Prop 4.6.1 page reference across the repository. Codex cross-check (web-verified ToC) confirms §4.5 (Lee–Yang) is at p. 64 and §4.6 (Analyticity of the Free Energy) starts at p. 67; Prop 4.6.1 itself is on p. 68. The repo currently mixes `p. 64` (incorrect) and `p. 68` (`FreeEnergy.lean:801`, correct).

This PR updates the erroneous `p. 64` citations for Prop 4.6.1 to `p. 68`.

## Test plan
- [ ] `lake build` clean
- [ ] `lake exe GKSTest` pass
- [ ] linter warnings zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)