### PR TITLE
feat: ℤ^d correlationInfinite_latticeGraph_monotone_{J,h,beta} any-Exhaustion wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3676,6 +3676,33 @@ theorem magnetizationInfinite_latticeGraph_monotone_beta
       (Set.Ioi 0) :=
   magnetizationInfinite_monotone_beta (IsingModel.latticeGraph d) Λ hJ hh i
 
+/-- **ℤ^d correlationInfinite J-monotonicity** (any Exhaustion). -/
+theorem correlationInfinite_latticeGraph_monotone_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β) (A : Finset (Fin d → ℤ)) :
+    MonotoneOn
+      (fun J : ℝ => correlationInfinite (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩ A)
+      (Set.Ici 0) :=
+  correlationInfinite_monotone_J (IsingModel.latticeGraph d) Λ hh hβ A
+
+/-- **ℤ^d correlationInfinite h-monotonicity** (any Exhaustion). -/
+theorem correlationInfinite_latticeGraph_monotone_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset (Fin d → ℤ)) :
+    MonotoneOn
+      (fun h : ℝ => correlationInfinite (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩ A)
+      (Set.Ici 0) :=
+  correlationInfinite_monotone_h (IsingModel.latticeGraph d) Λ hJ hβ A
+
+/-- **ℤ^d correlationInfinite β-monotonicity** (any Exhaustion). -/
+theorem correlationInfinite_latticeGraph_monotone_beta
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {h : ℝ} (hh : 0 ≤ h) (A : Finset (Fin d → ℤ)) :
+    MonotoneOn
+      (fun β : ℝ => correlationInfinite (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩ A)
+      (Set.Ioi 0) :=
+  correlationInfinite_monotone_beta (IsingModel.latticeGraph d) Λ hJ hh A
+
 /-- **ℤ^d `|magnetizationInfinite| ≤ 1`** site-wise (any Exhaustion, ferromagnetic):
 combines `magnetizationInfinite_latticeGraph_nonneg` (so `0 ≤ M`, hence
 `-1 ≤ M`) with `magnetizationInfinite_latticeGraph_le_one`. -/


### PR DESCRIPTION
## Summary
ℤ^d wrappers (over any Exhaustion) for `correlationInfinite` parameter monotonicities:

- `correlationInfinite_latticeGraph_monotone_J`
- `correlationInfinite_latticeGraph_monotone_h`
- `correlationInfinite_latticeGraph_monotone_beta`

Complements the existing `_cubicExhaustion_monotone_{J,h,beta}` forms.