### PR TITLE
feat: magnetizationAlongExhaustion_tendsto_ciSup + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2233,6 +2233,18 @@ theorem magnetizationAlongExhaustion_bddAbove
     BddAbove (Set.range (magnetizationAlongExhaustion G Λ p i)) :=
   correlationAlongExhaustion_bddAbove G Λ p {i}
 
+/-- **Convergence to the supremum** for `magnetizationAlongExhaustion`
+(ferromagnetic): `Tendsto … atTop (nhds (⨆ n, magnetizationAlongExhaustion G Λ p i n))`.
+Specialization of `correlationAlongExhaustion_tendsto_ciSup` at
+`A = {i}`. -/
+theorem magnetizationAlongExhaustion_tendsto_ciSup
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : V) :
+    Filter.Tendsto (magnetizationAlongExhaustion G Λ p i)
+      Filter.atTop (nhds (⨆ n, magnetizationAlongExhaustion G Λ p i n)) :=
+  correlationAlongExhaustion_tendsto_ciSup G Λ p hf {i}
+
 /-- **Exhaustion-independence of `magnetizationInfinite`**:
 the value does not depend on the choice of exhaustion.  Specialization
 of `correlationInfinite_indep_exhaustion`. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3207,6 +3207,17 @@ theorem magnetizationAlongExhaustion_latticeGraph_bddAbove
       (magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i)) :=
   magnetizationAlongExhaustion_bddAbove (IsingModel.latticeGraph d) Λ p i
 
+/-- **ℤ^d magnetizationAlongExhaustion → ⨆ n ...** (ferromagnetic). -/
+theorem magnetizationAlongExhaustion_latticeGraph_tendsto_ciSup
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : Fin d → ℤ) :
+    Filter.Tendsto
+        (magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i)
+      Filter.atTop
+      (nhds (⨆ n, magnetizationAlongExhaustion (IsingModel.latticeGraph d)
+        Λ p i n)) :=
+  magnetizationAlongExhaustion_tendsto_ciSup (IsingModel.latticeGraph d) Λ p hf i
+
 /-- **ℤ^d magnetizationΛ h-monotonicity**: `MonotoneOn` in `h` on `Ici 0`. -/
 theorem magnetizationΛ_latticeGraph_monotone_h
     (d : ℕ) (Λ : Finset (Fin d → ℤ))


### PR DESCRIPTION
## Summary
- `Ambient.magnetizationAlongExhaustion_tendsto_ciSup` (ferromagnetic): `Tendsto … atTop (nhds (⨆ n, magnetizationAlongExhaustion G Λ p i n))`.
- ℤ^d wrapper.

Specialization of `correlationAlongExhaustion_tendsto_ciSup` at `A = {i}`.

## Test plan
- [ ] lake build
- [ ] GKSTest