### PR TITLE
feat: truncated3Infinite swap symmetries + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3409,6 +3409,46 @@ theorem truncated3Infinite_apply
         + 2 * correlationInfinite G Λ p {i} * correlationInfinite G Λ p {j}
           * correlationInfinite G Λ p {k} := rfl
 
+/-- **`truncated3Infinite` symmetry under swapping `i, j`**. The defining
+formula is symmetric in the three site arguments, using that Finsets are
+unordered. -/
+theorem truncated3Infinite_swap_ij
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i j k : V) :
+    truncated3Infinite G Λ p i j k = truncated3Infinite G Λ p j i k := by
+  unfold truncated3Infinite
+  have h1 : ({i, j, k} : Finset V) = {j, i, k} := by
+    rw [Finset.insert_comm]
+  have h2 : ({i, j} : Finset V) = {j, i} := Finset.pair_comm i j
+  rw [h1, h2]
+  ring
+
+/-- **`truncated3Infinite` symmetry under swapping `j, k`**. -/
+theorem truncated3Infinite_swap_jk
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i j k : V) :
+    truncated3Infinite G Λ p i j k = truncated3Infinite G Λ p i k j := by
+  unfold truncated3Infinite
+  have h1 : ({i, j, k} : Finset V) = {i, k, j} := by
+    congr 1
+    exact Finset.pair_comm j k
+  have h2 : ({j, k} : Finset V) = {k, j} := Finset.pair_comm j k
+  rw [h1, h2]
+  ring
+
+/-- **`truncated3Infinite` symmetry under swapping `i, k`**: obtained by
+chaining the `ij` and `jk` swaps. -/
+theorem truncated3Infinite_swap_ik
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i j k : V) :
+    truncated3Infinite G Λ p i j k = truncated3Infinite G Λ p k j i := by
+  rw [truncated3Infinite_swap_ij G Λ p i j k,
+      truncated3Infinite_swap_jk G Λ p j i k,
+      truncated3Infinite_swap_ij G Λ p j k i]
+
 /-- **Truncated 3-point along an exhaustion** (local helper): evaluates
 the `truncated3`-style algebraic expression at the `n`-th volume of
 the exhaustion, using `correlationAlongExhaustion` instead of the

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2152,6 +2152,28 @@ theorem truncated3TwoPoint_apply (d : ℕ) (p : IsingParams ℝ)
       = truncated3Infinite (IsingModel.latticeGraph d)
           (Ambient.cubicExhaustion d) p 0 r s := rfl
 
+/-- **ℤ^d `truncated3Infinite` swap symmetries**. -/
+theorem truncated3Infinite_latticeGraph_swap_ij
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (i j k : Fin d → ℤ) :
+    truncated3Infinite (IsingModel.latticeGraph d) Λ p i j k
+      = truncated3Infinite (IsingModel.latticeGraph d) Λ p j i k :=
+  truncated3Infinite_swap_ij (IsingModel.latticeGraph d) Λ p i j k
+
+theorem truncated3Infinite_latticeGraph_swap_jk
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (i j k : Fin d → ℤ) :
+    truncated3Infinite (IsingModel.latticeGraph d) Λ p i j k
+      = truncated3Infinite (IsingModel.latticeGraph d) Λ p i k j :=
+  truncated3Infinite_swap_jk (IsingModel.latticeGraph d) Λ p i j k
+
+theorem truncated3Infinite_latticeGraph_swap_ik
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (i j k : Fin d → ℤ) :
+    truncated3Infinite (IsingModel.latticeGraph d) Λ p i j k
+      = truncated3Infinite (IsingModel.latticeGraph d) Λ p k j i :=
+  truncated3Infinite_swap_ik (IsingModel.latticeGraph d) Λ p i j k
+
 /-- **Three-point correlation depends only on two separations**:
 for ferromagnetic `p` and any `i, j, k : Fin d → ℤ`,
 


### PR DESCRIPTION
## Summary
Swap symmetries for `truncated3Infinite`:

- `Ambient.truncated3Infinite_swap_ij`: `truncated3Infinite p i j k = truncated3Infinite p j i k`.
- `Ambient.truncated3Infinite_swap_ik`: analogous for (i, k).
- `Ambient.truncated3Infinite_swap_jk`: analogous for (j, k).
- ℤ^d wrappers.

All follow from the symmetric definition + Finset unordered-pair equalities.

## Test plan
- [ ] lake build
- [ ] GKSTest