### PR TITLE
feat: ℤ^d correlationΛ trivial-slice wrappers (β=0, zero_params, h=0)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -340,6 +340,23 @@ theorem correlationInfinite_latticeGraph_empty
     correlationInfinite (IsingModel.latticeGraph d) Λ p ∅ = 1 :=
   correlationInfinite_empty (IsingModel.latticeGraph d) Λ p
 
+/-- **ℤ^d `correlationΛ` vanishes at `β = 0`** for nonempty `A : Finset ↑Λ`. -/
+theorem correlationΛ_latticeGraph_beta_zero_vanish_of_nonempty
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h : ℝ)
+    (A : Finset (↑Λ : Type _)) (hA : A.Nonempty) :
+    correlationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J, h, 0⟩ : IsingParams ℝ) A = 0 :=
+  correlationΛ_beta_zero_vanish_of_nonempty (IsingModel.latticeGraph d) Λ J h A hA
+
+/-- **ℤ^d `correlationΛ` vanishes at `J = h = 0`** for nonempty `A`. -/
+theorem correlationΛ_latticeGraph_zero_params_vanish_of_nonempty
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (β : ℝ)
+    (A : Finset (↑Λ : Type _)) (hA : A.Nonempty) :
+    correlationΛ (IsingModel.latticeGraph d) Λ
+        (⟨0, 0, β⟩ : IsingParams ℝ) A = 0 :=
+  correlationΛ_zero_params_vanish_of_nonempty (IsingModel.latticeGraph d) Λ β A hA
+
+
 /-- **ℤ^d correlationΛ_empty = 1** per finite volume. -/
 @[simp]
 theorem correlationΛ_latticeGraph_empty


### PR DESCRIPTION
## Summary
ℤ^d concrete wrappers for correlationΛ at trivial slices:

- `correlationΛ_latticeGraph_beta_zero_vanish_of_nonempty`
- `correlationΛ_latticeGraph_zero_params_vanish_of_nonempty`
- `correlationΛ_latticeGraph_h_zero_odd_vanish`

## Test plan
- [ ] lake build
- [ ] GKSTest