### PR TITLE
feat: freeEnergyΛ = |Λ|⁻¹ · log Z_Λ + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -94,6 +94,17 @@ noncomputable def freeEnergyΛ (G : SimpleGraph V) (Λ : Finset V)
     [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ) : ℝ :=
   IsingModel.freeEnergy (inducedGraph G Λ) p
 
+/-- **`freeEnergyΛ` as `|Λ|⁻¹ · log Z_Λ`** (named restatement of the
+definition unfolding `IsingModel.freeEnergy := (Fintype.card ι)⁻¹ ·
+log Z`). The ambient `Fintype.card` is taken on the subtype `↑Λ`, which
+coincides with `Λ.card` via `Fintype.card_coe`. -/
+theorem freeEnergyΛ_eq_inv_card_mul_log
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ) :
+    freeEnergyΛ G Λ p
+      = (Fintype.card (↑Λ : Type _) : ℝ)⁻¹
+        * Real.log (partitionFunctionΛ G Λ p) := rfl
+
 /-- The **magnetization** on a finite volume `Λ` at site `i : ↑Λ`:
 `M_Λ(i) = ⟨σ_i⟩ = correlationΛ G Λ p {i}`. Direct analog of
 `IsingModel.magnetization` at the ambient-lattice Λ layer, matching

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1175,6 +1175,14 @@ theorem log_partitionFunctionΛ_latticeGraph_nonneg
   log_partitionFunctionΛ_nonneg_of_ferromagnetic
     (IsingModel.latticeGraph d) Λ p hf
 
+/-- **ℤ^d `freeEnergyΛ = |↑Λ|⁻¹ · log Z_Λ`**. -/
+theorem freeEnergyΛ_latticeGraph_eq_inv_card_mul_log
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    freeEnergyΛ (IsingModel.latticeGraph d) Λ p
+      = (Fintype.card (↑Λ : Type _) : ℝ)⁻¹
+        * Real.log (partitionFunctionΛ (IsingModel.latticeGraph d) Λ p) :=
+  freeEnergyΛ_eq_inv_card_mul_log (IsingModel.latticeGraph d) Λ p
+
 /-- **ℤ^d partitionFunctionΛ ≥ (2 cosh βh)^|Λ|** (sharp, ferromagnetic). -/
 theorem partitionFunctionΛ_latticeGraph_ge_two_cosh_pow_card
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)


### PR DESCRIPTION
## Summary
Named-theorem restatement of the `freeEnergyΛ` definition:

- `Ambient.freeEnergyΛ_eq_inv_card_mul_log`: `freeEnergyΛ G Λ p = (Fintype.card ↑Λ)⁻¹ · log (partitionFunctionΛ G Λ p)`.
- ℤ^d wrapper.

## Test plan
- [ ] lake build
- [ ] GKSTest