### PR TITLE
feat: ℤ^d freeEnergy_convergent_subgraph (Λ-induced)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -794,6 +794,18 @@ theorem freeEnergyJ_analyticOn_latticeGraph
   IsingModel.freeEnergyJ_analyticOn
     (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β
 
+/-- **ℤ^d `freeEnergy_convergent_subgraph` at Λ-induced subgraph**:
+for a monotone sequence of subgraphs `Gn : ℕ → SimpleGraph ↑Λ` and
+ferromagnetic `p`, `n ↦ freeEnergy (Gn n) p` converges. -/
+theorem freeEnergy_convergent_subgraph_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    (Gn : ℕ → SimpleGraph (↑Λ : Type _)) [∀ n, Fintype (Gn n).edgeSet]
+    (hmono : Monotone Gn) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => IsingModel.freeEnergy (Gn n) p)
+      Filter.atTop (nhds L) :=
+  IsingModel.freeEnergy_convergent_subgraph Gn hmono p hf
+
 /-- **ℤ^d `partitionFunction` of `⊥` at Λ**: closed form
 `Z_⊥ = (2 cosh(βh))^|Λ|`. -/
 theorem partitionFunction_bot_latticeGraph


### PR DESCRIPTION
ℤ^d wrapper for freeEnergy_convergent_subgraph at Λ-induced subgraph level.