### PR TITLE
feat: correlationAlongExhaustion_le_correlationInfinite + magnetization + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -1536,6 +1536,16 @@ theorem correlationInfinite_eq_ciSup
     correlationInfinite G Λ p A
       = ⨆ n, correlationAlongExhaustion G Λ p A n := rfl
 
+/-- **Pointwise bound**: `correlationAlongExhaustion G Λ p A n ≤
+correlationInfinite G Λ p A` at every `n`. Direct from `le_ciSup` +
+`correlationAlongExhaustion_bddAbove`. -/
+theorem correlationAlongExhaustion_le_correlationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (A : Finset V) (n : ℕ) :
+    correlationAlongExhaustion G Λ p A n ≤ correlationInfinite G Λ p A :=
+  le_ciSup (correlationAlongExhaustion_bddAbove G Λ p A) n
+
 /-- **Tendsto to infinite-volume correlation** (primary form):
 `correlationAlongExhaustion` converges to `correlationInfinite`.
 Restatement of `correlationAlongExhaustion_tendsto_ciSup` in terms
@@ -2404,6 +2414,15 @@ theorem magnetizationInfinite_eq_ciSup
     (p : IsingParams ℝ) (i : V) :
     magnetizationInfinite G Λ p i
       = ⨆ n, magnetizationAlongExhaustion G Λ p i n := rfl
+
+/-- **Pointwise bound**: `magnetizationAlongExhaustion G Λ p i n ≤
+magnetizationInfinite G Λ p i` at every `n`. Specialization at `A = {i}`. -/
+theorem magnetizationAlongExhaustion_le_magnetizationInfinite
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (i : V) (n : ℕ) :
+    magnetizationAlongExhaustion G Λ p i n ≤ magnetizationInfinite G Λ p i :=
+  correlationAlongExhaustion_le_correlationInfinite G Λ p {i} n
 
 /-- **Exhaustion-independence of `magnetizationInfinite`**:
 the value does not depend on the choice of exhaustion.  Specialization

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3808,6 +3808,23 @@ theorem correlationInfinite_latticeGraph_eq_ciSup
       = ⨆ n, correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n :=
   correlationInfinite_eq_ciSup (IsingModel.latticeGraph d) Λ p A
 
+/-- **ℤ^d `correlationAlongExhaustion ≤ correlationInfinite`** pointwise. -/
+theorem correlationAlongExhaustion_le_correlationInfinite_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n
+      ≤ correlationInfinite (IsingModel.latticeGraph d) Λ p A :=
+  correlationAlongExhaustion_le_correlationInfinite (IsingModel.latticeGraph d) Λ p A n
+
+/-- **ℤ^d `magnetizationAlongExhaustion ≤ magnetizationInfinite`** pointwise. -/
+theorem magnetizationAlongExhaustion_le_magnetizationInfinite_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ p i n
+      ≤ magnetizationInfinite (IsingModel.latticeGraph d) Λ p i :=
+  magnetizationAlongExhaustion_le_magnetizationInfinite
+    (IsingModel.latticeGraph d) Λ p i n
+
 /-- **ℤ^d magnetizationΛ h-monotonicity**: `MonotoneOn` in `h` on `Ici 0`. -/
 theorem magnetizationΛ_latticeGraph_monotone_h
     (d : ℕ) (Λ : Finset (Fin d → ℤ))


### PR DESCRIPTION
## Summary
Pointwise bound: `correlationAlongExhaustion G Λ p A n ≤ correlationInfinite G Λ p A` via `le_ciSup` + `correlationAlongExhaustion_bddAbove`.

- `Ambient.correlationAlongExhaustion_le_correlationInfinite`
- `Ambient.magnetizationAlongExhaustion_le_magnetizationInfinite`
- ℤ^d wrappers.

## Test plan
- [ ] lake build
- [ ] GKSTest