### PR TITLE
feat: magnetization{Λ,Infinite}_ge_tanh (ferromagnetic) + ℤ^d

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -2512,6 +2512,18 @@ theorem correlationΛ_ge_tanh_pow_card
   exact correlationΛ_monotone_J G Λ hh hβ A
     (Set.mem_Ici.mpr le_rfl) (Set.mem_Ici.mpr hJ) hJ
 
+/-- **Λ-level lower bound `magnetizationΛ ≥ tanh(β·h)`** (ferromagnetic):
+specialization of `correlationΛ_ge_tanh_pow_card` at `A = {i}` where
+`|A|^1 = |A|.card = 1`. -/
+theorem magnetizationΛ_ge_tanh
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (i : ↑Λ) :
+    Real.tanh (β * h)
+      ≤ magnetizationΛ G Λ (⟨J, h, β⟩ : IsingParams ℝ) i := by
+  have := correlationΛ_ge_tanh_pow_card G Λ hJ hh hβ ({i} : Finset (↑Λ : Type _))
+  simpa [Finset.card_singleton] using this
+
 /-- **Z₂ symmetry at `h = 0` for `correlationAlongExhaustion`**:
 pointwise zero at every `n`.  Either `A ⊄ Λ.volume n` (both branches
 of the dite give `0`) or `A ⊆ Λ.volume n` and the lifted correlation
@@ -2646,6 +2658,18 @@ theorem correlationInfinite_ge_tanh_pow_card
   rw [← h_zero]
   exact correlationInfinite_monotone_J G Λ hh hβ A
     (Set.mem_Ici.mpr le_rfl) (Set.mem_Ici.mpr hJ) hJ
+
+/-- **∞-volume lower bound `magnetizationInfinite ≥ tanh(β·h)`**
+(ferromagnetic): specialization of `correlationInfinite_ge_tanh_pow_card`
+at `A = {i}`. -/
+theorem magnetizationInfinite_ge_tanh
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (i : V) :
+    Real.tanh (β * h)
+      ≤ magnetizationInfinite G Λ (⟨J, h, β⟩ : IsingParams ℝ) i := by
+  have := correlationInfinite_ge_tanh_pow_card G Λ hJ hh hβ ({i} : Finset V)
+  simpa [Finset.card_singleton] using this
 
 /-- **Empty-set correlation on `Λ` is `1`** (normalization). -/
 @[simp]

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -533,6 +533,25 @@ theorem correlationInfinite_latticeGraph_ge_tanh_pow_card
           (⟨J, h, β⟩ : IsingParams ℝ) A :=
   correlationInfinite_ge_tanh_pow_card (IsingModel.latticeGraph d) Λ hJ hh hβ A
 
+/-- **ℤ^d `magnetizationΛ ≥ tanh(β·h)`** (ferromagnetic). -/
+theorem magnetizationΛ_latticeGraph_ge_tanh
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (i : ↑Λ) :
+    Real.tanh (β * h)
+      ≤ magnetizationΛ (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β⟩ : IsingParams ℝ) i :=
+  magnetizationΛ_ge_tanh (IsingModel.latticeGraph d) Λ hJ hh hβ i
+
+/-- **ℤ^d `magnetizationInfinite ≥ tanh(β·h)`** (ferromagnetic, any Exhaustion). -/
+theorem magnetizationInfinite_latticeGraph_ge_tanh
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (i : Fin d → ℤ) :
+    Real.tanh (β * h)
+      ≤ magnetizationInfinite (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β⟩ : IsingParams ℝ) i :=
+  magnetizationInfinite_ge_tanh (IsingModel.latticeGraph d) Λ hJ hh hβ i
+
+
 /-- **ℤ^d `correlationAlongExhaustion` at `J = 0`** per stage (on-stage):
 `A ⊆ Λ.volume n ⇒ = tanh(β·h)^|A|`. -/
 theorem correlationAlongExhaustion_latticeGraph_J_zero_of_subset
@@ -1713,6 +1732,14 @@ theorem uniformMagnetization_apply (d : ℕ) (p : IsingParams ℝ) :
     uniformMagnetization d p
       = magnetizationInfinite (IsingModel.latticeGraph d)
           (Ambient.cubicExhaustion d) p 0 := rfl
+
+/-- **ℤ^d `uniformMagnetization ≥ tanh(β·h)`** (ferromagnetic). -/
+theorem uniformMagnetization_ge_tanh
+    (d : ℕ) {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.tanh (β * h)
+      ≤ uniformMagnetization d (⟨J, h, β⟩ : IsingParams ℝ) :=
+  magnetizationInfinite_ge_tanh (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hh hβ 0
 
 /-- **`uniformMagnetization` equals `magnetizationInfinite` under any
 Exhaustion** (ferromagnetic): bridges the fixed-`cubicExhaustion` form


### PR DESCRIPTION
## Summary
Ferromagnetic sharp lower bound `M ≥ tanh(β·h)` at single-site, from `correlation_ge_tanh_pow_card` at `A = {i}` (so `|A|^1 = |A|`):

- `Ambient.magnetizationΛ_ge_tanh`
- `Ambient.magnetizationInfinite_ge_tanh`
- `uniformMagnetization_ge_tanh` at ℤ^d.

## Test plan
- [ ] lake build
- [ ] GKSTest