### PR TITLE
feat: ℤ^d partitionFunction{Λ,AlongExhaustion}_monotone_ambient_subgraph

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3193,6 +3193,27 @@ theorem freeEnergyAlongExhaustion_latticeGraph_monotone_ambient_subgraph
       ≤ freeEnergyAlongExhaustion G₂ Λ p n :=
   freeEnergyAlongExhaustion_monotone_ambient_subgraph hG Λ p hf n
 
+/-- **ℤ^d partitionFunctionΛ ambient-subgraph monotonicity** (ferromagnetic). -/
+theorem partitionFunctionΛ_latticeGraph_monotone_ambient_subgraph
+    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (hG : G₁ ≤ G₂)
+    (Λ : Finset (Fin d → ℤ))
+    [Fintype (Ambient.inducedGraph G₁ Λ).edgeSet]
+    [Fintype (Ambient.inducedGraph G₂ Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunctionΛ G₁ Λ p ≤ partitionFunctionΛ G₂ Λ p :=
+  partitionFunctionΛ_monotone_ambient_subgraph hG Λ p hf
+
+/-- **ℤ^d partitionFunctionAlongExhaustion ambient-subgraph monotonicity** per stage. -/
+theorem partitionFunctionAlongExhaustion_latticeGraph_monotone_ambient_subgraph
+    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (hG : G₁ ≤ G₂)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (Ambient.inducedGraph G₂ (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (n : ℕ) :
+    partitionFunctionAlongExhaustion G₁ Λ p n
+      ≤ partitionFunctionAlongExhaustion G₂ Λ p n :=
+  partitionFunctionAlongExhaustion_monotone_ambient_subgraph hG Λ p hf n
+
 /-- **ℤ^d `log Z_{Λ_n}` ambient-subgraph `⊥ ≤ latticeGraph d`** per stage
 (ferromagnetic, `cubicExhaustion`). -/
 theorem log_partitionFunctionAlongExhaustion_bot_le_latticeGraph


### PR DESCRIPTION
## Summary
ℤ^d ambient-subgraph monotonicity at Z-level (ferromagnetic):

- `partitionFunctionΛ_latticeGraph_monotone_ambient_subgraph`
- `partitionFunctionAlongExhaustion_latticeGraph_monotone_ambient_subgraph`

## Test plan
- [ ] lake build