### PR TITLE
feat: correlation_sq_le_one across layers + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -246,6 +246,13 @@ theorem neg_one_le_correlationΛ (G : SimpleGraph V) (Λ : Finset V)
     -1 ≤ correlationΛ G Λ p A :=
   (abs_le.mp (abs_correlationΛ_le_one G Λ p A)).1
 
+/-- **`correlationΛ² ≤ 1`** unconditionally. -/
+theorem correlationΛ_sq_le_one (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ)
+    (A : Finset (↑Λ : Type _)) :
+    correlationΛ G Λ p A ^ 2 ≤ 1 :=
+  IsingModel.correlation_sq_le_one _ p A
+
 /-- For ferromagnetic `p`, the correlation on `Λ` is non-negative
 (GKS-I, lifted to the ambient framework). -/
 theorem correlationΛ_nonneg (G : SimpleGraph V) (Λ : Finset V)
@@ -593,6 +600,17 @@ theorem neg_one_le_correlationAlongExhaustion
     (p : IsingParams ℝ) (A : Finset V) (n : ℕ) :
     -1 ≤ correlationAlongExhaustion G Λ p A n :=
   (abs_le.mp (abs_correlationAlongExhaustion_le_one G Λ p A n)).1
+
+/-- **Pointwise `correlationAlongExhaustion² ≤ 1`** at every `n : ℕ`. -/
+theorem correlationAlongExhaustion_sq_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (A : Finset V) (n : ℕ) :
+    correlationAlongExhaustion G Λ p A n ^ 2 ≤ 1 := by
+  have h := abs_correlationAlongExhaustion_le_one G Λ p A n
+  have : |correlationAlongExhaustion G Λ p A n| ^ 2 ≤ 1 ^ 2 :=
+    pow_le_pow_left₀ (abs_nonneg _) h 2
+  simpa [sq_abs] using this
 
 /-! ## Monotonicity in the ambient subgraph direction
 
@@ -1472,6 +1490,17 @@ theorem neg_one_le_correlationInfinite
     (p : IsingParams ℝ) (A : Finset V) :
     -1 ≤ correlationInfinite G Λ p A :=
   (abs_le.mp (abs_correlationInfinite_le_one G Λ p A)).1
+
+/-- **`correlationInfinite² ≤ 1`** (unconditional). -/
+theorem correlationInfinite_sq_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (A : Finset V) :
+    correlationInfinite G Λ p A ^ 2 ≤ 1 := by
+  have h := abs_correlationInfinite_le_one G Λ p A
+  have : |correlationInfinite G Λ p A| ^ 2 ≤ 1 ^ 2 :=
+    pow_le_pow_left₀ (abs_nonneg _) h 2
+  simpa [sq_abs] using this
 
 /-- **Nonnegativity** (ferromagnetic): `correlationInfinite ≥ 0`.
 Uses `Λ.exhaust`: pick `N` with `A ⊆ Λ.volume N`; then

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3362,6 +3362,27 @@ theorem neg_one_le_correlationInfinite_latticeGraph
     -1 ≤ correlationInfinite (IsingModel.latticeGraph d) Λ p A :=
   neg_one_le_correlationInfinite (IsingModel.latticeGraph d) Λ p A
 
+/-- **ℤ^d `correlationΛ² ≤ 1`**. -/
+theorem correlationΛ_latticeGraph_sq_le_one
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)
+    (A : Finset (↑Λ : Type _)) :
+    correlationΛ (IsingModel.latticeGraph d) Λ p A ^ 2 ≤ 1 :=
+  correlationΛ_sq_le_one (IsingModel.latticeGraph d) Λ p A
+
+/-- **ℤ^d `correlationAlongExhaustion² ≤ 1`** per stage. -/
+theorem correlationAlongExhaustion_latticeGraph_sq_le_one
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n ^ 2 ≤ 1 :=
+  correlationAlongExhaustion_sq_le_one (IsingModel.latticeGraph d) Λ p A n
+
+/-- **ℤ^d `correlationInfinite² ≤ 1`**. -/
+theorem correlationInfinite_latticeGraph_sq_le_one
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) :
+    correlationInfinite (IsingModel.latticeGraph d) Λ p A ^ 2 ≤ 1 :=
+  correlationInfinite_sq_le_one (IsingModel.latticeGraph d) Λ p A
+
 /-- **ℤ^d `-1 ≤ magnetizationΛ`**. -/
 theorem neg_one_le_magnetizationΛ_latticeGraph
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) (i : ↑Λ) :

--- a/IsingModel/InfiniteVolume.lean
+++ b/IsingModel/InfiniteVolume.lean
@@ -546,6 +546,16 @@ theorem neg_one_le_correlation (G : SimpleGraph ι) [Fintype G.edgeSet]
     -1 ≤ correlation G p A :=
   (abs_le.mp (abs_correlation_le_one G p A)).1
 
+/-- **`correlation² ≤ 1`** unconditionally. From `abs_correlation_le_one`
+via `pow_le_pow_left₀` + `sq_abs`. -/
+theorem correlation_sq_le_one (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (A : Finset ι) :
+    correlation G p A ^ 2 ≤ 1 := by
+  have h := abs_correlation_le_one G p A
+  have : |correlation G p A| ^ 2 ≤ 1 ^ 2 :=
+    pow_le_pow_left₀ (abs_nonneg _) h 2
+  simpa [sq_abs] using this
+
 /-! ## Monotonicity in the lattice (Theorem 4.2.3, lattice version)
 
 For a fixed ambient finite lattice `ι` and ferromagnetic parameters `p`,


### PR DESCRIPTION
## Summary
Squared bounds `⟨σ^A⟩² ≤ 1` across the correlation layering:

- `IsingModel.correlation_sq_le_one`
- `Ambient.correlationΛ_sq_le_one`
- `Ambient.correlationAlongExhaustion_sq_le_one`
- `Ambient.correlationInfinite_sq_le_one`
- ℤ^d concrete wrappers.

## Test plan
- [ ] lake build
- [ ] GKSTest