### PR TITLE
feat: ℤ^d magnetizationΛ / truncated2Λ convergent via correlationΛ

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -758,6 +758,42 @@ theorem correlationΛ_latticeGraph_gks_second
   refine ⟨hAB, ?_⟩
   exact correlationΛ_gks_second (IsingModel.latticeGraph d) p hf hA hB
 
+/-- **ℤ^d magnetizationΛ J → ∞ convergence**: specialisation of
+`correlation_convergent` at `B = {i}`. -/
+theorem magnetizationΛ_latticeGraph_convergent_J
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h : ℝ) (hh : 0 ≤ h) (β : ℝ) (hβ : 0 < β)
+    (i : ↑Λ) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => IsingModel.correlationJ
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β {i} n)
+      Filter.atTop (nhds L) :=
+  IsingModel.correlation_convergent
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h hh β hβ {i}
+
+/-- **ℤ^d magnetizationΛ h → ∞ convergence**: specialisation of
+`correlation_convergent_h` at `A = {i}`. -/
+theorem magnetizationΛ_latticeGraph_convergent_h
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J : ℝ) (hJ : 0 ≤ J) (β : ℝ) (hβ : 0 < β)
+    (i : ↑Λ) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => correlationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J, (n : ℝ), β⟩ : IsingParams ℝ) {i})
+      Filter.atTop (nhds L) :=
+  IsingModel.correlation_convergent_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J hJ β hβ {i}
+
+/-- **ℤ^d magnetizationΛ β → ∞ convergence**: specialisation of
+`correlation_convergent_beta` at `A = {i}`. -/
+theorem magnetizationΛ_latticeGraph_convergent_beta
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J : ℝ) (hJ : 0 ≤ J) (h : ℝ) (hh : 0 ≤ h)
+    (i : ↑Λ) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => correlationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J, h, (n + 1 : ℝ)⟩ : IsingParams ℝ) {i})
+      Filter.atTop (nhds L) :=
+  IsingModel.correlation_convergent_beta
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J hJ h hh {i}
+
 /-- **ℤ^d correlationΛ J → ∞ convergence**: for `0 ≤ h`, `0 < β`. -/
 theorem correlationΛ_latticeGraph_convergent
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h : ℝ) (hh : 0 ≤ h) (β : ℝ) (hβ : 0 < β)


### PR DESCRIPTION
Add ℤ^d Λ-level wrappers for magnetization/truncated2 J/h/beta convergence, specializing correlation_convergent (doesn't require PhaseTransition.lean import).