### PR TITLE
feat: ℤ^d freeEnergyInfinite_latticeGraph_ge_log_two_cosh any-Exhaustion

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2984,6 +2984,22 @@ theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_ge_log_two_cosh
   exact inducedLatticeGraph_card_edgeFinset_le d
     ((Ambient.cubicExhaustion d).volume n)
 
+/-- **Sharp lower bound** `freeEnergyInfinite ≥ log(2 cosh(βh))` on ℤ^d
+(any Exhaustion with caller-supplied BED). -/
+theorem freeEnergyInfinite_latticeGraph_ge_log_two_cosh
+    (d : ℕ) [Nonempty (Fin d → ℤ)]
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    {c : ℝ}
+    (hc : ∀ n, (Λ.volume n).Nonempty →
+      ((Ambient.inducedGraph (IsingModel.latticeGraph d)
+          (Λ.volume n)).edgeFinset.card : ℝ)
+        ≤ c * Fintype.card (↑(Λ.volume n) : Type _)) :
+    Real.log (2 * Real.cosh (p.β * p.h))
+      ≤ freeEnergyInfinite (IsingModel.latticeGraph d) Λ p :=
+  freeEnergyInfinite_ge_log_two_cosh (IsingModel.latticeGraph d)
+    Λ p hf (c := c) hc
+
 /-- **ℤ^d ∞-vol free-energy sandwich bound** (ferromagnetic):
 `log 2 ≤ freeEnergyInfinite (latticeGraph d) (cubicExhaustion d) p
   ≤ log 2 + |β|·(|J|·d + |h|)`.


### PR DESCRIPTION
## Summary
Any-Exhaustion version with explicit BED parameter.