### PR TITLE
fix: ℤ^d truncated*_translation lint warnings

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1308,12 +1308,11 @@ theorem truncated2Infinite_latticeGraph_translation
     (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (t : Fin d → ℤ)
     [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
       (Λ.volume n)).edgeSet]
-    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
-      ((Λ.shift t).volume n)).edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : Fin d → ℤ) :
     truncated2Infinite (IsingModel.latticeGraph d) Λ p (t +ᵥ i) (t +ᵥ j)
-      = truncated2Infinite (IsingModel.latticeGraph d) Λ p i j :=
-  truncated2Infinite_translation (IsingModel.latticeGraph d) Λ t p hf i j
+      = truncated2Infinite (IsingModel.latticeGraph d) Λ p i j := by
+  classical
+  exact truncated2Infinite_translation (IsingModel.latticeGraph d) Λ t p hf i j
 
 /-- **ℤ^d truncated3Infinite translation invariance** (any-Exhaustion):
 `U_3(t+i, t+j, t+k) = U_3(i, j, k)`. -/
@@ -1321,13 +1320,12 @@ theorem truncated3Infinite_latticeGraph_translation
     (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (t : Fin d → ℤ)
     [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
       (Λ.volume n)).edgeSet]
-    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
-      ((Λ.shift t).volume n)).edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j k : Fin d → ℤ) :
     truncated3Infinite (IsingModel.latticeGraph d) Λ p
         (t +ᵥ i) (t +ᵥ j) (t +ᵥ k)
-      = truncated3Infinite (IsingModel.latticeGraph d) Λ p i j k :=
-  truncated3Infinite_translation (IsingModel.latticeGraph d) Λ t p hf i j k
+      = truncated3Infinite (IsingModel.latticeGraph d) Λ p i j k := by
+  classical
+  exact truncated3Infinite_translation (IsingModel.latticeGraph d) Λ t p hf i j k
 
 /-- **ℤ^d truncated4Infinite translation invariance** (any-Exhaustion):
 `U_4(t+i, t+j, t+k, t+l) = U_4(i, j, k, l)`. -/
@@ -1335,13 +1333,13 @@ theorem truncated4Infinite_latticeGraph_translation
     (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (t : Fin d → ℤ)
     [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
       (Λ.volume n)).edgeSet]
-    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
-      ((Λ.shift t).volume n)).edgeSet]
     (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j k l : Fin d → ℤ) :
     truncated4Infinite (IsingModel.latticeGraph d) Λ p
         (t +ᵥ i) (t +ᵥ j) (t +ᵥ k) (t +ᵥ l)
-      = truncated4Infinite (IsingModel.latticeGraph d) Λ p i j k l :=
-  truncated4Infinite_translation (IsingModel.latticeGraph d) Λ t p hf i j k l
+      = truncated4Infinite (IsingModel.latticeGraph d) Λ p i j k l := by
+  classical
+  exact truncated4Infinite_translation
+    (IsingModel.latticeGraph d) Λ t p hf i j k l
 
 /-- **ℤ^d freeEnergyAlongExhaustion shift translation invariance**:
 `freeEnergyAlongExhaustion (Λ.shift t) n = freeEnergyAlongExhaustion Λ n`. -/


### PR DESCRIPTION
Drop unused shifted Fintype hypothesis in truncated2/3/4Infinite_latticeGraph_translation wrappers (use classical).