### PR TITLE
feat: ℤ^d abs_spontaneousCorrelation_le_one + neg_one_le wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -445,6 +445,20 @@ theorem spontaneousCorrelation_latticeGraph_monotone_ambient_subgraph
       ≤ spontaneousCorrelation G₂ Λ J β A :=
   spontaneousCorrelation_monotone_ambient_subgraph hG Λ hJ hβ A
 
+/-- **ℤ^d `-1 ≤ spontaneousCorrelation`** (ferromagnetic). -/
+theorem neg_one_le_spontaneousCorrelation_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset (Fin d → ℤ)) :
+    -1 ≤ spontaneousCorrelation (IsingModel.latticeGraph d) Λ J β A :=
+  neg_one_le_spontaneousCorrelation (IsingModel.latticeGraph d) Λ hJ hβ A
+
+/-- **ℤ^d `|spontaneousCorrelation| ≤ 1`** (ferromagnetic). -/
+theorem abs_spontaneousCorrelation_latticeGraph_le_one
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset (Fin d → ℤ)) :
+    |spontaneousCorrelation (IsingModel.latticeGraph d) Λ J β A| ≤ 1 :=
+  abs_spontaneousCorrelation_le_one (IsingModel.latticeGraph d) Λ hJ hβ A
+
 /-- **ℤ^d `spontaneousMagnetization_monotone_ambient_subgraph`**
 (ferromagnetic). -/
 theorem spontaneousMagnetization_latticeGraph_monotone_ambient_subgraph


### PR DESCRIPTION
## Summary
- `abs_spontaneousCorrelation_latticeGraph_le_one` (ferromagnetic).
- `neg_one_le_spontaneousCorrelation_latticeGraph` (ferromagnetic).

Concrete ℤ^d specializations of PR #409.