### PR TITLE
fix: drop unused [DecidableEq α] from HNC finset_prod latticeGraph wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -1774,29 +1774,31 @@ theorem hasNonnegCorrelations_one_latticeGraph
 a product of `(a + b · σ^C)` factors over a Finset has HNC. -/
 theorem hasNonnegCorrelations_finset_prod_latticeGraph
     (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    {α : Type*} [DecidableEq α]
+    {α : Type*}
     (S : Finset α)
     (g : α → IsingModel.Config (↑Λ : Type _) → ℝ)
     (hg : ∀ a ∈ S, ∃ c e : ℝ, ∃ C : Finset (↑Λ : Type _), 0 ≤ c ∧ 0 ≤ e ∧
       ∀ σ, g a σ = c + e * IsingModel.spinProduct C σ) :
     IsingModel.HasNonnegCorrelations fun σ : IsingModel.Config (↑Λ : Type _) =>
-      ∏ a ∈ S, g a σ :=
-  IsingModel.hasNonnegCorrelations_finset_prod S g hg
+      ∏ a ∈ S, g a σ := by
+  classical
+  exact IsingModel.hasNonnegCorrelations_finset_prod S g hg
 
 /-- **ℤ^d hasNonnegCorrelations_mul_prod direct** (Λ-induced):
 multiplying an HNC function by a product of `(a + b · σ^C)` factors
 preserves HNC. -/
 theorem hasNonnegCorrelations_mul_prod_latticeGraph
     (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    {α : Type*} [DecidableEq α]
+    {α : Type*}
     (S : Finset α) {f : IsingModel.Config (↑Λ : Type _) → ℝ}
     (hf : IsingModel.HasNonnegCorrelations f)
     (g : α → IsingModel.Config (↑Λ : Type _) → ℝ)
     (hg : ∀ a ∈ S, ∃ c e : ℝ, ∃ C : Finset (↑Λ : Type _), 0 ≤ c ∧ 0 ≤ e ∧
       ∀ σ, g a σ = c + e * IsingModel.spinProduct C σ) :
     IsingModel.HasNonnegCorrelations fun σ : IsingModel.Config (↑Λ : Type _) =>
-      f σ * ∏ a ∈ S, g a σ :=
-  IsingModel.hasNonnegCorrelations_mul_prod S hf g hg
+      f σ * ∏ a ∈ S, g a σ := by
+  classical
+  exact IsingModel.hasNonnegCorrelations_mul_prod S hf g hg
 
 /-- **ℤ^d hasNonnegCorrelations_mul direct** (Λ-induced): if `f` has HNC
 then so does `f · (a + b · σ^C)` for `a, b ≥ 0`. -/


### PR DESCRIPTION
## Summary

- Remove unused `[DecidableEq α]` hypothesis from `hasNonnegCorrelations_finset_prod_latticeGraph` and `hasNonnegCorrelations_mul_prod_latticeGraph` to clear the two linter warnings introduced in #606.
- Wrap the proof body in `by classical; exact ...` so the underlying `IsingModel.hasNonnegCorrelations_finset_prod` / `_mul_prod` (which internally require `DecidableEq`) keep working.

## Why

CLAUDE.local.md mandates zero linter warnings; PR #606 shipped with two `does not use the following hypothesis in its type` warnings against these wrappers. This is a trailing cleanup of the same GJ Ising-formalization batch.

## Test plan

- [ ] `lake build` succeeds with no linter warnings on `IsingModel/Concrete/LatticeGraphCorrelation.lean`
- [ ] `lake exe GKSTest` passes
- [ ] Cross-check via `copilot -p`

🤖 Generated with [Claude Code](https://claude.com/claude-code)