### PR TITLE
feat: ℤ^d freeEnergyInfinite of_eventually_nonempty (three slices)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3535,6 +3535,42 @@ theorem twoPointFunction_J_zero_of_ne_zero
     exact (Ne.symm hr)
   rw [h_card]
 
+/-- **ℤ^d freeEnergyInfinite at β=0 under eventually-nonempty** (any-Exhaustion):
+`= log 2`. -/
+theorem freeEnergyInfinite_latticeGraph_beta_zero_of_eventually_nonempty
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h : ℝ)
+    (hne : ∀ᶠ n in Filter.atTop, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite (IsingModel.latticeGraph d) Λ
+        (⟨J, h, 0⟩ : IsingParams ℝ)
+      = Real.log 2 :=
+  freeEnergyInfinite_beta_zero_of_eventually_nonempty
+    (IsingModel.latticeGraph d) Λ J h hne
+
+/-- **ℤ^d freeEnergyInfinite at J=h=0 under eventually-nonempty** (any-Exhaustion):
+`= log 2`. -/
+theorem freeEnergyInfinite_latticeGraph_zero_params_of_eventually_nonempty
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (β : ℝ)
+    (hne : ∀ᶠ n in Filter.atTop, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite (IsingModel.latticeGraph d) Λ
+        (⟨0, 0, β⟩ : IsingParams ℝ)
+      = Real.log 2 :=
+  freeEnergyInfinite_zero_params_of_eventually_nonempty
+    (IsingModel.latticeGraph d) Λ β hne
+
+/-- **ℤ^d freeEnergyInfinite at J=0 under eventually-nonempty** (any-Exhaustion):
+`= log(2·cosh(β·h))`. -/
+theorem freeEnergyInfinite_latticeGraph_J_zero_of_eventually_nonempty
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (h β : ℝ)
+    (hne : ∀ᶠ n in Filter.atTop, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ)
+      = Real.log (2 * Real.cosh (β * h)) :=
+  freeEnergyInfinite_J_zero_of_eventually_nonempty
+    (IsingModel.latticeGraph d) Λ h β hne
+
 /-- **ℤ^d freeEnergyInfinite at β = 0** (any-Exhaustion): `= log 2`. -/
 theorem freeEnergyInfinite_latticeGraph_beta_zero
     (d : ℕ) [Nonempty (Fin d → ℤ)]


### PR DESCRIPTION
any-Exhaustion ℤ^d wrappers for freeEnergyInfinite_{beta_zero, zero_params, J_zero}_of_eventually_nonempty.