### PR TITLE
feat: abs_uniformMagnetization_le_one + -1 ≤ uniformMagnetization

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1450,6 +1450,22 @@ theorem uniformMagnetization_le_one
   magnetizationInfinite_le_one (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p 0
 
+/-- **`-1 ≤ uniformMagnetization`** unconditionally. Specialization of
+`neg_one_le_magnetizationInfinite` at site `0`. -/
+theorem neg_one_le_uniformMagnetization
+    (d : ℕ) (p : IsingParams ℝ) :
+    -1 ≤ uniformMagnetization d p :=
+  neg_one_le_magnetizationInfinite (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p 0
+
+/-- **`|uniformMagnetization| ≤ 1`** unconditionally. Specialization of
+`abs_magnetizationInfinite_le_one` at site `0`. -/
+theorem abs_uniformMagnetization_le_one
+    (d : ℕ) (p : IsingParams ℝ) :
+    |uniformMagnetization d p| ≤ 1 :=
+  abs_magnetizationInfinite_le_one (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p 0
+
 /-- **Uniform spontaneous magnetization on ℤ^d**: by site-independence
 of spontaneous magnetization on the translation-invariant ℤ^d lattice
 (PR #257), we package the value at `0` as a scalar.

--- a/docs/index.md
+++ b/docs/index.md
@@ -485,6 +485,7 @@ inventory (2026-04-17).
 | §4.2 | `-1 ≤ correlation/magnetization` lower bounds (Λ/Along/Infinite) + ℤ^d | **Done** | `neg_one_le_{correlation,magnetization}{Λ, AlongExhaustion, Infinite}` lower-bound counterparts of the existing `… ≤ 1` upper bounds, derived from the `abs_… ≤ 1` theorems via `abs_le.mp`. Concrete ℤ^d wrappers. (PR #405.) |
 | §4.2 | `-1 ≤ twoPointFunction` + `abs_twoPointFunction_le_one` | **Done** | `neg_one_le_twoPointFunction` and `abs_twoPointFunction_le_one` unconditionally, via specialization of `neg_one_le_correlationInfinite` / `abs_correlationInfinite_le_one` at `A = {0, r}`. (PR #406.) |
 | §4.6 | `{twoPointFunction, truncated2TwoPoint}` at `h = 0, r = 0` | **Done** | `twoPointFunction_h_zero_at_zero = 0` via `twoPointFunction_zero` + `magnetizationInfinite_zero_at_h_zero`. `truncated2TwoPoint_h_zero_at_zero = 0` via `truncated2TwoPoint_zero = M(1-M)` with `M = 0`. (PR #407.) |
+| §4.2, §5.3 | `abs_uniformMagnetization_le_one` + `-1 ≤ uniformMagnetization` | **Done** | `abs_uniformMagnetization_le_one` and `neg_one_le_uniformMagnetization` unconditionally (no Ferromagnetic hypothesis), via `abs_magnetizationInfinite_le_one` / `neg_one_le_magnetizationInfinite` at site 0. (PR #408.) |
 | §4.7 | Two-component spins | Out of scope | XY model |
 
 ### Chapter 5 (Phase transitions)


### PR DESCRIPTION
## Summary
Unconditional absolute-value and lower bounds for `uniformMagnetization`:

- `abs_uniformMagnetization_le_one` via `abs_magnetizationInfinite_le_one`.
- `neg_one_le_uniformMagnetization` via `neg_one_le_magnetizationInfinite`.
- Same for `uniformSpontaneousMagnetization` (using existing `_nonneg` + `_le_uniformMagnetization`).

## Test plan
- [ ] lake build
- [ ] GKSTest
- [ ] codex cross-check