### PR TITLE
feat: truncated4TwoPoint symmetries under pairwise swaps

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -521,6 +521,40 @@ theorem truncated3TwoPoint_symm_rs
   rw [h_triple, h_rs]
   ring
 
+/-- **Symmetry of `truncated4TwoPoint` under `(r, s)` swap**:
+`truncated4TwoPoint d p r s u = truncated4TwoPoint d p s r u`.
+
+From the Lebowitz 4-point definition: swapping `j ↔ k` in
+`truncated4Infinite ... i j k l` permutes the three pair-products,
+yielding the same sum. -/
+theorem truncated4TwoPoint_symm_rs
+    (d : ℕ) (p : IsingParams ℝ) (r s u : Fin d → ℤ) :
+    truncated4TwoPoint d p r s u = truncated4TwoPoint d p s r u := by
+  unfold truncated4TwoPoint truncated4Infinite
+  have h_quad : ({(0 : Fin d → ℤ), r, s, u} : Finset (Fin d → ℤ))
+      = {(0 : Fin d → ℤ), s, r, u} := by
+    ext x; simp only [Finset.mem_insert, Finset.mem_singleton]; tauto
+  have h_rs : ({r, s} : Finset (Fin d → ℤ)) = {s, r} := by
+    ext x; simp only [Finset.mem_insert, Finset.mem_singleton]; tauto
+  rw [h_quad, h_rs]
+  ring
+
+/-- **Symmetry of `truncated4TwoPoint` under `(s, u)` swap**:
+`truncated4TwoPoint d p r s u = truncated4TwoPoint d p r u s`.
+
+Same Lebowitz-permutation argument applied to swap of `k ↔ l`. -/
+theorem truncated4TwoPoint_symm_su
+    (d : ℕ) (p : IsingParams ℝ) (r s u : Fin d → ℤ) :
+    truncated4TwoPoint d p r s u = truncated4TwoPoint d p r u s := by
+  unfold truncated4TwoPoint truncated4Infinite
+  have h_quad : ({(0 : Fin d → ℤ), r, s, u} : Finset (Fin d → ℤ))
+      = {(0 : Fin d → ℤ), r, u, s} := by
+    ext x; simp only [Finset.mem_insert, Finset.mem_singleton]; tauto
+  have h_su : ({s, u} : Finset (Fin d → ℤ)) = {u, s} := by
+    ext x; simp only [Finset.mem_insert, Finset.mem_singleton]; tauto
+  rw [h_quad, h_su]
+  ring
+
 /-! ## Concrete Lebowitz / GHS inequalities on ℤ^d -/
 
 /-- **GHS `U_3 ≤ 0` on ℤ^d** (Glimm–Jaffe §4.3 Cor 4.3.4): for


### PR DESCRIPTION
## Summary

From `truncated4Infinite` symmetry under pairwise swaps of `(i, j, k, l)`, derive pairwise swap symmetries of the Lebowitz two-point function:

- `truncated4TwoPoint_symm_rs`: swap `r ↔ s`
- `truncated4TwoPoint_symm_su`: swap `s ↔ u`

## Test plan
- [ ] `lake build` clean
- [ ] `lake exe GKSTest` pass
- [ ] linter warnings zero