### PR TITLE
feat: abs_truncated2Infinite_le_one + neg_one_le + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3178,6 +3178,25 @@ theorem truncated2Infinite_le_one
   have h₂ := correlationInfinite_le_one G Λ p {i, j}
   linarith
 
+/-- **`-1 ≤ truncated2Infinite`** for ferromagnetic `p`: direct from
+`truncated2Infinite_nonneg`. -/
+theorem neg_one_le_truncated2Infinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
+    -1 ≤ truncated2Infinite G Λ p i j := by
+  have := truncated2Infinite_nonneg G Λ p hf i j
+  linarith
+
+/-- **`|truncated2Infinite| ≤ 1`** for ferromagnetic `p`. -/
+theorem abs_truncated2Infinite_le_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
+    |truncated2Infinite G Λ p i j| ≤ 1 :=
+  abs_le.mpr ⟨neg_one_le_truncated2Infinite G Λ p hf i j,
+    truncated2Infinite_le_one G Λ p hf i j⟩
+
 /-- **Exhaustion-independence of `truncated2Infinite`**: the value
 does not depend on the choice of exhaustion.  Follows from
 `correlationInfinite_indep_exhaustion` applied to each of the three

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2634,6 +2634,20 @@ theorem truncated2Infinite_latticeGraph_le_one
     truncated2Infinite (IsingModel.latticeGraph d) Λ p i j ≤ 1 :=
   truncated2Infinite_le_one (IsingModel.latticeGraph d) Λ p hf i j
 
+/-- **ℤ^d `-1 ≤ truncated2Infinite`** (ferromagnetic). -/
+theorem neg_one_le_truncated2Infinite_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : Fin d → ℤ) :
+    -1 ≤ truncated2Infinite (IsingModel.latticeGraph d) Λ p i j :=
+  neg_one_le_truncated2Infinite (IsingModel.latticeGraph d) Λ p hf i j
+
+/-- **ℤ^d `|truncated2Infinite| ≤ 1`** (ferromagnetic). -/
+theorem abs_truncated2Infinite_latticeGraph_le_one
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : Fin d → ℤ) :
+    |truncated2Infinite (IsingModel.latticeGraph d) Λ p i j| ≤ 1 :=
+  abs_truncated2Infinite_le_one (IsingModel.latticeGraph d) Λ p hf i j
+
 /-- **ℤ^d truncated2Infinite symmetry in (i, j)**. -/
 theorem truncated2Infinite_latticeGraph_symm
     (d : ℕ) (p : IsingParams ℝ) (i j : Fin d → ℤ) :


### PR DESCRIPTION
## Summary
- `Ambient.neg_one_le_truncated2Infinite`: from `truncated2Infinite_nonneg` (ferromagnetic).
- `Ambient.abs_truncated2Infinite_le_one`: via `abs_le.mpr` with nonneg + le_one.
- ℤ^d wrappers.

## Test plan
- [ ] lake build
- [ ] GKSTest