### PR TITLE
feat: {partitionFunction,correlation,freeEnergy}Λ apply unfolding lemmas + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -82,6 +82,13 @@ noncomputable def partitionFunctionΛ (G : SimpleGraph V) (Λ : Finset V)
     [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ) : ℝ :=
   IsingModel.partitionFunction (inducedGraph G Λ) p
 
+/-- **Unfolding of `partitionFunctionΛ`**: by construction, equal to
+`IsingModel.partitionFunction (inducedGraph G Λ) p`. -/
+theorem partitionFunctionΛ_apply (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ) :
+    partitionFunctionΛ G Λ p = IsingModel.partitionFunction (inducedGraph G Λ) p :=
+  rfl
+
 /-- The correlation function on a finite volume `Λ`, for a subset
 `A : Finset (↑Λ)` of sites. -/
 noncomputable def correlationΛ (G : SimpleGraph V) (Λ : Finset V)
@@ -89,10 +96,23 @@ noncomputable def correlationΛ (G : SimpleGraph V) (Λ : Finset V)
     (A : Finset (↑Λ : Type _)) : ℝ :=
   IsingModel.correlation (inducedGraph G Λ) p A
 
+/-- **Unfolding of `correlationΛ`**: by construction, equal to
+`IsingModel.correlation (inducedGraph G Λ) p A`. -/
+theorem correlationΛ_apply (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ)
+    (A : Finset (↑Λ : Type _)) :
+    correlationΛ G Λ p A = IsingModel.correlation (inducedGraph G Λ) p A := rfl
+
 /-- The free energy per site on a finite volume `Λ`. -/
 noncomputable def freeEnergyΛ (G : SimpleGraph V) (Λ : Finset V)
     [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ) : ℝ :=
   IsingModel.freeEnergy (inducedGraph G Λ) p
+
+/-- **Unfolding of `freeEnergyΛ`**: by construction, equal to
+`IsingModel.freeEnergy (inducedGraph G Λ) p`. -/
+theorem freeEnergyΛ_apply (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (p : IsingParams ℝ) :
+    freeEnergyΛ G Λ p = IsingModel.freeEnergy (inducedGraph G Λ) p := rfl
 
 /-- **`freeEnergyΛ` as `|Λ|⁻¹ · log Z_Λ`** (named restatement of the
 definition unfolding `IsingModel.freeEnergy := (Fintype.card ι)⁻¹ ·

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -374,6 +374,31 @@ theorem correlationAlongExhaustion_latticeGraph_zero_params_vanish
   correlationAlongExhaustion_zero_params_vanish (IsingModel.latticeGraph d)
     Λ β A hA n
 
+/-- **ℤ^d `partitionFunctionΛ_apply`** unfolding. -/
+theorem partitionFunctionΛ_latticeGraph_apply
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    partitionFunctionΛ (IsingModel.latticeGraph d) Λ p
+      = IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  partitionFunctionΛ_apply (IsingModel.latticeGraph d) Λ p
+
+/-- **ℤ^d `correlationΛ_apply`** unfolding. -/
+theorem correlationΛ_latticeGraph_apply
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)
+    (A : Finset (↑Λ : Type _)) :
+    correlationΛ (IsingModel.latticeGraph d) Λ p A
+      = IsingModel.correlation
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p A :=
+  correlationΛ_apply (IsingModel.latticeGraph d) Λ p A
+
+/-- **ℤ^d `freeEnergyΛ_apply`** unfolding. -/
+theorem freeEnergyΛ_latticeGraph_apply
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    freeEnergyΛ (IsingModel.latticeGraph d) Λ p
+      = IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  freeEnergyΛ_apply (IsingModel.latticeGraph d) Λ p
+
 /-- **ℤ^d `correlationΛ` at `J = 0` closed form**:
 `correlationΛ ⟨0, h, β⟩ A = tanh(β·h)^|A|`. -/
 theorem correlationΛ_latticeGraph_J_zero


### PR DESCRIPTION
## Summary
Named apply-lemmas exposing the definitional `(inducedGraph G Λ)` unfolding for the Λ-level quantities:

- `Ambient.partitionFunctionΛ_apply`
- `Ambient.correlationΛ_apply`
- `Ambient.freeEnergyΛ_apply`

Thin `rfl`-proofs for use in rewrites.

## Test plan
- [ ] lake build
- [ ] GKSTest