### PR TITLE
feat: ℤ^d log_partitionFunctionAlongExhaustion any-Exhaustion wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1208,6 +1208,76 @@ theorem freeEnergyAlongExhaustion_latticeGraph_monotone_beta
       (Set.Ioi 0) :=
   freeEnergyAlongExhaustion_monotone_beta (IsingModel.latticeGraph d) Λ hJ hh n
 
+/-- **ℤ^d log_partitionFunctionAlongExhaustion h-evenness** (any Exhaustion). -/
+theorem log_partitionFunctionAlongExhaustion_latticeGraph_neg_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h β : ℝ) (n : ℕ) :
+    Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, -h, β⟩ : IsingParams ℝ) n)
+      = Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β⟩ : IsingParams ℝ) n) :=
+  log_partitionFunctionAlongExhaustion_neg_h
+    (IsingModel.latticeGraph d) Λ J h β n
+
+/-- **ℤ^d log_partitionFunctionAlongExhaustion `|h|`-rewrite** (any Exhaustion). -/
+theorem log_partitionFunctionAlongExhaustion_latticeGraph_eq_abs_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h β : ℝ) (n : ℕ) :
+    Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β⟩ : IsingParams ℝ) n)
+      = Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨J, |h|, β⟩ : IsingParams ℝ) n) :=
+  log_partitionFunctionAlongExhaustion_eq_abs_h
+    (IsingModel.latticeGraph d) Λ J h β n
+
+/-- **ℤ^d log_partitionFunctionAlongExhaustion J-monotonicity** (any Exhaustion). -/
+theorem log_partitionFunctionAlongExhaustion_latticeGraph_monotone_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (h β : ℝ) (hh : 0 ≤ h) (hβ : 0 < β) {J₁ J₂ : ℝ}
+    (hJ₁ : 0 ≤ J₁) (hJ : J₁ ≤ J₂) (n : ℕ) :
+    Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J₁, h, β⟩ : IsingParams ℝ) n)
+      ≤ Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨J₂, h, β⟩ : IsingParams ℝ) n) :=
+  log_partitionFunctionAlongExhaustion_monotone_J
+    (IsingModel.latticeGraph d) Λ h β hh hβ hJ₁ hJ n
+
+/-- **ℤ^d log_partitionFunctionAlongExhaustion h-monotonicity** (any Exhaustion). -/
+theorem log_partitionFunctionAlongExhaustion_latticeGraph_monotone_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β) {h₁ h₂ : ℝ}
+    (hh₁ : 0 ≤ h₁) (hh : h₁ ≤ h₂) (n : ℕ) :
+    Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h₁, β⟩ : IsingParams ℝ) n)
+      ≤ Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨J, h₂, β⟩ : IsingParams ℝ) n) :=
+  log_partitionFunctionAlongExhaustion_monotone_h
+    (IsingModel.latticeGraph d) Λ J β hJ hβ hh₁ hh n
+
+/-- **ℤ^d log_partitionFunctionAlongExhaustion β-monotonicity** (any Exhaustion). -/
+theorem log_partitionFunctionAlongExhaustion_latticeGraph_monotone_beta
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h : ℝ) (hJ : 0 ≤ J) (hh : 0 ≤ h) {β₁ β₂ : ℝ}
+    (hβ₁ : 0 < β₁) (hβ : β₁ ≤ β₂) (n : ℕ) :
+    Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β₁⟩ : IsingParams ℝ) n)
+      ≤ Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β₂⟩ : IsingParams ℝ) n) :=
+  log_partitionFunctionAlongExhaustion_monotone_beta
+    (IsingModel.latticeGraph d) Λ J h hJ hh hβ₁ hβ n
+
+/-- **ℤ^d log_partitionFunctionAlongExhaustion `|h|`-monotonicity** (any Exhaustion). -/
+theorem log_partitionFunctionAlongExhaustion_latticeGraph_monotone_abs_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh : |h₁| ≤ |h₂|) (n : ℕ) :
+    Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h₁, β⟩ : IsingParams ℝ) n)
+      ≤ Real.log (partitionFunctionAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨J, h₂, β⟩ : IsingParams ℝ) n) :=
+  log_partitionFunctionAlongExhaustion_monotone_abs_h
+    (IsingModel.latticeGraph d) Λ J β hJ hβ hh n
+
 /-- **ℤ^d freeEnergyAlongExhaustion ≥ zero_params**: `f(0,0,β) ≤ f(J,h,β)`. -/
 theorem freeEnergyAlongExhaustion_latticeGraph_ge_zero_params
     (d : ℕ) {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (n : ℕ) :


### PR DESCRIPTION
## Summary
Any-Exhaustion log-Z wrappers:

- `log_partitionFunctionAlongExhaustion_latticeGraph_neg_h`
- `log_partitionFunctionAlongExhaustion_latticeGraph_eq_abs_h`
- `log_partitionFunctionAlongExhaustion_latticeGraph_monotone_J/h/beta/abs_h`

## Test plan
- [ ] lake build