### PR TITLE
feat: ℤ^d freeEnergyAlongExhaustion_{ge_log_two, ge_log_two_cosh}

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -244,6 +244,27 @@ theorem spontaneousMagnetization_latticeGraph_cubicExhaustion_eq
   rw [hvadd] at h
   exact h.symm
 
+/-- **Per-stage lower bound on ℤ^d**: `log 2 ≤ freeEnergyAlongExhaustion` for
+ferromagnetic + nonempty stage. -/
+theorem freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_ge_log_two
+    (d : ℕ) {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
+    (n : ℕ) (hne : ((Ambient.cubicExhaustion d).volume n).Nonempty) :
+    Real.log 2 ≤ freeEnergyAlongExhaustion (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) ⟨J, h, β⟩ n :=
+  freeEnergyAlongExhaustion_ge_log_two (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hh hβ n hne
+
+/-- **Sharp per-stage lower bound on ℤ^d**:
+`log(2 cosh(βh)) ≤ freeEnergyAlongExhaustion`. -/
+theorem freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_ge_log_two_cosh
+    (d : ℕ) {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
+    (n : ℕ) (hne : ((Ambient.cubicExhaustion d).volume n).Nonempty) :
+    Real.log (2 * Real.cosh (β * h))
+      ≤ freeEnergyAlongExhaustion (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) ⟨J, h, β⟩ n :=
+  freeEnergyAlongExhaustion_ge_log_two_cosh (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hh hβ n hne
+
 /-- **ℤ^d free-energy shift invariance**:
 `freeEnergyInfinite (latticeGraph d) ((cubicExhaustion d).shift t) p
   = freeEnergyInfinite (latticeGraph d) (cubicExhaustion d) p`. -/


### PR DESCRIPTION
Per-stage lower bounds on ℤ^d free energy.