### PR TITLE
feat: ℤ^d freeEnergyAlongExhaustion Fekete disjoint-tower wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3535,6 +3535,45 @@ theorem twoPointFunction_J_zero_of_ne_zero
     exact (Ne.symm hr)
   rw [h_card]
 
+/-- **ℤ^d Fekete-style convergence under disjoint-tower + BED** (any-Exhaustion):
+if `|Λ.volume (m+n)| = |Λ.volume m| + |Λ.volume n|`, log Z is super-additive,
+and BED holds, then `freeEnergyAlongExhaustion → freeEnergyInfinite`. -/
+theorem freeEnergyAlongExhaustion_latticeGraph_tendsto_of_disjoint_tower
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ)
+    (hBED : Ambient.BoundedEdgeDensity (IsingModel.latticeGraph d) Λ)
+    (hcard_add : ∀ m n, (Λ.volume (m + n)).card
+                          = (Λ.volume m).card + (Λ.volume n).card)
+    (hsuper : ∀ m n,
+        Real.log (partitionFunctionΛ (IsingModel.latticeGraph d)
+            (Λ.volume m) p)
+          + Real.log (partitionFunctionΛ (IsingModel.latticeGraph d)
+              (Λ.volume n) p)
+        ≤ Real.log (partitionFunctionΛ (IsingModel.latticeGraph d)
+            (Λ.volume (m + n)) p))
+    (hcard_one : (Λ.volume 1).card ≠ 0) :
+    Filter.Tendsto
+      (freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ p)
+      Filter.atTop
+      (nhds (freeEnergyInfinite (IsingModel.latticeGraph d) Λ p)) :=
+  freeEnergyAlongExhaustion_tendsto_of_disjoint_tower
+    (IsingModel.latticeGraph d) Λ p hBED hcard_add hsuper hcard_one
+
+/-- **ℤ^d Fekete-style convergence under disjoint-tower + BED, bundled form**
+(any-Exhaustion): same as `_of_disjoint_tower` but takes a
+`DisjointTowerHypotheses` record. -/
+theorem freeEnergyAlongExhaustion_latticeGraph_tendsto_of_disjointTowerHypotheses
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ)
+    (hBED : Ambient.BoundedEdgeDensity (IsingModel.latticeGraph d) Λ)
+    (h : Ambient.DisjointTowerHypotheses (IsingModel.latticeGraph d) Λ p) :
+    Filter.Tendsto
+      (freeEnergyAlongExhaustion (IsingModel.latticeGraph d) Λ p)
+      Filter.atTop
+      (nhds (freeEnergyInfinite (IsingModel.latticeGraph d) Λ p)) :=
+  freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses
+    (IsingModel.latticeGraph d) Λ p hBED h
+
 /-- **ℤ^d Fekete-style convergence under super-additivity**
 (any-Exhaustion): if `|Λ.volume (m+n)| = |Λ.volume m| + |Λ.volume n|`,
 log Z is super-additive on this additive grading, the range is bounded above,


### PR DESCRIPTION
any-Exhaustion ℤ^d wrappers for freeEnergyAlongExhaustion_tendsto_of_disjoint_tower and _disjointTowerHypotheses (GJ §4.6 Prop 4.6.1 Fekete).