### PR TITLE
feat: spontaneous{Correlation,Magnetization}_apply + uniform{,Spontaneous}Magnetization_apply

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2861,6 +2861,16 @@ noncomputable def spontaneousCorrelation
     (J β : ℝ) (A : Finset V) : ℝ :=
   ⨅ h : ↥(Set.Ioi (0 : ℝ)), correlationInfinite G Λ ⟨J, h.val, β⟩ A
 
+/-- **Unfolding of `spontaneousCorrelation`** as a named identity:
+`spontaneousCorrelation G Λ J β A = ⨅ h ∈ Ioi 0, correlationInfinite G Λ ⟨J, h, β⟩ A`. -/
+theorem spontaneousCorrelation_apply
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (A : Finset V) :
+    spontaneousCorrelation G Λ J β A
+      = ⨅ h : ↥(Set.Ioi (0 : ℝ)), correlationInfinite G Λ ⟨J, h.val, β⟩ A :=
+  rfl
+
 /-- **Bounded-below witness** for `spontaneousCorrelation`: the family
 `h ↦ correlationInfinite G Λ ⟨J, h, β⟩ A` over `Set.Ioi 0` is bounded
 below by `0` (ferromagnetic). -/
@@ -3000,6 +3010,15 @@ noncomputable def spontaneousMagnetization
     [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
     (J β : ℝ) (i : V) : ℝ :=
   spontaneousCorrelation G Λ J β {i}
+
+/-- **Unfolding of `spontaneousMagnetization`**:
+`spontaneousMagnetization G Λ J β i = spontaneousCorrelation G Λ J β {i}`. -/
+theorem spontaneousMagnetization_apply
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i : V) :
+    spontaneousMagnetization G Λ J β i = spontaneousCorrelation G Λ J β {i} :=
+  rfl
 
 /-- **Agreement at singletons**: `spontaneousCorrelation` on `{i}`
 equals `spontaneousMagnetization`. Holds by definition. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1666,6 +1666,13 @@ noncomputable def uniformMagnetization (d : ℕ) (p : IsingParams ℝ) : ℝ :=
   magnetizationInfinite (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p 0
 
+/-- **Unfolding of `uniformMagnetization`**:
+`uniformMagnetization d p = magnetizationInfinite (latticeGraph d) (cubicExhaustion d) p 0`. -/
+theorem uniformMagnetization_apply (d : ℕ) (p : IsingParams ℝ) :
+    uniformMagnetization d p
+      = magnetizationInfinite (IsingModel.latticeGraph d)
+          (Ambient.cubicExhaustion d) p 0 := rfl
+
 /-- **Bridge**: for ferromagnetic `p` and any site `i : Fin d → ℤ`,
 `magnetizationInfinite ... p i = uniformMagnetization d p`.
 
@@ -1730,6 +1737,14 @@ noncomputable def uniformSpontaneousMagnetization
     (d : ℕ) (J β : ℝ) : ℝ :=
   spontaneousMagnetization (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) J β 0
+
+/-- **Unfolding of `uniformSpontaneousMagnetization`**:
+`uniformSpontaneousMagnetization d J β = spontaneousMagnetization
+(latticeGraph d) (cubicExhaustion d) J β 0`. -/
+theorem uniformSpontaneousMagnetization_apply (d : ℕ) (J β : ℝ) :
+    uniformSpontaneousMagnetization d J β
+      = spontaneousMagnetization (IsingModel.latticeGraph d)
+          (Ambient.cubicExhaustion d) J β 0 := rfl
 
 /-- **J-monotonicity of `uniformSpontaneousMagnetization` on ℤ^d**. -/
 theorem uniformSpontaneousMagnetization_monotone_J


### PR DESCRIPTION
## Summary
Named apply-unfoldings:

- `Ambient.spontaneousCorrelation_apply`: `= ⨅ h > 0, correlationInfinite G Λ ⟨J,h,β⟩ A`.
- `Ambient.spontaneousMagnetization_apply`: `= spontaneousCorrelation G Λ J β {i}`.
- ℤ^d `uniformMagnetization_apply`: `= magnetizationInfinite (latticeGraph d) (cubicExhaustion d) p 0`.
- ℤ^d `uniformSpontaneousMagnetization_apply`.

## Test plan
- [ ] lake build