### PR TITLE
feat: ℤ^d freeEnergy monotone_J/h/beta direct (Λ-induced)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -935,6 +935,32 @@ theorem inducedGraph_mono_latticeGraph
     Ambient.inducedGraph G₁ Λ ≤ Ambient.inducedGraph G₂ Λ :=
   Ambient.inducedGraph_mono h Λ
 
+/-- **ℤ^d freeEnergy_monotone_h direct** (Λ-induced, ferromagnetic). -/
+theorem freeEnergy_monotone_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β) :
+    MonotoneOn (IsingModel.freeEnergyH
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β) (Set.Ici 0) :=
+  IsingModel.freeEnergy_monotone_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β hJ hβ
+
+/-- **ℤ^d freeEnergy_monotone_J direct** (Λ-induced, ferromagnetic). -/
+theorem freeEnergy_monotone_J_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β : ℝ) (hh : 0 ≤ h) (hβ : 0 < β) :
+    MonotoneOn (IsingModel.freeEnergyJ
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β) (Set.Ici 0) :=
+  IsingModel.freeEnergy_monotone_J
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β hh hβ
+
+/-- **ℤ^d freeEnergy_monotone_beta direct** (Λ-induced, ferromagnetic). -/
+theorem freeEnergy_monotone_beta_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J : ℝ) (hJ : 0 ≤ J) (h : ℝ) (hh : 0 ≤ h) :
+    MonotoneOn
+      (fun β : ℝ => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) ⟨J, h, β⟩)
+      (Set.Ioi 0) :=
+  IsingModel.freeEnergy_monotone_beta
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J hJ h hh
+
 /-- **ℤ^d freeEnergy_zero_params at Λ-induced**:
 `freeEnergy ⟨0, 0, β⟩ = log 2` for nonempty Λ. -/
 theorem freeEnergy_zero_params_latticeGraph


### PR DESCRIPTION
ℤ^d direct wrappers for freeEnergy_monotone_J / _monotone_h / _monotone_beta at Λ-induced subgraph.