### PR TITLE
feat: magnetizationAlongExhaustion of_mem / of_not_mem unfoldings + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1825,6 +1825,28 @@ theorem magnetizationAlongExhaustion_apply
     magnetizationAlongExhaustion G Λ p i n
       = correlationAlongExhaustion G Λ p {i} n := rfl
 
+/-- **Unfolding of `magnetizationAlongExhaustion` when `i ∈ Λ.volume n`**:
+the stagewise value equals the lifted finite-volume correlation. -/
+theorem magnetizationAlongExhaustion_of_mem
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) {i : V} {n : ℕ} (hi : i ∈ Λ.volume n) :
+    magnetizationAlongExhaustion G Λ p i n
+      = correlationΛ G (Λ.volume n) p
+          (liftFinset {i} (Finset.singleton_subset_iff.mpr hi)) :=
+  correlationAlongExhaustion_of_subset G Λ p
+    (Finset.singleton_subset_iff.mpr hi)
+
+/-- **Unfolding of `magnetizationAlongExhaustion` when `i ∉ Λ.volume n`**:
+`magnetizationAlongExhaustion G Λ p i n = 0`. -/
+theorem magnetizationAlongExhaustion_of_not_mem
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) {i : V} {n : ℕ} (hi : i ∉ Λ.volume n) :
+    magnetizationAlongExhaustion G Λ p i n = 0 :=
+  correlationAlongExhaustion_of_not_subset G Λ p
+    (fun hsub => hi (Finset.singleton_subset_iff.mp hsub))
+
 /-- **`magnetizationAlongExhaustion ≤ 1`** per stage for any parameters.
 Direct from `correlationAlongExhaustion_le_one` at `A = {i}`. -/
 theorem magnetizationAlongExhaustion_le_one

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3460,6 +3460,22 @@ theorem magnetizationAlongExhaustion_latticeGraph_apply
       = correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p {i} n :=
   magnetizationAlongExhaustion_apply (IsingModel.latticeGraph d) Λ p i n
 
+/-- **ℤ^d magnetizationAlongExhaustion `of_mem` unfolding**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_of_mem
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) {i : Fin d → ℤ} {n : ℕ} (hi : i ∈ Λ.volume n) :
+    magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i n
+      = correlationΛ (IsingModel.latticeGraph d) (Λ.volume n) p
+          (liftFinset {i} (Finset.singleton_subset_iff.mpr hi)) :=
+  magnetizationAlongExhaustion_of_mem (IsingModel.latticeGraph d) Λ p hi
+
+/-- **ℤ^d magnetizationAlongExhaustion `of_not_mem` unfolding**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_of_not_mem
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) {i : Fin d → ℤ} {n : ℕ} (hi : i ∉ Λ.volume n) :
+    magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i n = 0 :=
+  magnetizationAlongExhaustion_of_not_mem (IsingModel.latticeGraph d) Λ p hi
+
 /-- **ℤ^d magnetizationAlongExhaustion ≤ 1** per stage. -/
 theorem magnetizationAlongExhaustion_latticeGraph_le_one
     (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))


### PR DESCRIPTION
## Summary
Case-split unfoldings for `magnetizationAlongExhaustion`:

- `Ambient.magnetizationAlongExhaustion_of_mem`: `i ∈ Λ.volume n ⇒ = correlationΛ G (Λ.volume n) p (liftFinset {i} _)`.
- `Ambient.magnetizationAlongExhaustion_of_not_mem`: `i ∉ Λ.volume n ⇒ = 0`.
- ℤ^d wrappers.

Specializations of `correlationAlongExhaustion_of_{subset,not_subset}` at `A = {i}` using `Finset.singleton_subset_iff`.

## Test plan
- [ ] lake build
- [ ] GKSTest