### PR TITLE
feat: magnetizationAlongExhaustion_monotone + _bddAbove

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2212,6 +2212,27 @@ theorem magnetizationAlongExhaustion_convergent
       Filter.atTop (nhds L) :=
   correlationAlongExhaustion_convergent G Λ p hf {i}
 
+/-- **Stage-index monotonicity of `magnetizationAlongExhaustion`** for
+ferromagnetic `p`. Specialization of `correlationAlongExhaustion_monotone`
+at `A = {i}`. -/
+theorem magnetizationAlongExhaustion_monotone
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : V) :
+    Monotone (magnetizationAlongExhaustion G Λ p i) :=
+  correlationAlongExhaustion_monotone G Λ p hf {i}
+
+/-- **`magnetizationAlongExhaustion` is bounded above** (unconditional):
+the range of `n ↦ magnetizationAlongExhaustion G Λ p i n` is
+bounded above. Specialization of `correlationAlongExhaustion_bddAbove`
+at `A = {i}`. -/
+theorem magnetizationAlongExhaustion_bddAbove
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i : V) :
+    BddAbove (Set.range (magnetizationAlongExhaustion G Λ p i)) :=
+  correlationAlongExhaustion_bddAbove G Λ p {i}
+
 /-- **Exhaustion-independence of `magnetizationInfinite`**:
 the value does not depend on the choice of exhaustion.  Specialization
 of `correlationInfinite_indep_exhaustion`. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3191,6 +3191,22 @@ theorem magnetizationAlongExhaustion_latticeGraph_convergent
       Filter.atTop (nhds L) :=
   magnetizationAlongExhaustion_convergent (IsingModel.latticeGraph d) Λ p hf i
 
+/-- **ℤ^d stage-index monotonicity of `magnetizationAlongExhaustion`**
+(ferromagnetic). -/
+theorem magnetizationAlongExhaustion_latticeGraph_monotone
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : Fin d → ℤ) :
+    Monotone (magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i) :=
+  magnetizationAlongExhaustion_monotone (IsingModel.latticeGraph d) Λ p hf i
+
+/-- **ℤ^d `magnetizationAlongExhaustion` bounded above** (unconditional). -/
+theorem magnetizationAlongExhaustion_latticeGraph_bddAbove
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (i : Fin d → ℤ) :
+    BddAbove (Set.range
+      (magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i)) :=
+  magnetizationAlongExhaustion_bddAbove (IsingModel.latticeGraph d) Λ p i
+
 /-- **ℤ^d magnetizationΛ h-monotonicity**: `MonotoneOn` in `h` on `Ici 0`. -/
 theorem magnetizationΛ_latticeGraph_monotone_h
     (d : ℕ) (Λ : Finset (Fin d → ℤ))


### PR DESCRIPTION
## Summary
Pointwise monotonicity (ferromagnetic) and boundedness-above for `magnetizationAlongExhaustion`:

- `Ambient.magnetizationAlongExhaustion_monotone`: stage-index Monotone (ferromagnetic).
- `Ambient.magnetizationAlongExhaustion_bddAbove`: unconditional.
- ℤ^d wrappers.

## Test plan
- [ ] lake build
- [ ] GKSTest