### PR TITLE
feat: spontaneous{Correlation,Magnetization}_bot_le_latticeGraph + ℤ^d

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2906,6 +2906,26 @@ theorem magnetizationInfinite_bot_le_latticeGraph
       ≤ magnetizationInfinite (IsingModel.latticeGraph d) Λ p i :=
   magnetizationInfinite_monotone_ambient_subgraph bot_le Λ p hf i
 
+/-- **`⊥` ≤ `latticeGraph d` spontaneousCorrelation monotonicity** on ℤ^d. -/
+theorem spontaneousCorrelation_bot_le_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (⊥ : SimpleGraph (Fin d → ℤ))
+      (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset (Fin d → ℤ)) :
+    spontaneousCorrelation (⊥ : SimpleGraph (Fin d → ℤ)) Λ J β A
+      ≤ spontaneousCorrelation (IsingModel.latticeGraph d) Λ J β A :=
+  spontaneousCorrelation_monotone_ambient_subgraph bot_le Λ hJ hβ A
+
+/-- **`⊥` ≤ `latticeGraph d` spontaneousMagnetization monotonicity** on ℤ^d. -/
+theorem spontaneousMagnetization_bot_le_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (⊥ : SimpleGraph (Fin d → ℤ))
+      (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : Fin d → ℤ) :
+    spontaneousMagnetization (⊥ : SimpleGraph (Fin d → ℤ)) Λ J β i
+      ≤ spontaneousMagnetization (IsingModel.latticeGraph d) Λ J β i :=
+  spontaneousMagnetization_monotone_ambient_subgraph bot_le Λ hJ hβ i
+
 /-- **ℤ^d truncated2Infinite nonneg** (general). -/
 theorem truncated2Infinite_latticeGraph_nonneg
     (d : ℕ) (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : Fin d → ℤ) :


### PR DESCRIPTION
## Summary
ℤ^d `⊥ ≤ latticeGraph d` spontaneous correlation / magnetization bounds (ferromagnetic):

- `spontaneousCorrelation_bot_le_latticeGraph`
- `spontaneousMagnetization_bot_le_latticeGraph`

Specializations of the corresponding `_monotone_ambient_subgraph` lemmas at `bot_le`.

## Test plan
- [ ] lake build
- [ ] GKSTest