### PR TITLE
feat: truncated2Infinite_le_one + _le_correlationInfinite

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3149,6 +3149,35 @@ theorem truncated2Infinite_nonneg
     exact truncated2Infinite_nonneg_of_eq G Λ p hf i
   · exact truncated2Infinite_nonneg_of_ne G Λ p hf hij
 
+/-- **Upper bound by `correlationInfinite`**: for ferromagnetic `p`,
+`truncated2Infinite G Λ p i j ≤ correlationInfinite G Λ p {i, j}`.
+The product term `⟨σ_i⟩·⟨σ_j⟩` is nonneg by GKS-I, so subtracting it
+from `correlationInfinite {i, j}` reduces the value. -/
+theorem truncated2Infinite_le_correlationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
+    truncated2Infinite G Λ p i j
+      ≤ correlationInfinite G Λ p {i, j} := by
+  unfold truncated2Infinite
+  have hi := correlationInfinite_nonneg G Λ p hf {i}
+  have hj := correlationInfinite_nonneg G Λ p hf {j}
+  have : 0 ≤ correlationInfinite G Λ p {i} * correlationInfinite G Λ p {j} :=
+    mul_nonneg hi hj
+  linarith
+
+/-- **`truncated2Infinite ≤ 1`** for ferromagnetic `p`: from
+`truncated2Infinite_le_correlationInfinite` and
+`correlationInfinite_le_one`. -/
+theorem truncated2Infinite_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
+    truncated2Infinite G Λ p i j ≤ 1 := by
+  have h₁ := truncated2Infinite_le_correlationInfinite G Λ p hf i j
+  have h₂ := correlationInfinite_le_one G Λ p {i, j}
+  linarith
+
 /-- **Exhaustion-independence of `truncated2Infinite`**: the value
 does not depend on the choice of exhaustion.  Follows from
 `correlationInfinite_indep_exhaustion` applied to each of the three

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2619,6 +2619,21 @@ theorem truncated2Infinite_latticeGraph_nonneg_of_eq
   truncated2Infinite_nonneg_of_eq (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p hf i
 
+/-- **ℤ^d `truncated2Infinite ≤ correlationInfinite {i, j}`** (ferromagnetic). -/
+theorem truncated2Infinite_latticeGraph_le_correlationInfinite
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : Fin d → ℤ) :
+    truncated2Infinite (IsingModel.latticeGraph d) Λ p i j
+      ≤ correlationInfinite (IsingModel.latticeGraph d) Λ p {i, j} :=
+  truncated2Infinite_le_correlationInfinite (IsingModel.latticeGraph d) Λ p hf i j
+
+/-- **ℤ^d `truncated2Infinite ≤ 1`** (ferromagnetic). -/
+theorem truncated2Infinite_latticeGraph_le_one
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : Fin d → ℤ) :
+    truncated2Infinite (IsingModel.latticeGraph d) Λ p i j ≤ 1 :=
+  truncated2Infinite_le_one (IsingModel.latticeGraph d) Λ p hf i j
+
 /-- **ℤ^d truncated2Infinite symmetry in (i, j)**. -/
 theorem truncated2Infinite_latticeGraph_symm
     (d : ℕ) (p : IsingParams ℝ) (i j : Fin d → ℤ) :


### PR DESCRIPTION
## Summary
Upper bounds for `truncated2Infinite` (ferromagnetic):

- `Ambient.truncated2Infinite_le_correlationInfinite`: `truncated2Infinite ≤ correlationInfinite {i, j}` (from `nonneg` product term).
- `Ambient.truncated2Infinite_le_one`: `truncated2Infinite ≤ 1`.
- ℤ^d wrappers.

## Test plan
- [ ] lake build
- [ ] GKSTest