### PR TITLE
feat: correlationΛ_J_zero + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2372,6 +2372,18 @@ theorem correlationΛ_odd_vanish_h_zero
     correlationΛ G Λ ⟨J, 0, β⟩ A = 0 :=
   IsingModel.correlation_odd_vanish (inducedGraph G Λ) J β A hodd
 
+/-- **Λ-level correlation closed form at `J = 0`**:
+`correlationΛ G Λ ⟨0, h, β⟩ A = tanh(β·h)^A.card`. Direct lift of
+`IsingModel.correlation_J_zero` through
+`correlationΛ := correlation (inducedGraph G Λ)`. Unconditional. -/
+theorem correlationΛ_J_zero
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (h β : ℝ) (A : Finset (↑Λ : Type _)) :
+    correlationΛ G Λ (⟨0, h, β⟩ : IsingParams ℝ) A
+      = Real.tanh (β * h) ^ A.card :=
+  IsingModel.correlation_J_zero (inducedGraph G Λ) h β A
+
 /-- **Z₂ symmetry at `h = 0` for `correlationAlongExhaustion`**:
 pointwise zero at every `n`.  Either `A ⊄ Λ.volume n` (both branches
 of the dite give `0`) or `A ⊆ Λ.volume n` and the lifted correlation

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -374,6 +374,16 @@ theorem correlationAlongExhaustion_latticeGraph_zero_params_vanish
   correlationAlongExhaustion_zero_params_vanish (IsingModel.latticeGraph d)
     Λ β A hA n
 
+/-- **ℤ^d `correlationΛ` at `J = 0` closed form**:
+`correlationΛ ⟨0, h, β⟩ A = tanh(β·h)^|A|`. -/
+theorem correlationΛ_latticeGraph_J_zero
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β : ℝ)
+    (A : Finset (↑Λ : Type _)) :
+    correlationΛ (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ) A
+      = Real.tanh (β * h) ^ A.card :=
+  correlationΛ_J_zero (IsingModel.latticeGraph d) Λ h β A
+
 /-- **ℤ^d `correlationAlongExhaustion` at `J = 0`** per stage (on-stage):
 `A ⊆ Λ.volume n ⇒ = tanh(β·h)^|A|`. -/
 theorem correlationAlongExhaustion_latticeGraph_J_zero_of_subset


### PR DESCRIPTION
## Summary
- `Ambient.correlationΛ_J_zero`: `correlationΛ G Λ ⟨0, h, β⟩ A = tanh(β·h)^A.card`. Direct specialization of `IsingModel.correlation_J_zero` at induced graph.
- ℤ^d wrapper.

## Test plan
- [ ] lake build
- [ ] GKSTest