### PR TITLE
feat: ℤ^d Walsh completeness / Fourier inversion direct (Λ-induced)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1181,6 +1181,29 @@ theorem walsh_orthogonality_latticeGraph
       IsingModel.spinProduct S σ * IsingModel.spinProduct T σ = 0 :=
   IsingModel.walsh_orthogonality S T hST
 
+/-- **ℤ^d Walsh completeness at Λ-induced**:
+`Σ_S σ^S(σ) σ^S(τ) = card · [σ = τ]`. -/
+theorem walsh_completeness_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    (σ τ : IsingModel.Config (↑Λ : Type _)) :
+    ∑ S : Finset (↑Λ : Type _),
+        IsingModel.spinProduct S σ * IsingModel.spinProduct S τ
+      = if σ = τ then (Fintype.card (IsingModel.Config (↑Λ : Type _)) : ℝ) else 0 :=
+  IsingModel.walsh_completeness σ τ
+
+/-- **ℤ^d Walsh Fourier inversion at Λ-induced**:
+`f(σ) = Σ_S ĉ_S σ^S` where `ĉ_S = card⁻¹ Σ_τ σ^S(τ) f(τ)`. -/
+theorem walsh_fourier_inversion_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    (f : IsingModel.Config (↑Λ : Type _) → ℝ)
+    (σ : IsingModel.Config (↑Λ : Type _)) :
+    f σ = ∑ S : Finset (↑Λ : Type _),
+      ((Fintype.card (IsingModel.Config (↑Λ : Type _)) : ℝ)⁻¹
+        * ∑ τ : IsingModel.Config (↑Λ : Type _),
+            IsingModel.spinProduct S τ * f τ)
+      * IsingModel.spinProduct S σ :=
+  IsingModel.walsh_fourier_inversion f σ
+
 /-- **ℤ^d Walsh normalization at Λ-induced**. -/
 theorem walsh_normalization_latticeGraph
     (d : ℕ) (Λ : Finset (Fin d → ℤ))


### PR DESCRIPTION
ℤ^d direct wrappers for walsh_completeness and walsh_fourier_inversion at Λ-induced type.