### PR TITLE
feat: ℤ^d correlationΛ / correlationAlongExhaustion at h=0 odd-card vanishing

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2177,6 +2177,22 @@ theorem correlationInfinite_latticeGraph_cubicExhaustion_fkg_spinProduct
   correlationInfinite_fkg_spinProduct (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p hf A B
 
+/-- **ℤ^d Z₂ symmetry at `h = 0` for `correlationΛ`**:
+odd-cardinality spin product vanishes at h=0. -/
+theorem correlationΛ_latticeGraph_odd_vanish_h_zero
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ)
+    (A : Finset (↑Λ : Type _)) (hodd : Odd A.card) :
+    correlationΛ (IsingModel.latticeGraph d) Λ ⟨J, 0, β⟩ A = 0 :=
+  correlationΛ_odd_vanish_h_zero (IsingModel.latticeGraph d) Λ J β A hodd
+
+/-- **ℤ^d Z₂ symmetry at `h = 0` for `correlationAlongExhaustion`** stage-wise. -/
+theorem correlationAlongExhaustion_latticeGraph_h_zero
+    (d : ℕ) (J β : ℝ) (A : Finset (Fin d → ℤ)) (hodd : Odd A.card) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) ⟨J, 0, β⟩ A n = 0 :=
+  correlationAlongExhaustion_h_zero (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) J β A hodd n
+
 /-- **ℤ^d Z₂ symmetry at `h = 0` for `correlationInfinite`**:
 `correlationInfinite ⟨J, 0, β⟩ A = 0` for any `A` of odd cardinality. -/
 theorem correlationInfinite_latticeGraph_cubicExhaustion_h_zero


### PR DESCRIPTION
Z₂ specialisation at finite-volume / along-exhaustion layer.