### PR TITLE
feat: abs_spontaneousCorrelation_le_one + uniformSpontaneousMagnetization

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2636,6 +2636,25 @@ theorem spontaneousCorrelation_le_one
     ⟨1, by norm_num⟩ ?_
   exact correlationInfinite_le_one G Λ ⟨J, 1, β⟩ A
 
+/-- **`-1 ≤ spontaneousCorrelation`** (ferromagnetic). Follows from
+`spontaneousCorrelation_nonneg`. -/
+theorem neg_one_le_spontaneousCorrelation
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset V) :
+    -1 ≤ spontaneousCorrelation G Λ J β A := by
+  have := spontaneousCorrelation_nonneg G Λ hJ hβ A
+  linarith
+
+/-- **`|spontaneousCorrelation| ≤ 1`** (ferromagnetic). -/
+theorem abs_spontaneousCorrelation_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset V) :
+    |spontaneousCorrelation G Λ J β A| ≤ 1 :=
+  abs_le.mpr ⟨neg_one_le_spontaneousCorrelation G Λ hJ hβ A,
+    spontaneousCorrelation_le_one G Λ hJ hβ A⟩
+
 /-- **Lower bound by `correlationInfinite` at positive `h`**: for any
 `h > 0`, $\langle \sigma^A \rangle^* \le \langle \sigma^A \rangle(h)$. -/
 theorem spontaneousCorrelation_le_correlationInfinite

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1466,6 +1466,7 @@ theorem abs_uniformMagnetization_le_one
   abs_magnetizationInfinite_le_one (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p 0
 
+
 /-- **Uniform spontaneous magnetization on ℤ^d**: by site-independence
 of spontaneous magnetization on the translation-invariant ℤ^d lattice
 (PR #257), we package the value at `0` as a scalar.
@@ -1521,6 +1522,21 @@ theorem uniformSpontaneousMagnetization_le_one
     uniformSpontaneousMagnetization d J β ≤ 1 :=
   spontaneousMagnetization_le_one (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) hJ hβ 0
+
+/-- **`-1 ≤ uniformSpontaneousMagnetization`** (ferromagnetic).
+Direct from `uniformSpontaneousMagnetization_nonneg`. -/
+theorem neg_one_le_uniformSpontaneousMagnetization
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    -1 ≤ uniformSpontaneousMagnetization d J β := by
+  have := uniformSpontaneousMagnetization_nonneg d hJ hβ
+  linarith
+
+/-- **`|uniformSpontaneousMagnetization| ≤ 1`** (ferromagnetic). -/
+theorem abs_uniformSpontaneousMagnetization_le_one
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    |uniformSpontaneousMagnetization d J β| ≤ 1 :=
+  abs_le.mpr ⟨neg_one_le_uniformSpontaneousMagnetization d hJ hβ,
+    uniformSpontaneousMagnetization_le_one d hJ hβ⟩
 
 /-- **`uniformMagnetization` at `β = 0`**:
 `uniformMagnetization d ⟨J, h, 0⟩ = 0`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -486,6 +486,7 @@ inventory (2026-04-17).
 | §4.2 | `-1 ≤ twoPointFunction` + `abs_twoPointFunction_le_one` | **Done** | `neg_one_le_twoPointFunction` and `abs_twoPointFunction_le_one` unconditionally, via specialization of `neg_one_le_correlationInfinite` / `abs_correlationInfinite_le_one` at `A = {0, r}`. (PR #406.) |
 | §4.6 | `{twoPointFunction, truncated2TwoPoint}` at `h = 0, r = 0` | **Done** | `twoPointFunction_h_zero_at_zero = 0` via `twoPointFunction_zero` + `magnetizationInfinite_zero_at_h_zero`. `truncated2TwoPoint_h_zero_at_zero = 0` via `truncated2TwoPoint_zero = M(1-M)` with `M = 0`. (PR #407.) |
 | §4.2, §5.3 | `abs_uniformMagnetization_le_one` + `-1 ≤ uniformMagnetization` | **Done** | `abs_uniformMagnetization_le_one` and `neg_one_le_uniformMagnetization` unconditionally (no Ferromagnetic hypothesis), via `abs_magnetizationInfinite_le_one` / `neg_one_le_magnetizationInfinite` at site 0. (PR #408.) |
+| §4.2, §5.4 | `abs_spontaneousCorrelation_le_one` + uniformSpontaneousMagnetization (ferromagnetic) | **Done** | `Ambient.abs_spontaneousCorrelation_le_one` and `neg_one_le_spontaneousCorrelation` (ferromagnetic, via `spontaneousCorrelation_nonneg` + `_le_one`). Concrete ℤ^d `abs_uniformSpontaneousMagnetization_le_one` + `neg_one_le_uniformSpontaneousMagnetization`. (PR #409.) |
 | §4.7 | Two-component spins | Out of scope | XY model |
 
 ### Chapter 5 (Phase transitions)


### PR DESCRIPTION
## Summary
Under ferromagnetic hypotheses (`J ≥ 0, β > 0`), the spontaneous correlation lies in `[0, 1]`, so `|⟨σ^A⟩*| ≤ 1` and `-1 ≤ ⟨σ^A⟩*` follow:

- `abs_spontaneousCorrelation_le_one`
- `neg_one_le_spontaneousCorrelation`
- `abs_uniformSpontaneousMagnetization_le_one`
- `neg_one_le_uniformSpontaneousMagnetization`

## Test plan
- [ ] lake build
- [ ] GKSTest
- [ ] codex cross-check