### PR TITLE
feat: ℤ^d freeEnergyInfinite_latticeGraph_pos/_nonneg any-Exhaustion

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -854,6 +854,32 @@ theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_nonneg
       (Ambient.cubicExhaustion d) p :=
   (freeEnergyInfinite_latticeGraph_cubicExhaustion_pos d p hf).le
 
+/-- **ℤ^d freeEnergyInfinite strictly positive** (ferromagnetic, any Exhaustion). -/
+theorem freeEnergyInfinite_latticeGraph_pos
+    (d : ℕ) [Nonempty (Fin d → ℤ)]
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((Ambient.inducedGraph (IsingModel.latticeGraph d)
+          (Λ.volume n)).edgeFinset.card : ℝ)
+        ≤ c * Fintype.card (↑(Λ.volume n) : Type _)) :
+    0 < freeEnergyInfinite (IsingModel.latticeGraph d) Λ p :=
+  freeEnergyInfinite_pos (IsingModel.latticeGraph d) Λ p hf (c := c) hc
+
+/-- **ℤ^d freeEnergyInfinite nonnegative** (ferromagnetic, any Exhaustion). -/
+theorem freeEnergyInfinite_latticeGraph_nonneg
+    (d : ℕ) [Nonempty (Fin d → ℤ)]
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((Ambient.inducedGraph (IsingModel.latticeGraph d)
+          (Λ.volume n)).edgeFinset.card : ℝ)
+        ≤ c * Fintype.card (↑(Λ.volume n) : Type _)) :
+    0 ≤ freeEnergyInfinite (IsingModel.latticeGraph d) Λ p :=
+  (freeEnergyInfinite_latticeGraph_pos d Λ p hf hc).le
+
 /-- **log Z → ∞ along cubicExhaustion** (ferromagnetic, infinite ℤ^d). -/
 theorem log_partitionFunctionAlongExhaustion_latticeGraph_tendsto_atTop
     (d : ℕ) [Infinite (Fin d → ℤ)]


### PR DESCRIPTION
## Summary
Any-Exhaustion versions:

- `freeEnergyInfinite_latticeGraph_pos`: `0 < f_∞` (ferromagnetic).
- `freeEnergyInfinite_latticeGraph_nonneg`: `0 ≤ f_∞`.

## Test plan
- [ ] lake build