### PR TITLE
feat: ℤ^d partitionFunction slices direct (Λ-induced)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1144,6 +1144,78 @@ theorem hamiltonian_bot_latticeGraph
       = -p.h * ∑ i : (↑Λ : Type _), IsingModel.Spin.sign ℝ (σ i) :=
   IsingModel.hamiltonian_bot p σ
 
+/-- **ℤ^d partitionFunction_J_zero direct** at Λ-induced:
+`Z_Λ at ⟨0, h, β⟩ = (2·cosh(β·h))^|Λ|`. -/
+theorem partitionFunction_J_zero_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β : ℝ) :
+    IsingModel.partitionFunction
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨0, h, β⟩ : IsingParams ℝ)
+      = (2 * Real.cosh (β * h)) ^ Fintype.card (↑Λ : Type _) :=
+  IsingModel.partitionFunction_J_zero
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β
+
+/-- **ℤ^d partitionFunction_beta_zero direct** at Λ-induced:
+`Z_Λ at ⟨J, h, 0⟩ = |Config Λ| = 2^|Λ|`. -/
+theorem partitionFunction_beta_zero_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h : ℝ) :
+    IsingModel.partitionFunction
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, h, 0⟩ : IsingParams ℝ)
+      = (Fintype.card (IsingModel.Config (↑Λ : Type _)) : ℝ) :=
+  IsingModel.partitionFunction_beta_zero
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h
+
+/-- **ℤ^d partitionFunction_zero_params direct** at Λ-induced:
+`Z_Λ at ⟨0, 0, β⟩ = |Config Λ|`. -/
+theorem partitionFunction_zero_params_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (β : ℝ) :
+    IsingModel.partitionFunction
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨0, 0, β⟩ : IsingParams ℝ)
+      = (Fintype.card (IsingModel.Config (↑Λ : Type _)) : ℝ) :=
+  IsingModel.partitionFunction_zero_params
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) β
+
+/-- **ℤ^d partitionFunction_neg_h direct** at Λ-induced:
+`Z_Λ at ⟨J, -h, β⟩ = Z_Λ at ⟨J, h, β⟩`. -/
+theorem partitionFunction_neg_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ) :
+    IsingModel.partitionFunction
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, -h, β⟩ : IsingParams ℝ)
+      = IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (⟨J, h, β⟩ : IsingParams ℝ) :=
+  IsingModel.partitionFunction_neg_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β
+
+/-- **ℤ^d partitionFunction_eq_abs_h direct** at Λ-induced. -/
+theorem partitionFunction_eq_abs_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ) :
+    IsingModel.partitionFunction
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, h, β⟩ : IsingParams ℝ)
+      = IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (⟨J, |h|, β⟩ : IsingParams ℝ) :=
+  IsingModel.partitionFunction_eq_abs_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β
+
+/-- **ℤ^d partitionFunction_monotone_abs_h direct** at Λ-induced
+(ferromagnetic). -/
+theorem partitionFunction_monotone_abs_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh : |h₁| ≤ |h₂|) :
+    IsingModel.partitionFunction
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, h₁, β⟩ : IsingParams ℝ)
+      ≤ IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (⟨J, h₂, β⟩ : IsingParams ℝ) :=
+  IsingModel.partitionFunction_monotone_abs_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β hJ hβ hh
+
 /-- **ℤ^d partitionFunction_pos direct** at Λ-induced: `0 < Z_Λ`. -/
 theorem partitionFunction_pos_latticeGraph
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :


### PR DESCRIPTION
ℤ^d direct wrappers for partitionFunction_{J_zero, beta_zero, zero_params, neg_h, eq_abs_h, monotone_abs_h} at Λ-induced subgraph.