### PR TITLE
chore: pause docs generation in CI

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -21,13 +21,19 @@ jobs:
       - name: Run tests
         run: lake exe GKSTest
 
-  docs:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: leanprover/lean-action@v1
-      - uses: leanprover-community/docgen-action@main
-        with:
-          use-github-cache: false
+  # NOTE: docs generation via `leanprover-community/docgen-action` has been
+  # temporarily disabled because every main-push run takes ~1 hour and
+  # CI queues backed up. Re-enable once the docgen step is accelerated
+  # (e.g. by caching or by running on a schedule instead of every push).
+  # See README / docs/index.md for user-facing notice.
+  #
+  # docs:
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #     - uses: leanprover/lean-action@v1
+  #     - uses: leanprover-community/docgen-action@main
+  #       with:
+  #         use-github-cache: false

--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ Glimm–Jaffe chapter-by-chapter progress table, see the
 ## Documentation
 
 - Project page: [https://phasetr.github.io/ising-model/](https://phasetr.github.io/ising-model/)
-- API documentation (doc-gen4): [https://phasetr.github.io/ising-model/docs/](https://phasetr.github.io/ising-model/docs/)
+- API documentation (doc-gen4): **temporarily unavailable** (automatic
+  publication paused). See note below.
+
+> **Note:** automatic publication of the doc-gen4 API reference to
+> GitHub Pages is currently paused because each main-push run of the
+> `docs` job was taking roughly an hour and queuing up behind every
+> merge. The `docs` job in `.github/workflows/lean_action_ci.yml` is
+> commented out until we accelerate the docgen step (caching, a
+> scheduled run, or an alternative pipeline). To build the API
+> reference locally, run `lake -R -Kenv=dev build IsingModel:docs`
+> and open `.lake/build/doc/index.html`.
 
 Mathematical documentation for the formalized proofs is in `tex/` as
 LaTeX source files. To compile:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,16 @@ Lean 4 + mathlib formalization of Ising model theorems, with particular
 emphasis on Glimm–Jaffe, *Quantum Physics: A Functional Integral Point of
 View* (2nd ed., 1987).
 
+> **Notice:** automatic publication of the doc-gen4 API reference to
+> `/docs/` on GitHub Pages is **currently paused**. Every main-push
+> run of the `docs` job in the CI workflow was taking ~1 hour and
+> queuing up behind each merge, so the `docs` job in
+> `.github/workflows/lean_action_ci.yml` has been commented out. The
+> Lean build and tests (`build` job) continue to run on every push
+> and pull request. To build the API reference locally, run
+> `lake -R -Kenv=dev build IsingModel:docs` and open
+> `.lake/build/doc/index.html`.
+
 All theorems are formally proved with **zero `sorry`**.
 Pre-existing axioms (four items) cover Lebowitz-type inequalities
 whose full proofs require measure theory machinery; see the *Axioms*


### PR DESCRIPTION
## Summary

- Comment out the `docs` job in `.github/workflows/lean_action_ci.yml`.
- Add a user-facing notice in `README.md` and `docs/index.md` that doc-gen4 API publication to GitHub Pages is temporarily paused and describe how to build the reference locally.

## Why

Every push to `main` triggered the `docs` job, which invokes `leanprover-community/docgen-action@main` with `use-github-cache: false`. Each run rebuilt mathlib from scratch (~1 hour). Because the job is gated on push-to-main, merges stacked up behind each other and saturated the runner queue. At peak there were 66 queued / in-progress runs (all now cancelled).

The `build` job (Lean compile + `lake exe GKSTest`) continues to run on every push and pull request, so correctness coverage is unchanged.

## Re-enabling later

Options considered for a follow-up PR:
- Restore the GitHub Actions cache for `.elan` and `.lake/build` so docgen reuses the mathlib build.
- Switch to `schedule: cron` (weekly) + `workflow_dispatch` instead of per-push generation.
- Gate on release tags.

## Test plan

- [ ] CI `build` job passes.
- [ ] `docs` job does not run (commented out).
- [ ] Local `lake -R -Kenv=dev build IsingModel:docs` still produces output.