### PR TITLE
feat: ℤ^d correlation monotone_J/h/beta direct (Λ-induced)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1521,6 +1521,35 @@ theorem gibbsExpectation_nonneg_of_numerator_nonneg_latticeGraph
   IsingModel.gibbsExpectation_nonneg_of_numerator_nonneg
     (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p F hnum
 
+/-- **ℤ^d correlation_monotone_J direct** (Λ-induced, ferromagnetic). -/
+theorem correlation_monotone_J_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h : ℝ) (hh : 0 ≤ h) (β : ℝ) (hβ : 0 < β)
+    (B : Finset (↑Λ : Type _)) :
+    MonotoneOn (IsingModel.correlationJ
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β B) (Set.Ici 0) :=
+  IsingModel.correlation_monotone_J
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h hh β hβ B
+
+/-- **ℤ^d correlation_monotone_h direct** (Λ-induced, ferromagnetic). -/
+theorem correlation_monotone_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J : ℝ) (hJ : 0 ≤ J) (β : ℝ) (hβ : 0 < β)
+    (B : Finset (↑Λ : Type _)) :
+    MonotoneOn (IsingModel.correlationH
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β B) (Set.Ici 0) :=
+  IsingModel.correlation_monotone_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J hJ β hβ B
+
+/-- **ℤ^d correlation_monotone_beta direct** (Λ-induced, ferromagnetic). -/
+theorem correlation_monotone_beta_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J : ℝ) (hJ : 0 ≤ J) (h : ℝ) (hh : 0 ≤ h)
+    (A : Finset (↑Λ : Type _)) :
+    MonotoneOn
+      (fun β : ℝ => IsingModel.correlation
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) ⟨J, h, β⟩ A)
+      (Set.Ioi 0) :=
+  IsingModel.correlation_monotone_beta
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J hJ h hh A
+
 /-- **ℤ^d abs_correlation_le_one direct** (Λ-induced): `|⟨σ^A⟩| ≤ 1`. -/
 theorem abs_correlation_le_one_latticeGraph
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)


### PR DESCRIPTION
ℤ^d direct wrappers for correlation_monotone_J / _monotone_h / _monotone_beta at Λ-induced subgraph.