### PR TITLE
feat: ℤ^d freeEnergyΛ weighted super-add + partitionFunctionΛ disjoint-union bounds

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -947,6 +947,46 @@ theorem card_mul_freeEnergyΛ_latticeGraph_eq_log_partitionFunctionΛ_of_nonempt
   card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty
     (IsingModel.latticeGraph d) hne p
 
+/-- **ℤ^d weighted super-additivity of `freeEnergyΛ` on disjoint unions**
+(ferromagnetic). -/
+theorem freeEnergyΛ_latticeGraph_weighted_super_additive_of_nonempty
+    (d : ℕ) {Λ₁ Λ₂ : Finset (Fin d → ℤ)}
+    (hne₁ : Λ₁.Nonempty) (hne₂ : Λ₂.Nonempty) (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ₁).edgeSet]
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ₂).edgeSet]
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Λ₁.card : ℝ) * freeEnergyΛ (IsingModel.latticeGraph d) Λ₁ p
+      + (Λ₂.card : ℝ) * freeEnergyΛ (IsingModel.latticeGraph d) Λ₂ p
+    ≤ ((Λ₁ ∪ Λ₂).card : ℝ)
+        * freeEnergyΛ (IsingModel.latticeGraph d) (Λ₁ ∪ Λ₂) p :=
+  freeEnergyΛ_weighted_super_additive_of_nonempty
+    (IsingModel.latticeGraph d) hne₁ hne₂ hd p hf
+
+/-- **ℤ^d `log Z_{Λ₁} ≤ log Z_{Λ₁ ∪ Λ₂}`** on disjoint unions (ferromagnetic). -/
+theorem log_partitionFunctionΛ_latticeGraph_le_of_disjoint_union
+    (d : ℕ) {Λ₁ Λ₂ : Finset (Fin d → ℤ)} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ₁).edgeSet]
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Real.log (partitionFunctionΛ (IsingModel.latticeGraph d) Λ₁ p)
+      ≤ Real.log (partitionFunctionΛ (IsingModel.latticeGraph d) (Λ₁ ∪ Λ₂) p) := by
+  classical
+  exact log_partitionFunctionΛ_le_of_disjoint_union
+    (IsingModel.latticeGraph d) hd p hf
+
+/-- **ℤ^d `Z_{Λ₁} ≤ Z_{Λ₁ ∪ Λ₂}`** on disjoint unions (ferromagnetic). -/
+theorem partitionFunctionΛ_latticeGraph_le_of_disjoint_union
+    (d : ℕ) {Λ₁ Λ₂ : Finset (Fin d → ℤ)} (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ₁).edgeSet]
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    partitionFunctionΛ (IsingModel.latticeGraph d) Λ₁ p
+      ≤ partitionFunctionΛ (IsingModel.latticeGraph d) (Λ₁ ∪ Λ₂) p := by
+  classical
+  exact partitionFunctionΛ_le_of_disjoint_union
+    (IsingModel.latticeGraph d) hd p hf
+
 /-- **ℤ^d log partitionFunctionAlongExhaustion volume-monotonicity**
 (ferromagnetic, any-Exhaustion). -/
 theorem log_partitionFunctionAlongExhaustion_latticeGraph_monotone_volume


### PR DESCRIPTION
ℤ^d wrappers for freeEnergyΛ_weighted_super_additive_of_nonempty, log_partitionFunctionΛ_le_of_disjoint_union, and partitionFunctionΛ_le_of_disjoint_union.