### PR TITLE
feat: ℤ^d partitionFunctionAlongExhaustion_latticeGraph_tendsto_atTop (any-Exhaustion)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1125,6 +1125,18 @@ theorem log_partitionFunctionAlongExhaustion_latticeGraph_tendsto_atTop
   log_partitionFunctionAlongExhaustion_tendsto_atTop
     (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d) p hf
 
+/-- **Z → ∞ along any-Exhaustion** (ferromagnetic, infinite ℤ^d). -/
+theorem partitionFunctionAlongExhaustion_latticeGraph_tendsto_atTop_general
+    (d : ℕ) [Infinite (Fin d → ℤ)]
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Filter.Tendsto
+      (fun n => partitionFunctionAlongExhaustion (IsingModel.latticeGraph d)
+        Λ p n)
+      Filter.atTop Filter.atTop :=
+  partitionFunctionAlongExhaustion_tendsto_atTop
+    (IsingModel.latticeGraph d) Λ p hf
+
 /-- **Z → ∞ along cubicExhaustion** (ferromagnetic, infinite ℤ^d). -/
 theorem partitionFunctionAlongExhaustion_latticeGraph_tendsto_atTop
     (d : ℕ) [Infinite (Fin d → ℤ)]


### PR DESCRIPTION
any-Exhaustion ℤ^d wrapper for partitionFunctionAlongExhaustion_tendsto_atTop.