### PR TITLE
feat: freeEnergyAlongExhaustion = |Λ_n|⁻¹ · log Z_n + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -105,6 +105,16 @@ theorem freeEnergyΛ_eq_inv_card_mul_log
       = (Fintype.card (↑Λ : Type _) : ℝ)⁻¹
         * Real.log (partitionFunctionΛ G Λ p) := rfl
 
+/-- **`freeEnergyΛ` with `Λ.card` cast**: using `Fintype.card_coe`,
+`freeEnergyΛ G Λ p = (Λ.card : ℝ)⁻¹ · log (partitionFunctionΛ G Λ p)`.
+Convenient form when working with the Finset cardinality directly. -/
+theorem freeEnergyΛ_eq_inv_Λcard_mul_log
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ) :
+    freeEnergyΛ G Λ p
+      = (Λ.card : ℝ)⁻¹ * Real.log (partitionFunctionΛ G Λ p) := by
+  rw [freeEnergyΛ_eq_inv_card_mul_log, Fintype.card_coe]
+
 /-- The **magnetization** on a finite volume `Λ` at site `i : ↑Λ`:
 `M_Λ(i) = ⟨σ_i⟩ = correlationΛ G Λ p {i}`. Direct analog of
 `IsingModel.magnetization` at the ambient-lattice Λ layer, matching
@@ -494,6 +504,7 @@ theorem freeEnergyAlongExhaustion_apply
     freeEnergyAlongExhaustion G Λ p n = freeEnergyΛ G (Λ.volume n) p :=
   rfl
 
+
 /-- **Partition function along an exhaustion**: the volume-direction
 partition function sequence $Z_n := Z_{\Lambda_n}$.  Companion to
 `freeEnergyAlongExhaustion` (Glimm–Jaffe §4.6); useful for Prop 4.6.1
@@ -529,6 +540,29 @@ theorem partitionFunctionAlongExhaustion_apply
     partitionFunctionAlongExhaustion G Λ p n
       = partitionFunctionΛ G (Λ.volume n) p :=
   rfl
+
+/-- **Along-exhaustion free energy as `|Λ_n|⁻¹ · log Z_n`** per stage:
+`freeEnergyAlongExhaustion G Λ p n = (Fintype.card ↑(Λ.volume n))⁻¹ ·
+log (partitionFunctionAlongExhaustion G Λ p n)`. Per-stage
+specialization of `freeEnergyΛ_eq_inv_card_mul_log`. -/
+theorem freeEnergyAlongExhaustion_eq_inv_card_mul_log
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ p n
+      = (Fintype.card (↑(Λ.volume n) : Type _) : ℝ)⁻¹
+        * Real.log (partitionFunctionAlongExhaustion G Λ p n) :=
+  freeEnergyΛ_eq_inv_card_mul_log G (Λ.volume n) p
+
+/-- **Along-exhaustion free energy with `(Λ.volume n).card` cast**. -/
+theorem freeEnergyAlongExhaustion_eq_inv_Λcard_mul_log
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ p n
+      = ((Λ.volume n).card : ℝ)⁻¹
+        * Real.log (partitionFunctionAlongExhaustion G Λ p n) :=
+  freeEnergyΛ_eq_inv_Λcard_mul_log G (Λ.volume n) p
 
 /-- **Positivity along an exhaustion**:
 `0 < partitionFunctionAlongExhaustion G Λ p n` for every `n`. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1183,6 +1183,35 @@ theorem freeEnergyΛ_latticeGraph_eq_inv_card_mul_log
         * Real.log (partitionFunctionΛ (IsingModel.latticeGraph d) Λ p) :=
   freeEnergyΛ_eq_inv_card_mul_log (IsingModel.latticeGraph d) Λ p
 
+/-- **ℤ^d `freeEnergyΛ = (Λ.card)⁻¹ · log Z_Λ`** (Finset-card form). -/
+theorem freeEnergyΛ_latticeGraph_eq_inv_Λcard_mul_log
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    freeEnergyΛ (IsingModel.latticeGraph d) Λ p
+      = (Λ.card : ℝ)⁻¹
+        * Real.log (partitionFunctionΛ (IsingModel.latticeGraph d) Λ p) :=
+  freeEnergyΛ_eq_inv_Λcard_mul_log (IsingModel.latticeGraph d) Λ p
+
+/-- **ℤ^d `freeEnergyAlongExhaustion = |↑(Λ_n)|⁻¹ · log Z_n`** per stage. -/
+theorem freeEnergyAlongExhaustion_latticeGraph_eq_inv_card_mul_log
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ p n
+      = (Fintype.card (↑(Λ.volume n) : Type _) : ℝ)⁻¹
+        * Real.log (partitionFunctionAlongExhaustion
+            (IsingModel.latticeGraph d) Λ p n) :=
+  freeEnergyAlongExhaustion_eq_inv_card_mul_log (IsingModel.latticeGraph d) Λ p n
+
+/-- **ℤ^d `freeEnergyAlongExhaustion = ((Λ.volume n).card)⁻¹ · log Z_n`**. -/
+theorem freeEnergyAlongExhaustion_latticeGraph_eq_inv_Λcard_mul_log
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ p n
+      = ((Λ.volume n).card : ℝ)⁻¹
+        * Real.log (partitionFunctionAlongExhaustion
+            (IsingModel.latticeGraph d) Λ p n) :=
+  freeEnergyAlongExhaustion_eq_inv_Λcard_mul_log
+    (IsingModel.latticeGraph d) Λ p n
+
 /-- **ℤ^d partitionFunctionΛ ≥ (2 cosh βh)^|Λ|** (sharp, ferromagnetic). -/
 theorem partitionFunctionΛ_latticeGraph_ge_two_cosh_pow_card
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)


### PR DESCRIPTION
## Summary
Per-stage unfolding:

- `Ambient.freeEnergyAlongExhaustion_eq_inv_card_mul_log`: `freeEnergyAlongExhaustion G Λ p n = (Fintype.card ↑(Λ.volume n))⁻¹ · log (partitionFunctionAlongExhaustion G Λ p n)`.
- ℤ^d wrapper.

## Test plan
- [ ] lake build
- [ ] GKSTest