### PR TITLE
feat: ℤ^d freeEnergyInfinite slice closed forms (β=0, J=h=0, J=0)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -806,6 +806,33 @@ theorem twoPointFunction_J_zero_of_ne_zero
     exact (Ne.symm hr)
   rw [h_card]
 
+/-- **ℤ^d freeEnergyInfinite at β = 0**: `= log 2`. -/
+theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_beta_zero
+    (d : ℕ) [Nonempty (Fin d → ℤ)] (J h : ℝ) :
+    freeEnergyInfinite (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) (⟨J, h, 0⟩ : IsingParams ℝ)
+      = Real.log 2 :=
+  freeEnergyInfinite_beta_zero_of_nonempty (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) J h
+
+/-- **ℤ^d freeEnergyInfinite at J = h = 0**: `= log 2`. -/
+theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_zero_params
+    (d : ℕ) [Nonempty (Fin d → ℤ)] (β : ℝ) :
+    freeEnergyInfinite (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) (⟨0, 0, β⟩ : IsingParams ℝ)
+      = Real.log 2 :=
+  freeEnergyInfinite_zero_params_of_nonempty (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) β
+
+/-- **ℤ^d freeEnergyInfinite at J = 0**: `= log(2 cosh(β·h))`. -/
+theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_J_zero
+    (d : ℕ) [Nonempty (Fin d → ℤ)] (h β : ℝ) :
+    freeEnergyInfinite (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) (⟨0, h, β⟩ : IsingParams ℝ)
+      = Real.log (2 * Real.cosh (β * h)) :=
+  freeEnergyInfinite_J_zero_of_nonempty (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) h β
+
 /-- **Sharp lower bound** `freeEnergyInfinite ≥ log(2 cosh(βh))` on ℤ^d. -/
 theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_ge_log_two_cosh
     (d : ℕ) [Nonempty (Fin d → ℤ)]


### PR DESCRIPTION
Concrete specialisations of the three trivial-slice freeEnergyInfinite closed forms.