### PR TITLE
feat: ℤ^d correlationAlongExhaustion_latticeGraph bddAbove / convergent / monotone

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -4661,6 +4661,32 @@ theorem correlationAlongExhaustion_latticeGraph_bddBelow
       (correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A)) :=
   correlationAlongExhaustion_bddBelow (IsingModel.latticeGraph d) Λ p A
 
+/-- **ℤ^d `correlationAlongExhaustion` bounded above** (unconditional). -/
+theorem correlationAlongExhaustion_latticeGraph_bddAbove
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) :
+    BddAbove (Set.range
+      (correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A)) :=
+  correlationAlongExhaustion_bddAbove (IsingModel.latticeGraph d) Λ p A
+
+/-- **ℤ^d `correlationAlongExhaustion` monotone** (ferromagnetic):
+volume-increasing ⇒ correlation nondecreasing. -/
+theorem correlationAlongExhaustion_latticeGraph_monotone
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (A : Finset (Fin d → ℤ)) :
+    Monotone (correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A) :=
+  correlationAlongExhaustion_monotone (IsingModel.latticeGraph d) Λ p hf A
+
+/-- **ℤ^d `correlationAlongExhaustion` existential convergence**
+(ferromagnetic). -/
+theorem correlationAlongExhaustion_latticeGraph_convergent
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (A : Finset (Fin d → ℤ)) :
+    ∃ L : ℝ, Filter.Tendsto
+      (correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A)
+      Filter.atTop (nhds L) :=
+  correlationAlongExhaustion_convergent (IsingModel.latticeGraph d) Λ p hf A
+
 /-- **ℤ^d `magnetizationAlongExhaustion` bounded below** (unconditional). -/
 theorem magnetizationAlongExhaustion_latticeGraph_bddBelow
     (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))


### PR DESCRIPTION
any-Exhaustion ℤ^d wrappers for correlationAlongExhaustion_bddAbove, correlationAlongExhaustion_convergent, correlationAlongExhaustion_monotone.