### PR TITLE
feat: ℤ^d card_mul_freeEnergyΛ_le_of_disjoint_union

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1017,6 +1017,21 @@ theorem card_mul_freeEnergyΛ_latticeGraph_eq_log_partitionFunctionΛ_of_nonempt
   card_mul_freeEnergyΛ_eq_log_partitionFunctionΛ_of_nonempty
     (IsingModel.latticeGraph d) hne p
 
+/-- **ℤ^d weighted monotonicity of `freeEnergyΛ` on disjoint unions**
+(ferromagnetic): `|Λ₁|·f_{Λ₁} ≤ |Λ₁ ∪ Λ₂|·f_{Λ₁ ∪ Λ₂}`. -/
+theorem card_mul_freeEnergyΛ_latticeGraph_le_of_disjoint_union
+    (d : ℕ) {Λ₁ Λ₂ : Finset (Fin d → ℤ)}
+    (hne₁ : Λ₁.Nonempty) (hd : Disjoint Λ₁ Λ₂)
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ₁).edgeSet]
+    [Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d) (Λ₁ ∪ Λ₂)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Λ₁.card : ℝ) * freeEnergyΛ (IsingModel.latticeGraph d) Λ₁ p
+      ≤ ((Λ₁ ∪ Λ₂).card : ℝ)
+          * freeEnergyΛ (IsingModel.latticeGraph d) (Λ₁ ∪ Λ₂) p := by
+  classical
+  exact card_mul_freeEnergyΛ_le_of_disjoint_union
+    (IsingModel.latticeGraph d) hne₁ hd p hf
+
 /-- **ℤ^d weighted super-additivity of `freeEnergyΛ` on disjoint unions**
 (ferromagnetic). -/
 theorem freeEnergyΛ_latticeGraph_weighted_super_additive_of_nonempty


### PR DESCRIPTION
ℤ^d wrapper for card_mul_freeEnergyΛ_le_of_disjoint_union (weighted monotonicity on disjoint unions).