### PR TITLE
feat: ℤ^d freeEnergyInfinite J/h/β monotonicities + h-symmetry

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -806,6 +806,49 @@ theorem twoPointFunction_J_zero_of_ne_zero
     exact (Ne.symm hr)
   rw [h_card]
 
+/-- **J-monotonicity of `freeEnergyInfinite` on ℤ^d** under the concrete
+BED constant `c = d` (PR #246). -/
+theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_monotone_J
+    (d : ℕ) [Nonempty (Fin d → ℤ)]
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β) :
+    MonotoneOn
+      (fun J : ℝ => freeEnergyInfinite (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) (⟨J, h, β⟩ : IsingParams ℝ))
+      (Set.Ici 0) := by
+  refine freeEnergyInfinite_monotone_J (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hh hβ (c := (d : ℝ)) ?_
+  intro n _
+  exact inducedLatticeGraph_card_edgeFinset_le d
+    ((Ambient.cubicExhaustion d).volume n)
+
+/-- **h-monotonicity of `freeEnergyInfinite` on ℤ^d**. -/
+theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_monotone_h
+    (d : ℕ) [Nonempty (Fin d → ℤ)]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    MonotoneOn
+      (fun h : ℝ => freeEnergyInfinite (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) (⟨J, h, β⟩ : IsingParams ℝ))
+      (Set.Ici 0) := by
+  refine freeEnergyInfinite_monotone_h (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hβ (c := (d : ℝ)) ?_
+  intro n _
+  exact inducedLatticeGraph_card_edgeFinset_le d
+    ((Ambient.cubicExhaustion d).volume n)
+
+/-- **β-monotonicity of `freeEnergyInfinite` on ℤ^d**. -/
+theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_monotone_beta
+    (d : ℕ) [Nonempty (Fin d → ℤ)]
+    {J : ℝ} (hJ : 0 ≤ J) {h : ℝ} (hh : 0 ≤ h) :
+    MonotoneOn
+      (fun β : ℝ => freeEnergyInfinite (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) (⟨J, h, β⟩ : IsingParams ℝ))
+      (Set.Ioi 0) := by
+  refine freeEnergyInfinite_monotone_beta (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hh (c := (d : ℝ)) ?_
+  intro n _
+  exact inducedLatticeGraph_card_edgeFinset_le d
+    ((Ambient.cubicExhaustion d).volume n)
+
 /-- **J-monotonicity of `spontaneousMagnetization` on ℤ^d** at any site. -/
 theorem spontaneousMagnetization_latticeGraph_cubicExhaustion_monotone_J
     (d : ℕ) {β : ℝ} (hβ : 0 < β) (i : Fin d → ℤ) :


### PR DESCRIPTION
Direct specializations of freeEnergyInfinite_monotone_{J,h,beta,abs_h} on (latticeGraph d, cubicExhaustion d) using BED c=d from PR #246.