### PR TITLE
feat: abs_spontaneousMagnetization_le_one + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2768,6 +2768,25 @@ theorem spontaneousMagnetization_le_one
     spontaneousMagnetization G Λ J β i ≤ 1 :=
   spontaneousCorrelation_le_one G Λ hJ hβ {i}
 
+/-- **`-1 ≤ spontaneousMagnetization`** (ferromagnetic).
+Direct from `spontaneousMagnetization_nonneg`. -/
+theorem neg_one_le_spontaneousMagnetization
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
+    -1 ≤ spontaneousMagnetization G Λ J β i := by
+  have := spontaneousMagnetization_nonneg G Λ hJ hβ i
+  linarith
+
+/-- **`|spontaneousMagnetization| ≤ 1`** (ferromagnetic). -/
+theorem abs_spontaneousMagnetization_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
+    |spontaneousMagnetization G Λ J β i| ≤ 1 :=
+  abs_le.mpr ⟨neg_one_le_spontaneousMagnetization G Λ hJ hβ i,
+    spontaneousMagnetization_le_one G Λ hJ hβ i⟩
+
 /-- **Lower bound for `magnetizationInfinite` at positive `h`**:
 $m^* \le M(h)$ for $h > 0$. Specialization of
 `spontaneousCorrelation_le_correlationInfinite` at `A = {i}` (noting

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1538,6 +1538,20 @@ theorem abs_uniformSpontaneousMagnetization_le_one
   abs_le.mpr ⟨neg_one_le_uniformSpontaneousMagnetization d hJ hβ,
     uniformSpontaneousMagnetization_le_one d hJ hβ⟩
 
+/-- **ℤ^d `-1 ≤ spontaneousMagnetization`** (ferromagnetic). -/
+theorem neg_one_le_spontaneousMagnetization_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : Fin d → ℤ) :
+    -1 ≤ spontaneousMagnetization (IsingModel.latticeGraph d) Λ J β i :=
+  neg_one_le_spontaneousMagnetization (IsingModel.latticeGraph d) Λ hJ hβ i
+
+/-- **ℤ^d `|spontaneousMagnetization| ≤ 1`** (ferromagnetic). -/
+theorem abs_spontaneousMagnetization_latticeGraph_le_one
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : Fin d → ℤ) :
+    |spontaneousMagnetization (IsingModel.latticeGraph d) Λ J β i| ≤ 1 :=
+  abs_spontaneousMagnetization_le_one (IsingModel.latticeGraph d) Λ hJ hβ i
+
 /-- **`uniformMagnetization` at `β = 0`**:
 `uniformMagnetization d ⟨J, h, 0⟩ = 0`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -487,6 +487,7 @@ inventory (2026-04-17).
 | §4.6 | `{twoPointFunction, truncated2TwoPoint}` at `h = 0, r = 0` | **Done** | `twoPointFunction_h_zero_at_zero = 0` via `twoPointFunction_zero` + `magnetizationInfinite_zero_at_h_zero`. `truncated2TwoPoint_h_zero_at_zero = 0` via `truncated2TwoPoint_zero = M(1-M)` with `M = 0`. (PR #407.) |
 | §4.2, §5.3 | `abs_uniformMagnetization_le_one` + `-1 ≤ uniformMagnetization` | **Done** | `abs_uniformMagnetization_le_one` and `neg_one_le_uniformMagnetization` unconditionally (no Ferromagnetic hypothesis), via `abs_magnetizationInfinite_le_one` / `neg_one_le_magnetizationInfinite` at site 0. (PR #408.) |
 | §4.2, §5.4 | `abs_spontaneousCorrelation_le_one` + uniformSpontaneousMagnetization (ferromagnetic) | **Done** | `Ambient.abs_spontaneousCorrelation_le_one` and `neg_one_le_spontaneousCorrelation` (ferromagnetic, via `spontaneousCorrelation_nonneg` + `_le_one`). Concrete ℤ^d `abs_uniformSpontaneousMagnetization_le_one` + `neg_one_le_uniformSpontaneousMagnetization`. (PR #409.) |
+| §5.4 | `abs_spontaneousMagnetization_le_one` + ℤ^d (ferromagnetic) | **Done** | `Ambient.abs_spontaneousMagnetization_le_one` and `neg_one_le_spontaneousMagnetization` via `abs_le.mpr` combining `spontaneousMagnetization_nonneg` + `_le_one`. Concrete ℤ^d wrappers. (PR #410.) |
 | §4.7 | Two-component spins | Out of scope | XY model |
 
 ### Chapter 5 (Phase transitions)


### PR DESCRIPTION
## Summary
Absolute-value and lower bounds for spontaneous magnetization (ferromagnetic):

- `Ambient.neg_one_le_spontaneousMagnetization`
- `Ambient.abs_spontaneousMagnetization_le_one`
- ℤ^d concrete wrappers.

All ferromagnetic-conditional via existing `spontaneousMagnetization_nonneg + _le_one`.

## Test plan
- [ ] lake build
- [ ] GKSTest