### PR TITLE
feat: magnetizationInfinite_eq_ciSup + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2245,6 +2245,18 @@ theorem magnetizationAlongExhaustion_tendsto_ciSup
       Filter.atTop (nhds (⨆ n, magnetizationAlongExhaustion G Λ p i n)) :=
   correlationAlongExhaustion_tendsto_ciSup G Λ p hf {i}
 
+/-- **`magnetizationInfinite` as `ciSup`**:
+`magnetizationInfinite G Λ p i = ⨆ n, magnetizationAlongExhaustion G Λ p i n`.
+Definitional identity threading `magnetizationInfinite := correlationInfinite … {i}`
+and `correlationInfinite := ⨆ n, correlationAlongExhaustion …` through
+`magnetizationAlongExhaustion := correlationAlongExhaustion … {i}`. -/
+theorem magnetizationInfinite_eq_ciSup
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i : V) :
+    magnetizationInfinite G Λ p i
+      = ⨆ n, magnetizationAlongExhaustion G Λ p i n := rfl
+
 /-- **Exhaustion-independence of `magnetizationInfinite`**:
 the value does not depend on the choice of exhaustion.  Specialization
 of `correlationInfinite_indep_exhaustion`. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3218,6 +3218,15 @@ theorem magnetizationAlongExhaustion_latticeGraph_tendsto_ciSup
         Λ p i n)) :=
   magnetizationAlongExhaustion_tendsto_ciSup (IsingModel.latticeGraph d) Λ p hf i
 
+/-- **ℤ^d `magnetizationInfinite` as `ciSup`**:
+`magnetizationInfinite = ⨆ n, magnetizationAlongExhaustion`. -/
+theorem magnetizationInfinite_latticeGraph_eq_ciSup
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (i : Fin d → ℤ) :
+    magnetizationInfinite (IsingModel.latticeGraph d) Λ p i
+      = ⨆ n, magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i n :=
+  magnetizationInfinite_eq_ciSup (IsingModel.latticeGraph d) Λ p i
+
 /-- **ℤ^d magnetizationΛ h-monotonicity**: `MonotoneOn` in `h` on `Ici 0`. -/
 theorem magnetizationΛ_latticeGraph_monotone_h
     (d : ℕ) (Λ : Finset (Fin d → ℤ))


### PR DESCRIPTION
## Summary
- `Ambient.magnetizationInfinite_eq_ciSup`: `magnetizationInfinite G Λ p i = ⨆ n, magnetizationAlongExhaustion G Λ p i n`. Refl-identity via definitional unfolding of `magnetizationInfinite := correlationInfinite … {i}` and `magnetizationAlongExhaustion := correlationAlongExhaustion … {i}`.
- ℤ^d wrapper.

## Test plan
- [ ] lake build
- [ ] GKSTest