### PR TITLE
feat: correlationInfinite_eq_ciSup + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1443,6 +1443,16 @@ noncomputable def correlationInfinite
     (p : IsingParams ℝ) (A : Finset V) : ℝ :=
   ⨆ n, correlationAlongExhaustion G Λ p A n
 
+/-- **`correlationInfinite` as `ciSup`**:
+`correlationInfinite G Λ p A = ⨆ n, correlationAlongExhaustion G Λ p A n`
+(named restatement of the definition for use in rewrites). -/
+theorem correlationInfinite_eq_ciSup
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (A : Finset V) :
+    correlationInfinite G Λ p A
+      = ⨆ n, correlationAlongExhaustion G Λ p A n := rfl
+
 /-- **Tendsto to infinite-volume correlation** (primary form):
 `correlationAlongExhaustion` converges to `correlationInfinite`.
 Restatement of `correlationAlongExhaustion_tendsto_ciSup` in terms

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3227,6 +3227,14 @@ theorem magnetizationInfinite_latticeGraph_eq_ciSup
       = ⨆ n, magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i n :=
   magnetizationInfinite_eq_ciSup (IsingModel.latticeGraph d) Λ p i
 
+/-- **ℤ^d `correlationInfinite` as `ciSup`**. -/
+theorem correlationInfinite_latticeGraph_eq_ciSup
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) :
+    correlationInfinite (IsingModel.latticeGraph d) Λ p A
+      = ⨆ n, correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n :=
+  correlationInfinite_eq_ciSup (IsingModel.latticeGraph d) Λ p A
+
 /-- **ℤ^d magnetizationΛ h-monotonicity**: `MonotoneOn` in `h` on `Ici 0`. -/
 theorem magnetizationΛ_latticeGraph_monotone_h
     (d : ℕ) (Λ : Finset (Fin d → ℤ))


### PR DESCRIPTION
## Summary
Expose `correlationInfinite = ⨆ n, correlationAlongExhaustion ...` as a named theorem rather than a purely definitional unfold. Concrete ℤ^d wrapper.

## Test plan
- [ ] lake build
- [ ] GKSTest