### PR TITLE
feat: log_partitionFunctionΛ_nonneg_of_ferromagnetic + ℤ^d

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -335,6 +335,15 @@ theorem partitionFunctionΛ_ge_one_of_ferromagnetic
     1 ≤ partitionFunctionΛ G Λ p :=
   IsingModel.partitionFunction_ge_one_of_ferromagnetic _ p hf
 
+/-- **`log Z_Λ ≥ 0`** for ferromagnetic parameters: immediate from
+`partitionFunctionΛ_ge_one_of_ferromagnetic` via `Real.log_nonneg`. -/
+theorem log_partitionFunctionΛ_nonneg_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    0 ≤ Real.log (partitionFunctionΛ G Λ p) :=
+  Real.log_nonneg (partitionFunctionΛ_ge_one_of_ferromagnetic G Λ p hf)
+
 /-- **`partitionFunctionAlongExhaustion ≥ 1`** for ferromagnetic
 parameters: pointwise lift of PR #141
 `partitionFunction_ge_one_of_ferromagnetic`. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1167,6 +1167,14 @@ theorem log_partitionFunctionΛ_latticeGraph_ge_card_mul_log_two
   log_partitionFunctionΛ_ge_card_mul_log_two_of_ferromagnetic
     (IsingModel.latticeGraph d) Λ p hf
 
+/-- **ℤ^d `log Z_Λ ≥ 0`** (ferromagnetic). -/
+theorem log_partitionFunctionΛ_latticeGraph_nonneg
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)
+    (hf : Ferromagnetic p) :
+    0 ≤ Real.log (partitionFunctionΛ (IsingModel.latticeGraph d) Λ p) :=
+  log_partitionFunctionΛ_nonneg_of_ferromagnetic
+    (IsingModel.latticeGraph d) Λ p hf
+
 /-- **ℤ^d partitionFunctionΛ ≥ (2 cosh βh)^|Λ|** (sharp, ferromagnetic). -/
 theorem partitionFunctionΛ_latticeGraph_ge_two_cosh_pow_card
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)


### PR DESCRIPTION
## Summary
- `Ambient.log_partitionFunctionΛ_nonneg_of_ferromagnetic`: `0 ≤ log Z_Λ` for ferromagnetic `p`, via `partitionFunctionΛ_ge_one_of_ferromagnetic + Real.log_nonneg`.
- ℤ^d wrapper.

## Test plan
- [ ] lake build
- [ ] GKSTest