### PR TITLE
feat: twoPointFunction / truncated2TwoPoint at h=0, r=0

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2650,6 +2650,23 @@ theorem abs_twoPointFunction_le_one
   abs_correlationInfinite_le_one (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p {(0 : Fin d → ℤ), r}
 
+/-- **`twoPointFunction` at `h = 0, r = 0` vanishes** (Z₂ via
+`twoPointFunction_zero` + `magnetizationInfinite_zero_at_h_zero`):
+`twoPointFunction d ⟨J, 0, β⟩ 0 = 0`. -/
+theorem twoPointFunction_h_zero_at_zero (d : ℕ) (J β : ℝ) :
+    twoPointFunction d (⟨J, 0, β⟩ : IsingParams ℝ) 0 = 0 := by
+  rw [twoPointFunction_zero,
+      magnetizationInfinite_zero_at_h_zero]
+
+/-- **`truncated2TwoPoint` at `h = 0, r = 0` vanishes**: at `r = 0`,
+`truncated2TwoPoint = M · (1 − M)`; at `h = 0`, `M = 0` by Z₂, so the
+product is `0`. -/
+theorem truncated2TwoPoint_h_zero_at_zero (d : ℕ) (J β : ℝ) :
+    truncated2TwoPoint d (⟨J, 0, β⟩ : IsingParams ℝ) 0 = 0 := by
+  rw [truncated2TwoPoint_zero,
+      magnetizationInfinite_zero_at_h_zero]
+  ring
+
 /-- **J-monotonicity of `twoPointFunction`** (GJ Prop 4.2.1):
 for `0 ≤ h, 0 < β`, `twoPointFunction d ⟨J, h, β⟩ r` is monotone in
 `J` on `Ici 0`. Direct specialization of

--- a/docs/index.md
+++ b/docs/index.md
@@ -484,6 +484,7 @@ inventory (2026-04-17).
 | §4.2 | Unconditional `abs_correlationInfinite_le_one` + magnetization + ℤ^d | **Done** | `Ambient.abs_correlationInfinite_le_one`: `|correlationInfinite G Λ p A| ≤ 1` unconditionally (no ferromagnetic assumption). Upper bound from `correlationInfinite_le_one`; lower bound via `le_ciSup` + `correlationAlongExhaustion_bddAbove` applied to stage 0 (where `-1 ≤ correlationAlongExhaustion ... 0`). `abs_magnetizationInfinite_le_one` specialization. Concrete ℤ^d wrappers — strictly stronger than the ferromagnetic-only PR #395. (PR #404.) |
 | §4.2 | `-1 ≤ correlation/magnetization` lower bounds (Λ/Along/Infinite) + ℤ^d | **Done** | `neg_one_le_{correlation,magnetization}{Λ, AlongExhaustion, Infinite}` lower-bound counterparts of the existing `… ≤ 1` upper bounds, derived from the `abs_… ≤ 1` theorems via `abs_le.mp`. Concrete ℤ^d wrappers. (PR #405.) |
 | §4.2 | `-1 ≤ twoPointFunction` + `abs_twoPointFunction_le_one` | **Done** | `neg_one_le_twoPointFunction` and `abs_twoPointFunction_le_one` unconditionally, via specialization of `neg_one_le_correlationInfinite` / `abs_correlationInfinite_le_one` at `A = {0, r}`. (PR #406.) |
+| §4.6 | `{twoPointFunction, truncated2TwoPoint}` at `h = 0, r = 0` | **Done** | `twoPointFunction_h_zero_at_zero = 0` via `twoPointFunction_zero` + `magnetizationInfinite_zero_at_h_zero`. `truncated2TwoPoint_h_zero_at_zero = 0` via `truncated2TwoPoint_zero = M(1-M)` with `M = 0`. (PR #407.) |
 | §4.7 | Two-component spins | Out of scope | XY model |
 
 ### Chapter 5 (Phase transitions)


### PR DESCRIPTION
## Summary
Combine existing `_zero` and `_h_zero` results at the `r = 0, h = 0` corner:

- `twoPointFunction_h_zero_at_zero`: `twoPointFunction d ⟨J,0,β⟩ 0 = 0` via `twoPointFunction_zero` + `magnetizationInfinite_latticeGraph_zero_at_h_zero`.
- `truncated2TwoPoint_h_zero_at_zero`: same via `twoPointFunction_h_zero_at_zero` and the h=0 identity.

## Test plan
- [ ] lake build
- [ ] GKSTest
- [ ] codex cross-check