### PR TITLE
feat: zeta_nonneg_finite_vol + eta/zeta_nonneg_infinite_vol (§17.7 completion)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -5072,6 +5072,37 @@ theorem BddAbove_freeEnergyAlongExhaustion_range
       rw [hcard, Nat.cast_zero, inv_zero, zero_mul]
     rw [hfe]; exact le_max_left _ _
 
+/-! ## Critical exponents at ∞-volume (GJ §17.7 Thm 17.7.1)
+
+Explicit ∞-vol named aliases for the critical-exponent bounds
+`η ≥ 0` and `ζ ≥ 0`, matching the finite-volume
+`IsingModel.eta_nonneg_finite_vol` / `zeta_nonneg_finite_vol`
+pattern. Direct pass-throughs of `truncated2Infinite_nonneg` (GKS-II
+at ∞-vol) and `truncated4Infinite_nonpos_h_zero` (Cor 4.3.3 at ∞-vol). -/
+
+/-- **η ≥ 0 at ∞-volume** (GJ §17.7 Thm 17.7.1, ∞-vol lattice version).
+Explicit alias of `truncated2Infinite_nonneg` matching the
+`eta_nonneg_finite_vol` naming convention. -/
+theorem eta_nonneg_infinite_vol
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
+    0 ≤ truncated2Infinite G Λ p i j :=
+  truncated2Infinite_nonneg G Λ p hf i j
+
+/-- **ζ ≥ 0 at ∞-volume** (GJ §17.7 Thm 17.7.1, ∞-vol lattice version,
+at `h = 0`). Explicit alias of `truncated4Infinite_nonpos_h_zero` —
+`U₄^∞ ≤ 0` for pairwise-distinct sites at `h = 0`. -/
+theorem zeta_nonneg_infinite_vol
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩)
+    {i j k l : V}
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    truncated4Infinite G Λ ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  truncated4Infinite_nonpos_h_zero G Λ J β hf hij hik hil hjk hjl hkl
+
 end Ambient
 end IsingModel
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2619,6 +2619,53 @@ theorem prop_5_4_2_plusGibbsExpectationLiminf_bound_latticeGraph
   exact IsingModel.prop_5_4_2_plusGibbsExpectationLiminf_bound
     (IsingModel.latticeGraph d) Λ hconn J β c hβ hJ B hB i hexp
 
+/-! #### §17.7 critical-exponent bounds at ℤ^d
+
+Direct ℤ^d wrappers for the `η ≥ 0` and `ζ ≥ 0` critical-exponent
+bounds at ℤ^d, for both finite-volume and ∞-volume. Pass-throughs of
+`IsingModel.{eta,zeta}_nonneg_{finite,infinite}_vol`. -/
+
+/-- **ℤ^d `ζ ≥ 0` finite-volume** (Λ-induced, GJ §17.7 Thm 17.7.1,
+ferromagnetic at `h = 0`). Pass-through of
+`IsingModel.zeta_nonneg_finite_vol`. -/
+theorem zeta_nonneg_finite_vol_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ)
+    (hf : Ferromagnetic (⟨J, (0 : ℝ), β⟩ : IsingParams ℝ))
+    (i j k l : (↑Λ : Type _))
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    IsingModel.truncated4
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  IsingModel.zeta_nonneg_finite_vol
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β hf
+    i j k l hij hik hil hjk hjl hkl
+
+/-- **ℤ^d `η ≥ 0` ∞-volume** (GJ §17.7 Thm 17.7.1, ferromagnetic).
+Pass-through of `IsingModel.Ambient.eta_nonneg_infinite_vol`. -/
+theorem eta_nonneg_infinite_vol_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : Fin d → ℤ) :
+    0 ≤ Ambient.truncated2Infinite (IsingModel.latticeGraph d) Λ p i j :=
+  Ambient.eta_nonneg_infinite_vol (IsingModel.latticeGraph d) Λ p hf i j
+
+/-- **ℤ^d `ζ ≥ 0` ∞-volume** (GJ §17.7 Thm 17.7.1, ferromagnetic at
+`h = 0`). Pass-through of `IsingModel.Ambient.zeta_nonneg_infinite_vol`. -/
+theorem zeta_nonneg_infinite_vol_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hf : Ferromagnetic (⟨J, (0 : ℝ), β⟩ : IsingParams ℝ))
+    {i j k l : Fin d → ℤ}
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    Ambient.truncated4Infinite (IsingModel.latticeGraph d) Λ
+        ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  Ambient.zeta_nonneg_infinite_vol (IsingModel.latticeGraph d) Λ J β hf
+    hij hik hil hjk hjl hkl
+
 /-- **ℤ^d partitionFunction monotone_subgraph** at Λ-induced subgraph:
 `G₁ ≤ G₂ ⇒ Z_{G₁} ≤ Z_{G₂}` for ferromagnetic `p`. -/
 theorem partitionFunction_monotone_subgraph_latticeGraph

--- a/IsingModel/PhaseTransition.lean
+++ b/IsingModel/PhaseTransition.lean
@@ -402,6 +402,20 @@ theorem eta_nonneg_finite_vol (G : SimpleGraph ι) [Fintype G.edgeSet]
     0 ≤ truncated2 G p i j :=
   truncated2_nonneg G p hf i j
 
+/-- **ζ ≥ 0** (Glimm–Jaffe, Thm 17.7.1, finite-volume lattice version,
+at `h = 0`). The critical exponent `ζ` measures the anomalous dimension
+of the four-point truncated correlator; `ζ ≥ 0` follows from
+`U₄(i, j, k, l) ≤ 0` (Cor 4.3.3) for pairwise-distinct sites at `h = 0`.
+
+Explicit named alias of `cor_4_3_3` matching the `eta_nonneg_finite_vol`
+pattern. -/
+theorem zeta_nonneg_finite_vol (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩) (i j k l : ι)
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    truncated4 G ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  cor_4_3_3 G J β hf i j k l hij hik hil hjk hjl hkl
+
 /-! ## Lattice-growth convergence of §5 quantities
 
 Named corollaries of `correlation_convergent_subgraph` (PR #64) for the

--- a/docs/index.md
+++ b/docs/index.md
@@ -569,7 +569,7 @@ inventory (2026-04-17).
 |---|---|---|
 | §17.2 | Absence of even bound states | **Done** (via Cor 4.3.3) |
 | §17.5 | Correlation length | Not formalized (spectral theory) |
-| §17.7 | `η ≥ 0`, `ζ ≥ 0` | **Done** |
+| §17.7 | `η ≥ 0`, `ζ ≥ 0` | **Done (finite + ∞-vol)** | `eta_nonneg_finite_vol` + `zeta_nonneg_finite_vol` (`PhaseTransition.lean`) + `Ambient.eta_nonneg_infinite_vol` + `Ambient.zeta_nonneg_infinite_vol` (`AmbientLattice.lean`) + ℤ^d `{eta,zeta}_nonneg_{finite,infinite}_vol_latticeGraph`. Explicit named aliases of `truncated2_nonneg`/`truncated2Infinite_nonneg` (GKS-II) and `cor_4_3_3`/`truncated4Infinite_nonpos_h_zero` (Lebowitz at `h = 0`). (PR #636.) |
 | §17.8 | `η ≤ 1` | **Done** |
 
 ### Chapter 18 (Cluster expansion)


### PR DESCRIPTION
## Summary

Fill the §17.7 gap at the explicit-named-theorem level:

**Finite-volume (`IsingModel/PhaseTransition.lean`):**
- `zeta_nonneg_finite_vol`: `truncated4 G ⟨J, 0, β⟩ i j k l ≤ 0` for pairwise-distinct sites (ferromagnetic, `h = 0`). Explicit name wrapping `cor_4_3_3`.

**∞-volume (`IsingModel/AmbientLattice.lean` extension):**
- `eta_nonneg_infinite_vol`: `0 ≤ truncated2Infinite G Λ p i j` (ferromagnetic). Wrapping `truncated2Infinite_nonneg`.
- `zeta_nonneg_infinite_vol`: `truncated4Infinite G Λ ⟨J, 0, β⟩ i j k l ≤ 0` for pairwise-distinct sites. Wrapping `truncated4Infinite_nonpos_h_zero`.

**ℤ^d wrappers:**
- `eta_nonneg_infinite_vol_latticeGraph`, `zeta_nonneg_{finite,infinite}_vol_latticeGraph`.

All are thin pass-throughs of existing inequalities. No new proofs, no sorry.

## Why

§17.7 row in docs/index.md marks η ≥ 0, ζ ≥ 0 Done "via Cor 4.3.3". This PR adds explicit named theorems `zeta_nonneg_finite_vol` and ∞-vol variants matching `eta_nonneg_finite_vol`'s pattern, making the §17.7 API complete and uniform.

## Test plan

- [ ] `lake build` zero warnings
- [ ] `lake exe GKSTest` passes
- [ ] Docs updated
- [ ] Cross-check via `codex exec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)