### PR TITLE
feat: sandwich bounds for slabBrick and centeredSlab (§4.6 Prop 4.6.1 two-sided)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -460,6 +460,43 @@ theorem freeEnergy_centeredSlab_tendsto
     (freeEnergy_centeredSlab_bddAbove widths p)
     (centeredSlab_one_card_ne_zero hw)
 
+/-! ## Sandwich bounds for the centered slab (ferromagnetic) -/
+
+/-- **Lower bound** on the centered slab (ferromagnetic, nonempty):
+`log 2 ≤ freeEnergy (inducedGraph (latticeGraph (d+1)) (centeredSlab widths n)) p`. -/
+theorem centeredSlab_freeEnergy_ge_log_two {widths : Fin d → ℕ} {n : ℕ}
+    (hne : (centeredSlab widths n).Nonempty)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+      ≤ IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+            (centeredSlab widths n))
+          (⟨J, h, β⟩ : IsingParams ℝ) := by
+  have hpos : 0 < Fintype.card (↑(centeredSlab widths n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_of_ferromagnetic _ _ ⟨hJ, hh, hβ⟩ hpos
+
+/-- **Sandwich bound** on the centered slab (ferromagnetic, nonempty):
+`log 2 ≤ freeEnergy ≤ log 2 + |β|·((d+1)·|J| + |h|)`.
+
+Combines `centeredSlab_freeEnergy_ge_log_two` and
+`centeredSlab_freeEnergy_le`. -/
+theorem centeredSlab_freeEnergy_sandwich {widths : Fin d → ℕ} {n : ℕ}
+    (hne : (centeredSlab widths n).Nonempty)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+      ≤ IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+            (centeredSlab widths n))
+          (⟨J, h, β⟩ : IsingParams ℝ)
+    ∧ IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+            (centeredSlab widths n))
+          (⟨J, h, β⟩ : IsingParams ℝ)
+        ≤ Real.log 2 + |β| * ((d + 1) * |J| + |h|) :=
+  ⟨centeredSlab_freeEnergy_ge_log_two hne hJ hh hβ,
+   centeredSlab_freeEnergy_le widths n ⟨J, h, β⟩⟩
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -412,6 +412,51 @@ theorem stripeBrick2D_eq_slabBrick (w n : ℕ) :
   · intro j
     simp
 
+/-! ## Sandwich bounds for the slab (ferromagnetic)
+
+Pair the upper bound `slabBrick_freeEnergy_le` (PR #642) with the
+underlying lower bound `log 2 ≤ freeEnergy` (from
+`freeEnergy_ge_log_two_of_ferromagnetic`) for the nonempty stages. -/
+
+/-- **Lower bound** on the slab (ferromagnetic, nonempty slab):
+`log 2 ≤ freeEnergy (inducedGraph (latticeGraph (d+1)) (slabBrick widths n)) p`.
+
+Derived from the base-layer `freeEnergy_ge_log_two_of_ferromagnetic`
+via the `Finset.Nonempty` coe-cardinality bridge. -/
+theorem slabBrick_freeEnergy_ge_log_two {widths : Fin d → ℕ} {n : ℕ}
+    (hne : (slabBrick widths n).Nonempty)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+      ≤ IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+            (slabBrick widths n))
+          (⟨J, h, β⟩ : IsingParams ℝ) := by
+  have hpos : 0 < Fintype.card (↑(slabBrick widths n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_of_ferromagnetic _ _ ⟨hJ, hh, hβ⟩ hpos
+
+/-- **Sandwich bound** on the slab (ferromagnetic, nonempty slab):
+`log 2 ≤ freeEnergy ≤ log 2 + |β|·((d+1)·|J| + |h|)`.
+
+Combines `slabBrick_freeEnergy_ge_log_two` and `slabBrick_freeEnergy_le`.
+Concrete slab-version of the cubic sandwich
+`freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_bounds` (PR #247). -/
+theorem slabBrick_freeEnergy_sandwich {widths : Fin d → ℕ} {n : ℕ}
+    (hne : (slabBrick widths n).Nonempty)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+      ≤ IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+            (slabBrick widths n))
+          (⟨J, h, β⟩ : IsingParams ℝ)
+    ∧ IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+            (slabBrick widths n))
+          (⟨J, h, β⟩ : IsingParams ℝ)
+        ≤ Real.log 2 + |β| * ((d + 1) * |J| + |h|) :=
+  ⟨slabBrick_freeEnergy_ge_log_two hne hJ hh hβ,
+   slabBrick_freeEnergy_le widths n ⟨J, h, β⟩⟩
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #649.

Builds on #644.

## Summary

Add explicit two-sided sandwich bounds (`log 2 ≤ freeEnergy ≤ log 2 + |β|·((d+1)·|J| + |h|)`) for both the single-sided general slab (PR #642) and two-sided centered slab (PR #644) under ferromagnetic parameters `0 ≤ J, 0 ≤ h, 0 < β`:

- `slabBrick_freeEnergy_ge_log_two`, `slabBrick_freeEnergy_sandwich`.
- `centeredSlab_freeEnergy_ge_log_two`, `centeredSlab_freeEnergy_sandwich`.

Lower bound via `freeEnergyΛ_ge_log_two` (mathlib-style application of `freeEnergy_ge_log_two_of_ferromagnetic`). Upper bound from the existing `*_freeEnergy_le` lemmas.

## Why

Gives callers a single explicit sandwich for each slab variant, matching the style of the concrete ℤ^d cubic sandwich `freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_bounds` (PR #247).

## Test plan

- [ ] `lake build` zero warnings
- [ ] `lake exe GKSTest` passes
- [ ] Codex cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)