### PR TITLE
feat: ℤ^d correlationAlongExhaustion/Infinite trivial-slice wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -356,6 +356,24 @@ theorem correlationΛ_latticeGraph_zero_params_vanish_of_nonempty
         (⟨0, 0, β⟩ : IsingParams ℝ) A = 0 :=
   correlationΛ_zero_params_vanish_of_nonempty (IsingModel.latticeGraph d) Λ β A hA
 
+/-- **ℤ^d `correlationAlongExhaustion` vanishes at `β = 0`** per stage. -/
+theorem correlationAlongExhaustion_latticeGraph_beta_zero_vanish
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h : ℝ) (A : Finset (Fin d → ℤ)) (hA : A.Nonempty) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, 0⟩ : IsingParams ℝ) A n = 0 :=
+  correlationAlongExhaustion_beta_zero_vanish (IsingModel.latticeGraph d)
+    Λ J h A hA n
+
+/-- **ℤ^d `correlationAlongExhaustion` vanishes at `J = h = 0`** per stage. -/
+theorem correlationAlongExhaustion_latticeGraph_zero_params_vanish
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (β : ℝ) (A : Finset (Fin d → ℤ)) (hA : A.Nonempty) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨0, 0, β⟩ : IsingParams ℝ) A n = 0 :=
+  correlationAlongExhaustion_zero_params_vanish (IsingModel.latticeGraph d)
+    Λ β A hA n
+
 
 /-- **ℤ^d correlationΛ_empty = 1** per finite volume. -/
 @[simp]


### PR DESCRIPTION
## Summary
- `correlationAlongExhaustion_latticeGraph_beta_zero_vanish`, `_zero_params_vanish`.
- `correlationInfinite_latticeGraph_beta_zero_vanish`, `_zero_params_vanish`, `_h_zero`.

## Test plan
- [ ] lake build
- [ ] GKSTest