### PR TITLE
feat: truncated2TwoPoint at β=0 is 0

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -770,6 +770,32 @@ theorem twoPointFunction_ge_uniformMagnetization_sq
     (uniformMagnetization d p)^2 ≤ twoPointFunction d p r :=
   twoPointFunction_ge_magnetization_sq d p hf r
 
+/-- **`truncated2TwoPoint` at `β = 0` vanishes**:
+`truncated2TwoPoint d ⟨J, h, 0⟩ r = 0`.
+
+At infinite temperature `β = 0` all correlations vanish:
+`correlationInfinite ... {0, r} = 0` (PR #278) and the magnetization
+term is `0 · 0 = 0` (PR #276). Direct computation. -/
+theorem truncated2TwoPoint_beta_zero
+    (d : ℕ) (J h : ℝ) (r : Fin d → ℤ) :
+    truncated2TwoPoint d (⟨J, h, 0⟩ : IsingParams ℝ) r = 0 := by
+  unfold truncated2TwoPoint truncated2Infinite
+  -- `correlationInfinite ... {0, r} = 0`, `correlationInfinite ... {0} = 0`,
+  -- `correlationInfinite ... {r} = 0`.
+  rw [show correlationInfinite (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) (⟨J, h, 0⟩ : IsingParams ℝ)
+      {(0 : Fin d → ℤ), r} = 0 from
+    correlationInfinite_beta_zero_vanish _ _ J h _ (by simp),
+      show correlationInfinite (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) (⟨J, h, 0⟩ : IsingParams ℝ)
+      {(0 : Fin d → ℤ)} = 0 from
+    correlationInfinite_beta_zero_vanish _ _ J h _ (by simp),
+      show correlationInfinite (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) (⟨J, h, 0⟩ : IsingParams ℝ)
+      {r} = 0 from
+    correlationInfinite_beta_zero_vanish _ _ J h _ (by simp)]
+  ring
+
 /-- **`truncated2TwoPoint` at `J = 0` vanishes for `r ≠ 0`** (ferromagnetic):
 `truncated2TwoPoint d ⟨0, h, β⟩ r = 0`.
 


### PR DESCRIPTION
Direct from twoPointFunction_beta_zero = 0 + uniformMagnetization_beta_zero = 0.