### PR TITLE
feat: freeEnergyAlongExhaustion_nonneg (ferromagnetic) + ℤ^d

### DIFF
--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -223,6 +223,16 @@ theorem freeEnergyΛ_nonneg_of_ferromagnetic
   IsingModel.freeEnergy_nonneg_of_ferromagnetic
     (inducedGraph G Λ) p hf hne.fintype_card_coe_pos
 
+/-- **Per-stage `freeEnergyAlongExhaustion ≥ 0`** (ferromagnetic, nonempty stage):
+direct from `freeEnergyΛ_nonneg_of_ferromagnetic` at `Λ.volume n`. -/
+theorem freeEnergyAlongExhaustion_nonneg_of_ferromagnetic
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {n : ℕ}
+    (hne : (Λ.volume n).Nonempty) :
+    0 ≤ freeEnergyAlongExhaustion G Λ p n :=
+  freeEnergyΛ_nonneg_of_ferromagnetic G hne p hf
+
 /-- **Λ-level free-energy closed form at `J = 0`**:
 for nonempty `Λ` and any ambient graph `G`,
 `freeEnergyΛ G Λ ⟨0, h, β⟩ = log(2·cosh(β·h))`. Thin wrapper of

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1981,6 +1981,15 @@ theorem freeEnergyAlongExhaustion_latticeGraph_ge_log_two_cosh
   freeEnergyAlongExhaustion_ge_log_two_cosh (IsingModel.latticeGraph d) Λ
     hJ hh hβ n hne
 
+/-- **ℤ^d per-stage `0 ≤ f_n`** (ferromagnetic, nonempty stage, any Exhaustion). -/
+theorem freeEnergyAlongExhaustion_latticeGraph_nonneg
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {n : ℕ}
+    (hne : (Λ.volume n).Nonempty) :
+    0 ≤ freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ p n :=
+  freeEnergyAlongExhaustion_nonneg_of_ferromagnetic
+    (IsingModel.latticeGraph d) Λ p hf hne
+
 /-- **ℤ^d free-energy shift invariance**:
 `freeEnergyInfinite (latticeGraph d) ((cubicExhaustion d).shift t) p
   = freeEnergyInfinite (latticeGraph d) (cubicExhaustion d) p`. -/


### PR DESCRIPTION
## Summary
- `Ambient.freeEnergyAlongExhaustion_nonneg_of_ferromagnetic`: per-stage `0 ≤ f_n` for ferromagnetic on nonempty `Λ.volume n`.
- ℤ^d wrapper.