### PR TITLE
feat: magnetization_sq_le_one across layers + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -281,6 +281,16 @@ theorem neg_one_le_magnetizationΛ (G : SimpleGraph V) (Λ : Finset V)
     -1 ≤ magnetizationΛ G Λ p i :=
   neg_one_le_correlationΛ G Λ p {i}
 
+/-- **`magnetizationΛ² ≤ 1`** unconditionally. From
+`abs_magnetizationΛ_le_one` via `sq_le_one'`. -/
+theorem magnetizationΛ_sq_le_one (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ) (i : ↑Λ) :
+    magnetizationΛ G Λ p i ^ 2 ≤ 1 := by
+  have h := abs_magnetizationΛ_le_one G Λ p i
+  have : |magnetizationΛ G Λ p i| ^ 2 ≤ 1 ^ 2 :=
+    pow_le_pow_left₀ (abs_nonneg _) h 2
+  simpa [sq_abs] using this
+
 /-- **`magnetizationΛ ≥ 0`** for ferromagnetic `p` at any site `i : ↑Λ`.
 Direct from `correlationΛ_nonneg` at `A = {i}` (GKS-I). -/
 theorem magnetizationΛ_nonneg (G : SimpleGraph V) (Λ : Finset V)
@@ -2137,6 +2147,18 @@ theorem neg_one_le_magnetizationInfinite
     -1 ≤ magnetizationInfinite G Λ p i :=
   neg_one_le_correlationInfinite G Λ p {i}
 
+/-- **`magnetizationInfinite² ≤ 1`** unconditionally. From
+`abs_magnetizationInfinite_le_one` via `sq_le_one'`. -/
+theorem magnetizationInfinite_sq_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i : V) :
+    magnetizationInfinite G Λ p i ^ 2 ≤ 1 := by
+  have h := abs_magnetizationInfinite_le_one G Λ p i
+  have : |magnetizationInfinite G Λ p i| ^ 2 ≤ 1 ^ 2 :=
+    pow_le_pow_left₀ (abs_nonneg _) h 2
+  simpa [sq_abs] using this
+
 /-- **Convergence of `magnetizationAlongExhaustion` to `magnetizationInfinite`**
 for ferromagnetic `p`:
 `Tendsto (magnetizationAlongExhaustion G Λ p i) atTop (nhds (magnetizationInfinite G Λ p i))`.
@@ -2786,6 +2808,17 @@ theorem abs_spontaneousMagnetization_le_one
     |spontaneousMagnetization G Λ J β i| ≤ 1 :=
   abs_le.mpr ⟨neg_one_le_spontaneousMagnetization G Λ hJ hβ i,
     spontaneousMagnetization_le_one G Λ hJ hβ i⟩
+
+/-- **`spontaneousMagnetization² ≤ 1`** (ferromagnetic). -/
+theorem spontaneousMagnetization_sq_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : V) :
+    spontaneousMagnetization G Λ J β i ^ 2 ≤ 1 := by
+  have h := abs_spontaneousMagnetization_le_one G Λ hJ hβ i
+  have : |spontaneousMagnetization G Λ J β i| ^ 2 ≤ 1 ^ 2 :=
+    pow_le_pow_left₀ (abs_nonneg _) h 2
+  simpa [sq_abs] using this
 
 /-- **Lower bound for `magnetizationInfinite` at positive `h`**:
 $m^* \le M(h)$ for $h > 0$. Specialization of

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1466,6 +1466,14 @@ theorem abs_uniformMagnetization_le_one
   abs_magnetizationInfinite_le_one (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p 0
 
+/-- **`uniformMagnetization² ≤ 1`** unconditionally. Specialization of
+`magnetizationInfinite_sq_le_one` at site `0`. -/
+theorem uniformMagnetization_sq_le_one
+    (d : ℕ) (p : IsingParams ℝ) :
+    uniformMagnetization d p ^ 2 ≤ 1 :=
+  magnetizationInfinite_sq_le_one (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p 0
+
 
 /-- **Uniform spontaneous magnetization on ℤ^d**: by site-independence
 of spontaneous magnetization on the translation-invariant ℤ^d lattice
@@ -1537,6 +1545,13 @@ theorem abs_uniformSpontaneousMagnetization_le_one
     |uniformSpontaneousMagnetization d J β| ≤ 1 :=
   abs_le.mpr ⟨neg_one_le_uniformSpontaneousMagnetization d hJ hβ,
     uniformSpontaneousMagnetization_le_one d hJ hβ⟩
+
+/-- **`uniformSpontaneousMagnetization² ≤ 1`** (ferromagnetic). -/
+theorem uniformSpontaneousMagnetization_sq_le_one
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    uniformSpontaneousMagnetization d J β ^ 2 ≤ 1 :=
+  spontaneousMagnetization_sq_le_one (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hβ 0
 
 /-- **ℤ^d `-1 ≤ spontaneousMagnetization`** (ferromagnetic). -/
 theorem neg_one_le_spontaneousMagnetization_latticeGraph

--- a/IsingModel/PhaseTransition.lean
+++ b/IsingModel/PhaseTransition.lean
@@ -175,6 +175,16 @@ theorem magnetization_nonneg (G : SimpleGraph ι) [Fintype G.edgeSet]
     0 ≤ magnetization G p i :=
   gks_first G p hf {i}
 
+/-- **`magnetization² ≤ 1`** unconditionally. Immediate from
+`abs_magnetization_le_one` via `sq_le_one'`. -/
+theorem magnetization_sq_le_one (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (i : ι) :
+    magnetization G p i ^ 2 ≤ 1 := by
+  have h := abs_magnetization_le_one G p i
+  have : |magnetization G p i| ^ 2 ≤ 1 ^ 2 :=
+    pow_le_pow_left₀ (abs_nonneg _) h 2
+  simpa [sq_abs] using this
+
 /-- **Susceptibility** (per site `i`):
 `χ(i) = Σ_j ⟨σ_i; σ_j⟩ = Σ_j truncated2(i, j)`.
 


### PR DESCRIPTION
## Summary
Squared bounds `m² ≤ 1` across the magnetization layering, combining `abs_… ≤ 1` with `sq_le_one'`:

- `IsingModel.magnetization_sq_le_one`
- `Ambient.magnetizationInfinite_sq_le_one`
- `Ambient.magnetizationΛ_sq_le_one`
- `Ambient.spontaneousMagnetization_sq_le_one` (ferromagnetic)
- ℤ^d `uniformMagnetization_sq_le_one`, `uniformSpontaneousMagnetization_sq_le_one`.

## Test plan
- [ ] lake build
- [ ] GKSTest