### PR TITLE
feat: ℤ^d freeEnergyInfinite_latticeGraph_eq_of_tendsto / of_eventually_const (any-Exhaustion)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2168,6 +2168,25 @@ theorem freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_J_zero
   freeEnergyAlongExhaustion_J_zero (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) h β n hne
 
+/-- **ℤ^d freeEnergyInfinite from convergence** (any-Exhaustion): if
+`freeEnergyAlongExhaustion` tendsto `L`, then `freeEnergyInfinite = L`. -/
+theorem freeEnergyInfinite_latticeGraph_eq_of_tendsto
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) {L : ℝ}
+    (h : Filter.Tendsto (freeEnergyAlongExhaustion (IsingModel.latticeGraph d)
+      Λ p) Filter.atTop (nhds L)) :
+    freeEnergyInfinite (IsingModel.latticeGraph d) Λ p = L :=
+  freeEnergyInfinite_eq_of_tendsto (IsingModel.latticeGraph d) Λ p h
+
+/-- **ℤ^d freeEnergyInfinite of eventually constant sequence** (any-Exhaustion). -/
+theorem freeEnergyInfinite_latticeGraph_of_eventually_const
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) {c : ℝ}
+    (h : ∀ᶠ n in Filter.atTop, freeEnergyAlongExhaustion
+      (IsingModel.latticeGraph d) Λ p n = c) :
+    freeEnergyInfinite (IsingModel.latticeGraph d) Λ p = c :=
+  freeEnergyInfinite_of_eventually_const (IsingModel.latticeGraph d) Λ p h
+
 /-- **ℤ^d freeEnergyInfinite from convergence**: if
 `freeEnergyAlongExhaustion` tendsto `L`, then `freeEnergyInfinite = L`. -/
 theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_eq_of_tendsto


### PR DESCRIPTION
any-Exhaustion ℤ^d wrappers for freeEnergyInfinite_eq_of_tendsto and freeEnergyInfinite_of_eventually_const.