### PR TITLE
feat: magnetizationAlongExhaustion_convergent + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2201,6 +2201,17 @@ theorem tendsto_magnetizationAlongExhaustion_magnetizationInfinite
       Filter.atTop (nhds (magnetizationInfinite G Λ p i)) :=
   tendsto_correlationAlongExhaustion_correlationInfinite G Λ p hf {i}
 
+/-- **Existential convergence of `magnetizationAlongExhaustion`** for
+ferromagnetic `p`: `∃ L, Tendsto (magnetizationAlongExhaustion G Λ p i) atTop (nhds L)`.
+Specialization of `correlationAlongExhaustion_convergent` at `A = {i}`. -/
+theorem magnetizationAlongExhaustion_convergent
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : V) :
+    ∃ L : ℝ, Filter.Tendsto (magnetizationAlongExhaustion G Λ p i)
+      Filter.atTop (nhds L) :=
+  correlationAlongExhaustion_convergent G Λ p hf {i}
+
 /-- **Exhaustion-independence of `magnetizationInfinite`**:
 the value does not depend on the choice of exhaustion.  Specialization
 of `correlationInfinite_indep_exhaustion`. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3181,6 +3181,16 @@ theorem tendsto_magnetizationAlongExhaustion_magnetizationInfinite_latticeGraph
   tendsto_magnetizationAlongExhaustion_magnetizationInfinite
     (IsingModel.latticeGraph d) Λ p hf i
 
+/-- **ℤ^d existential convergence of `magnetizationAlongExhaustion`**
+(ferromagnetic). -/
+theorem magnetizationAlongExhaustion_latticeGraph_convergent
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : Fin d → ℤ) :
+    ∃ L : ℝ, Filter.Tendsto
+        (magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i)
+      Filter.atTop (nhds L) :=
+  magnetizationAlongExhaustion_convergent (IsingModel.latticeGraph d) Λ p hf i
+
 /-- **ℤ^d magnetizationΛ h-monotonicity**: `MonotoneOn` in `h` on `Ici 0`. -/
 theorem magnetizationΛ_latticeGraph_monotone_h
     (d : ℕ) (Λ : Finset (Fin d → ℤ))


### PR DESCRIPTION
## Summary
Existential convergence form:

- `Ambient.magnetizationAlongExhaustion_convergent` (ferromagnetic): `∃ L, Tendsto ... L`. Specialization of `correlationAlongExhaustion_convergent` at `A = {i}`.
- ℤ^d wrapper.

## Test plan
- [ ] lake build
- [ ] GKSTest