### PR TITLE
feat: ℤ^d freeEnergyAlongExhaustion trivial-slice Tendsto (eventually-nonempty)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3535,6 +3535,42 @@ theorem twoPointFunction_J_zero_of_ne_zero
     exact (Ne.symm hr)
   rw [h_card]
 
+/-- **ℤ^d freeEnergyAlongExhaustion Tendsto at J=0 under eventually-nonempty**
+(any-Exhaustion). -/
+theorem freeEnergyAlongExhaustion_latticeGraph_J_zero_tendsto_of_eventually_nonempty
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (h β : ℝ)
+    (hne : ∀ᶠ n in Filter.atTop, (Λ.volume n).Nonempty) :
+    Filter.Tendsto
+      (freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ))
+      Filter.atTop (nhds (Real.log (2 * Real.cosh (β * h)))) :=
+  freeEnergyAlongExhaustion_J_zero_tendsto_of_eventually_nonempty
+    (IsingModel.latticeGraph d) Λ h β hne
+
+/-- **ℤ^d freeEnergyAlongExhaustion Tendsto at β=0 under eventually-nonempty**
+(any-Exhaustion). -/
+theorem freeEnergyAlongExhaustion_latticeGraph_beta_zero_tendsto_of_eventually_nonempty
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (J h : ℝ)
+    (hne : ∀ᶠ n in Filter.atTop, (Λ.volume n).Nonempty) :
+    Filter.Tendsto
+      (freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, 0⟩ : IsingParams ℝ))
+      Filter.atTop (nhds (Real.log 2)) :=
+  freeEnergyAlongExhaustion_beta_zero_tendsto_of_eventually_nonempty
+    (IsingModel.latticeGraph d) Λ J h hne
+
+/-- **ℤ^d freeEnergyAlongExhaustion Tendsto at J=h=0 under eventually-nonempty**
+(any-Exhaustion). -/
+theorem freeEnergyAlongExhaustion_latticeGraph_zero_params_tendsto_of_eventually_nonempty
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (β : ℝ)
+    (hne : ∀ᶠ n in Filter.atTop, (Λ.volume n).Nonempty) :
+    Filter.Tendsto
+      (freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨0, 0, β⟩ : IsingParams ℝ))
+      Filter.atTop (nhds (Real.log 2)) :=
+  freeEnergyAlongExhaustion_zero_params_tendsto_of_eventually_nonempty
+    (IsingModel.latticeGraph d) Λ β hne
+
 /-- **ℤ^d freeEnergyInfinite at β=0 under eventually-nonempty** (any-Exhaustion):
 `= log 2`. -/
 theorem freeEnergyInfinite_latticeGraph_beta_zero_of_eventually_nonempty


### PR DESCRIPTION
any-Exhaustion ℤ^d wrappers for freeEnergyAlongExhaustion_{J_zero, beta_zero, zero_params}_tendsto_of_eventually_nonempty.