### PR TITLE
feat: absence_of_even_bound_states explicit aliases (§17.2 finite + ∞-vol)

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -5103,6 +5103,21 @@ theorem zeta_nonneg_infinite_vol
     truncated4Infinite G Λ ⟨J, 0, β⟩ i j k l ≤ 0 :=
   truncated4Infinite_nonpos_h_zero G Λ J β hf hij hik hil hjk hjl hkl
 
+/-- **Absence of even bound states — ∞-volume lattice** (Glimm–Jaffe
+§17.2, pp. 311–313). ∞-vol version of
+`IsingModel.absence_of_even_bound_states_finite_vol`:
+`U₄^∞(i,j,k,l) ≤ 0` for ferromagnetic `⟨J, 0, β⟩` and pairwise-distinct
+sites. Explicit alias of `truncated4Infinite_nonpos_h_zero`. -/
+theorem absence_of_even_bound_states_infinite_vol
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩)
+    {i j k l : V}
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    truncated4Infinite G Λ ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  truncated4Infinite_nonpos_h_zero G Λ J β hf hij hik hil hjk hjl hkl
+
 end Ambient
 end IsingModel
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -2666,6 +2666,38 @@ theorem zeta_nonneg_infinite_vol_latticeGraph
   Ambient.zeta_nonneg_infinite_vol (IsingModel.latticeGraph d) Λ J β hf
     hij hik hil hjk hjl hkl
 
+/-- **ℤ^d absence of even bound states, finite-volume** (GJ §17.2
+Λ-induced, ferromagnetic at `h = 0`). Pass-through of
+`IsingModel.absence_of_even_bound_states_finite_vol`. -/
+theorem absence_of_even_bound_states_finite_vol_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ)
+    (hf : Ferromagnetic (⟨J, (0 : ℝ), β⟩ : IsingParams ℝ))
+    (i j k l : (↑Λ : Type _))
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    IsingModel.truncated4
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  IsingModel.absence_of_even_bound_states_finite_vol
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β hf
+    i j k l hij hik hil hjk hjl hkl
+
+/-- **ℤ^d absence of even bound states, ∞-volume** (GJ §17.2,
+ferromagnetic at `h = 0`). Pass-through of
+`IsingModel.Ambient.absence_of_even_bound_states_infinite_vol`. -/
+theorem absence_of_even_bound_states_infinite_vol_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hf : Ferromagnetic (⟨J, (0 : ℝ), β⟩ : IsingParams ℝ))
+    {i j k l : Fin d → ℤ}
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    Ambient.truncated4Infinite (IsingModel.latticeGraph d) Λ
+        ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  Ambient.absence_of_even_bound_states_infinite_vol
+    (IsingModel.latticeGraph d) Λ J β hf hij hik hil hjk hjl hkl
+
 /-- **ℤ^d partitionFunction monotone_subgraph** at Λ-induced subgraph:
 `G₁ ≤ G₂ ⇒ Z_{G₁} ≤ Z_{G₂}` for ferromagnetic `p`. -/
 theorem partitionFunction_monotone_subgraph_latticeGraph

--- a/IsingModel/PhaseTransition.lean
+++ b/IsingModel/PhaseTransition.lean
@@ -416,6 +416,24 @@ theorem zeta_nonneg_finite_vol (G : SimpleGraph ι) [Fintype G.edgeSet]
     truncated4 G ⟨J, 0, β⟩ i j k l ≤ 0 :=
   cor_4_3_3 G J β hf i j k l hij hik hil hjk hjl hkl
 
+/-- **Absence of even bound states — finite-volume lattice** (Glimm–Jaffe
+§17.2, pp. 311–313). For a ferromagnetic Ising model at zero external
+field, the truncated four-point correlator `U₄(i,j,k,l) ≤ 0` is
+negative semidefinite. Physically this means there are no even-sector
+bound states in the two-body spectrum beyond those already captured by
+disconnected one-body contributions.
+
+Explicit named alias of `cor_4_3_3` (= Lebowitz inequality at `h = 0`),
+matching the `eta_nonneg_finite_vol` / `zeta_nonneg_finite_vol`
+convention. -/
+theorem absence_of_even_bound_states_finite_vol
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩) (i j k l : ι)
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    truncated4 G ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  cor_4_3_3 G J β hf i j k l hij hik hil hjk hjl hkl
+
 /-! ## Lattice-growth convergence of §5 quantities
 
 Named corollaries of `correlation_convergent_subgraph` (PR #64) for the

--- a/docs/index.md
+++ b/docs/index.md
@@ -567,7 +567,7 @@ inventory (2026-04-17).
 
 | Section | Result | Status |
 |---|---|---|
-| §17.2 | Absence of even bound states | **Done** (via Cor 4.3.3) |
+| §17.2 | Absence of even bound states | **Done (finite + ∞-vol, explicit)** | `absence_of_even_bound_states_finite_vol` (`PhaseTransition.lean`) + `Ambient.absence_of_even_bound_states_infinite_vol` (`AmbientLattice.lean`) + ℤ^d `_latticeGraph` wrappers. Explicit named aliases of `cor_4_3_3` / `truncated4Infinite_nonpos_h_zero` matching the §17.7 `eta/zeta_nonneg` convention. (PR #637.) |
 | §17.5 | Correlation length | Not formalized (spectral theory) |
 | §17.7 | `η ≥ 0`, `ζ ≥ 0` | **Done (finite + ∞-vol)** | `eta_nonneg_finite_vol` + `zeta_nonneg_finite_vol` (`PhaseTransition.lean`) + `Ambient.eta_nonneg_infinite_vol` + `Ambient.zeta_nonneg_infinite_vol` (`AmbientLattice.lean`) + ℤ^d `{eta,zeta}_nonneg_{finite,infinite}_vol_latticeGraph`. Explicit named aliases of `truncated2_nonneg`/`truncated2Infinite_nonneg` (GKS-II) and `cor_4_3_3`/`truncated4Infinite_nonpos_h_zero` (Lebowitz at `h = 0`). (PR #636.) |
 | §17.8 | `η ≤ 1` | **Done** |


### PR DESCRIPTION
## Summary

Add explicit named aliases for GJ §17.2 "Absence of even bound states", matching the §17.7 pattern from PR #636:

**Finite-volume (`IsingModel/PhaseTransition.lean`):**
- `absence_of_even_bound_states_finite_vol`: alias of `cor_4_3_3`, stating `U₄(i,j,k,l) ≤ 0` at `h = 0` for pairwise-distinct sites (bound-state nonexistence in even sector).

**∞-volume (`IsingModel/AmbientLattice.lean`):**
- `Ambient.absence_of_even_bound_states_infinite_vol`: alias of `truncated4Infinite_nonpos_h_zero`.

**ℤ^d wrappers (`Concrete/LatticeGraphCorrelation.lean`):**
- `absence_of_even_bound_states_{finite,infinite}_vol_latticeGraph`.

All are thin pass-throughs. No new proofs, no sorry.

## Why

§17.2 was marked Done "via Cor 4.3.3" but without an explicit named theorem. This PR adds the explicit §17.2 aliases matching the §17.7 convention (PR #636), making the §17.2 API explicit and discoverable.

## Test plan

- [ ] `lake build` zero warnings
- [ ] `lake exe GKSTest` passes
- [ ] Docs updated
- [ ] Cross-check via `codex exec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)