### PR TITLE
feat: magnetizationInfinite_apply + freeEnergyInfinite_apply + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2263,6 +2263,15 @@ noncomputable def magnetizationInfinite
     (p : IsingParams ℝ) (i : V) : ℝ :=
   correlationInfinite G Λ p {i}
 
+/-- **Unfolding of `magnetizationInfinite`**:
+`magnetizationInfinite G Λ p i = correlationInfinite G Λ p {i}`,
+by definition. -/
+theorem magnetizationInfinite_apply
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i : V) :
+    magnetizationInfinite G Λ p i = correlationInfinite G Λ p {i} := rfl
+
 /-- **Nonnegativity of `magnetizationInfinite`** (ferromagnetic):
 `0 ≤ magnetizationInfinite G Λ p i`.  Specialization of
 `correlationInfinite_nonneg` at `A = {i}`. -/
@@ -4309,6 +4318,16 @@ noncomputable def freeEnergyInfinite
     [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
     (p : IsingParams ℝ) : ℝ :=
   Filter.limsup (freeEnergyAlongExhaustion G Λ p) Filter.atTop
+
+/-- **Unfolding of `freeEnergyInfinite`**:
+`freeEnergyInfinite G Λ p = limsup (freeEnergyAlongExhaustion G Λ p)`
+at `atTop`, by definition. -/
+theorem freeEnergyInfinite_apply
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) :
+    freeEnergyInfinite G Λ p
+      = Filter.limsup (freeEnergyAlongExhaustion G Λ p) Filter.atTop := rfl
 
 /-- **Zero-params lower-bound comparison for `freeEnergyAlongExhaustion`**.
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3476,6 +3476,23 @@ theorem magnetizationAlongExhaustion_latticeGraph_of_not_mem
     magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i n = 0 :=
   magnetizationAlongExhaustion_of_not_mem (IsingModel.latticeGraph d) Λ p hi
 
+/-- **ℤ^d `magnetizationInfinite_apply`** unfolding. -/
+theorem magnetizationInfinite_latticeGraph_apply
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (i : Fin d → ℤ) :
+    magnetizationInfinite (IsingModel.latticeGraph d) Λ p i
+      = correlationInfinite (IsingModel.latticeGraph d) Λ p {i} :=
+  magnetizationInfinite_apply (IsingModel.latticeGraph d) Λ p i
+
+/-- **ℤ^d `freeEnergyInfinite_apply`** unfolding (limsup form). -/
+theorem freeEnergyInfinite_latticeGraph_apply
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (p : IsingParams ℝ) :
+    freeEnergyInfinite (IsingModel.latticeGraph d) Λ p
+      = Filter.limsup
+          (freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ p)
+          Filter.atTop :=
+  freeEnergyInfinite_apply (IsingModel.latticeGraph d) Λ p
+
 /-- **ℤ^d magnetizationAlongExhaustion ≤ 1** per stage. -/
 theorem magnetizationAlongExhaustion_latticeGraph_le_one
     (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))


### PR DESCRIPTION
## Summary
Named apply-unfoldings at the infinite-volume layer:

- `Ambient.magnetizationInfinite_apply`: `magnetizationInfinite G Λ p i = correlationInfinite G Λ p {i}` by definition.
- `Ambient.freeEnergyInfinite_apply`: `freeEnergyInfinite G Λ p = limsup (freeEnergyAlongExhaustion G Λ p)` by definition.
- ℤ^d wrappers.

## Test plan
- [ ] lake build
- [ ] GKSTest