### PR TITLE
feat: ℤ^d magnetizationInfinite_latticeGraph_monotone_{J,h,beta} wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3649,6 +3649,33 @@ theorem magnetizationInfinite_latticeGraph_nonneg
     0 ≤ magnetizationInfinite (IsingModel.latticeGraph d) Λ p i :=
   magnetizationInfinite_nonneg (IsingModel.latticeGraph d) Λ p hf i
 
+/-- **ℤ^d magnetizationInfinite J-monotonicity** (any Exhaustion). -/
+theorem magnetizationInfinite_latticeGraph_monotone_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β) (i : Fin d → ℤ) :
+    MonotoneOn
+      (fun J : ℝ => magnetizationInfinite (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩ i)
+      (Set.Ici 0) :=
+  magnetizationInfinite_monotone_J (IsingModel.latticeGraph d) Λ hh hβ i
+
+/-- **ℤ^d magnetizationInfinite h-monotonicity** (any Exhaustion). -/
+theorem magnetizationInfinite_latticeGraph_monotone_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : Fin d → ℤ) :
+    MonotoneOn
+      (fun h : ℝ => magnetizationInfinite (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩ i)
+      (Set.Ici 0) :=
+  magnetizationInfinite_monotone_h (IsingModel.latticeGraph d) Λ hJ hβ i
+
+/-- **ℤ^d magnetizationInfinite β-monotonicity** (any Exhaustion). -/
+theorem magnetizationInfinite_latticeGraph_monotone_beta
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {h : ℝ} (hh : 0 ≤ h) (i : Fin d → ℤ) :
+    MonotoneOn
+      (fun β : ℝ => magnetizationInfinite (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩ i)
+      (Set.Ioi 0) :=
+  magnetizationInfinite_monotone_beta (IsingModel.latticeGraph d) Λ hJ hh i
+
 /-- **ℤ^d `|magnetizationInfinite| ≤ 1`** site-wise (any Exhaustion, ferromagnetic):
 combines `magnetizationInfinite_latticeGraph_nonneg` (so `0 ≤ M`, hence
 `-1 ≤ M`) with `magnetizationInfinite_latticeGraph_le_one`. -/


### PR DESCRIPTION
## Summary
ℤ^d concrete wrappers (over any Exhaustion) for `magnetizationInfinite` parameter monotonicities:

- `magnetizationInfinite_latticeGraph_monotone_J`
- `magnetizationInfinite_latticeGraph_monotone_h`
- `magnetizationInfinite_latticeGraph_monotone_beta`

## Test plan
- [ ] lake build
- [ ] GKSTest