### PR TITLE
feat: ℤ^d freeEnergyInfinite |h|-monotonicity

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -838,6 +838,22 @@ theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_bounds
   · exact freeEnergyInfinite_le_uniform_upper_bound
       (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d) p hf hc
 
+/-- **`|h|`-monotonicity of `freeEnergyInfinite` on ℤ^d**:
+`|h₁| ≤ |h₂| ⇒ freeEnergyInfinite ⟨J, h₁, β⟩ ≤ freeEnergyInfinite ⟨J, h₂, β⟩`. -/
+theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_monotone_abs_h
+    (d : ℕ) [Nonempty (Fin d → ℤ)]
+    {J β : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh : |h₁| ≤ |h₂|) :
+    freeEnergyInfinite (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) (⟨J, h₁, β⟩ : IsingParams ℝ)
+      ≤ freeEnergyInfinite (IsingModel.latticeGraph d)
+          (Ambient.cubicExhaustion d) (⟨J, h₂, β⟩ : IsingParams ℝ) := by
+  refine freeEnergyInfinite_monotone_abs_h (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hβ (c := (d : ℝ)) ?_ hh
+  intro n _
+  exact inducedLatticeGraph_card_edgeFinset_le d
+    ((Ambient.cubicExhaustion d).volume n)
+
 /-- **h-evenness of `freeEnergyInfinite` on ℤ^d**:
 `freeEnergyInfinite ⟨J, -h, β⟩ = freeEnergyInfinite ⟨J, h, β⟩`. -/
 theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_neg_h


### PR DESCRIPTION
Concrete specialization of freeEnergyInfinite_monotone_abs_h with BED c=d.