### PR TITLE
feat: magnetization{Λ,AlongExhaustion} at β=0 / zero_params + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2161,6 +2161,7 @@ theorem magnetizationAlongExhaustion_h_zero
   correlationAlongExhaustion_h_zero G Λ J β {i}
     (by simp [Finset.card_singleton]) n
 
+
 /-- **`correlationAlongExhaustion` at `J = 0` (on-stage closed form)**:
 whenever the test set `A` is contained in `Λ.volume n`,
 `correlationAlongExhaustion G Λ ⟨0, h, β⟩ A n = tanh(β·h)^A.card`.
@@ -2337,6 +2338,46 @@ theorem correlationInfinite_zero_params_vanish
     correlationInfinite G Λ (⟨0, 0, β⟩ : IsingParams ℝ) A = 0 := by
   simp only [correlationInfinite,
     correlationAlongExhaustion_zero_params_vanish G Λ β A hA, ciSup_const]
+
+/-- **`magnetizationΛ` vanishes at `β = 0`**: for any `J, h`, any site
+`i : ↑Λ`, `magnetizationΛ G Λ ⟨J, h, 0⟩ i = 0`. Specialization of
+`correlationΛ_beta_zero_vanish_of_nonempty` at the nonempty singleton
+`{i}`. -/
+theorem magnetizationΛ_beta_zero (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (J h : ℝ) (i : ↑Λ) :
+    magnetizationΛ G Λ (⟨J, h, 0⟩ : IsingParams ℝ) i = 0 :=
+  correlationΛ_beta_zero_vanish_of_nonempty G Λ J h {i}
+    (Finset.singleton_nonempty i)
+
+/-- **`magnetizationAlongExhaustion` vanishes at `β = 0`** per stage:
+for any `J, h`, any site `i : V`, and any `n`,
+`magnetizationAlongExhaustion G Λ ⟨J, h, 0⟩ i n = 0`. Specialization
+of `correlationAlongExhaustion_beta_zero_vanish` at `A = {i}`. -/
+theorem magnetizationAlongExhaustion_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (i : V) (n : ℕ) :
+    magnetizationAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ) i n = 0 :=
+  correlationAlongExhaustion_beta_zero_vanish G Λ J h {i}
+    (Finset.singleton_nonempty i) n
+
+/-- **`magnetizationΛ` vanishes at `J = h = 0`**: for any `β`, any site
+`i : ↑Λ`, `magnetizationΛ G Λ ⟨0, 0, β⟩ i = 0`. Specialization of
+`correlationΛ_zero_params_vanish_of_nonempty`. -/
+theorem magnetizationΛ_zero_params (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (β : ℝ) (i : ↑Λ) :
+    magnetizationΛ G Λ (⟨0, 0, β⟩ : IsingParams ℝ) i = 0 :=
+  correlationΛ_zero_params_vanish_of_nonempty G Λ β {i}
+    (Finset.singleton_nonempty i)
+
+/-- **`magnetizationAlongExhaustion` vanishes at `J = h = 0`** per stage. -/
+theorem magnetizationAlongExhaustion_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (i : V) (n : ℕ) :
+    magnetizationAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ) i n = 0 :=
+  correlationAlongExhaustion_zero_params_vanish G Λ β {i}
+    (Finset.singleton_nonempty i) n
 
 /-- **β=0 infinite-volume magnetization vanishes**: at infinite
 temperature (`β = 0`), spins are uniformly distributed and decoupled,

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3163,6 +3163,36 @@ theorem magnetizationAlongExhaustion_latticeGraph_h_zero
         (⟨J, 0, β⟩ : IsingParams ℝ) i n = 0 :=
   magnetizationAlongExhaustion_h_zero (IsingModel.latticeGraph d) Λ J β i n
 
+/-- **ℤ^d magnetizationΛ vanishes at β=0**. -/
+theorem magnetizationΛ_latticeGraph_beta_zero
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h : ℝ) (i : ↑Λ) :
+    magnetizationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J, h, 0⟩ : IsingParams ℝ) i = 0 :=
+  magnetizationΛ_beta_zero (IsingModel.latticeGraph d) Λ J h i
+
+/-- **ℤ^d magnetizationAlongExhaustion vanishes at β=0** per stage. -/
+theorem magnetizationAlongExhaustion_latticeGraph_beta_zero
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (J h : ℝ)
+    (i : Fin d → ℤ) (n : ℕ) :
+    magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, 0⟩ : IsingParams ℝ) i n = 0 :=
+  magnetizationAlongExhaustion_beta_zero (IsingModel.latticeGraph d) Λ J h i n
+
+/-- **ℤ^d magnetizationΛ vanishes at J=h=0**. -/
+theorem magnetizationΛ_latticeGraph_zero_params
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (β : ℝ) (i : ↑Λ) :
+    magnetizationΛ (IsingModel.latticeGraph d) Λ
+        (⟨0, 0, β⟩ : IsingParams ℝ) i = 0 :=
+  magnetizationΛ_zero_params (IsingModel.latticeGraph d) Λ β i
+
+/-- **ℤ^d magnetizationAlongExhaustion vanishes at J=h=0** per stage. -/
+theorem magnetizationAlongExhaustion_latticeGraph_zero_params
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (β : ℝ)
+    (i : Fin d → ℤ) (n : ℕ) :
+    magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨0, 0, β⟩ : IsingParams ℝ) i n = 0 :=
+  magnetizationAlongExhaustion_zero_params (IsingModel.latticeGraph d) Λ β i n
+
 /-- **ℤ^d magnetizationInfinite at h = 0 site-wise**:
 `magnetizationInfinite (latticeGraph d) Λ ⟨J, 0, β⟩ i = 0`. -/
 theorem magnetizationInfinite_latticeGraph_zero_at_h_zero

--- a/docs/index.md
+++ b/docs/index.md
@@ -478,6 +478,7 @@ inventory (2026-04-17).
 | §4.2 | `magnetizationAlongExhaustion → magnetizationInfinite` (ferromagnetic) + ℤ^d | **Done** | `tendsto_magnetizationAlongExhaustion_magnetizationInfinite` — direct specialization of `tendsto_correlationAlongExhaustion_correlationInfinite` at `A = {i}`. Concrete ℤ^d wrapper. (PR #398.) |
 | §4.2 | `magnetization{Λ, AlongExhaustion}` {J,h,β}-monotonicities + ℤ^d | **Done** | `magnetizationΛ_monotone_{J,h,beta}` (MonotoneOn: `J ∈ Ici 0` / `h ∈ Ici 0` / `β ∈ Ioi 0`) and `magnetizationAlongExhaustion_monotone_{J,h,beta}` (pointwise per-stage). Direct specializations of `correlationΛ_monotone_{J,h,beta}` / `correlationAlongExhaustion_monotone_{J,h,beta}` at `A = {i}`. Concrete ℤ^d cubic wrappers. (PR #399.) |
 | §4.2 | `magnetization{Λ, AlongExhaustion}` at `h = 0` (Z₂) + ℤ^d | **Done** | `magnetizationΛ_h_zero = 0` and per-stage `magnetizationAlongExhaustion_h_zero = 0` for any `J, β` and any site. Specializations of `correlationΛ_odd_vanish_h_zero` / `correlationAlongExhaustion_h_zero` at `A = {i}` (`Odd 1` discharges the odd-cardinality hypothesis). Concrete ℤ^d wrappers. (PR #400.) |
+| §4.2 | `magnetization{Λ, AlongExhaustion}` at `β = 0` / `J = h = 0` + ℤ^d | **Done** | `magnetization{Λ, AlongExhaustion}_{beta_zero, zero_params} = 0`. Specializations of `correlation{Λ, AlongExhaustion}_{beta_zero, zero_params}_vanish` at `A = {i}` using `Finset.singleton_nonempty`. Concrete ℤ^d wrappers. (PR #401.) |
 | §4.7 | Two-component spins | Out of scope | XY model |
 
 ### Chapter 5 (Phase transitions)


### PR DESCRIPTION
## Summary
Trivial-slice vanishing of single-site magnetization at β=0 and J=h=0:

- `Ambient.magnetizationΛ_{beta_zero, zero_params}`: `M_Λ = 0` for any `J, h` / any `β`.
- `Ambient.magnetizationAlongExhaustion_{beta_zero, zero_params}`: per-stage zero.
- ℤ^d concrete wrappers.

Specializations of `correlationΛ_{beta_zero, zero_params}_vanish_of_nonempty` / `correlationAlongExhaustion_{beta_zero, zero_params}_vanish` at `A = {i}` (using `{i}.Nonempty`).

## Test plan
- [ ] lake build
- [ ] GKSTest
- [ ] codex cross-check