### PR TITLE
feat: ℤ^d partitionFunction/log_partitionFunction ferromagnetic bounds direct (Λ-induced)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1311,6 +1311,61 @@ theorem partitionFunction_monotone_abs_h_latticeGraph
   IsingModel.partitionFunction_monotone_abs_h
     (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β hJ hβ hh
 
+/-- **ℤ^d partitionFunction_ge_one_of_ferromagnetic direct** (Λ-induced). -/
+theorem partitionFunction_ge_one_of_ferromagnetic_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (1 : ℝ) ≤ IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  IsingModel.partitionFunction_ge_one_of_ferromagnetic
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p hf
+
+/-- **ℤ^d log_partitionFunction_nonneg_of_ferromagnetic direct** (Λ-induced). -/
+theorem log_partitionFunction_nonneg_of_ferromagnetic_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    0 ≤ Real.log (IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p) :=
+  IsingModel.log_partitionFunction_nonneg_of_ferromagnetic
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p hf
+
+/-- **ℤ^d partitionFunction_ge_two_pow_card_of_ferromagnetic direct** (Λ-induced). -/
+theorem partitionFunction_ge_two_pow_card_of_ferromagnetic_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (2 : ℝ) ^ Fintype.card (↑Λ : Type _)
+      ≤ IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  IsingModel.partitionFunction_ge_two_pow_card_of_ferromagnetic
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p hf
+
+/-- **ℤ^d partitionFunction_ge_two_cosh_pow_card_of_ferromagnetic direct**
+(Λ-induced). -/
+theorem partitionFunction_ge_two_cosh_pow_card_of_ferromagnetic_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (2 * Real.cosh (p.β * p.h)) ^ Fintype.card (↑Λ : Type _)
+      ≤ IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  IsingModel.partitionFunction_ge_two_cosh_pow_card_of_ferromagnetic
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p hf
+
+/-- **ℤ^d log_partitionFunction_ge_card_mul_log_two_of_ferromagnetic direct**
+(Λ-induced). -/
+theorem log_partitionFunction_ge_card_mul_log_two_of_ferromagnetic_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Fintype.card (↑Λ : Type _) : ℝ) * Real.log 2
+      ≤ Real.log (IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p) :=
+  IsingModel.log_partitionFunction_ge_card_mul_log_two_of_ferromagnetic
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p hf
+
+/-- **ℤ^d log_partitionFunction_ge_card_mul_log_two_cosh_of_ferromagnetic direct**
+(Λ-induced). -/
+theorem log_partitionFunction_ge_card_mul_log_two_cosh_of_ferromagnetic_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    (Fintype.card (↑Λ : Type _) : ℝ) * Real.log (2 * Real.cosh (p.β * p.h))
+      ≤ Real.log (IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p) :=
+  IsingModel.log_partitionFunction_ge_card_mul_log_two_cosh_of_ferromagnetic
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p hf
+
 /-- **ℤ^d partitionFunction_pos direct** at Λ-induced: `0 < Z_Λ`. -/
 theorem partitionFunction_pos_latticeGraph
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :


### PR DESCRIPTION
ℤ^d direct wrappers for partitionFunction_ge_{one,two_pow_card,two_cosh_pow_card}_of_ferromagnetic, log_partitionFunction_nonneg_of_ferromagnetic, log_partitionFunction_ge_card_mul_log_two_{,cosh}_of_ferromagnetic at Λ-induced subgraph.