### PR TITLE
feat: J=0 closed form for freeEnergyInfinite on slabs (§4.6 Prop 4.6.1 trivial slice)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -522,6 +522,41 @@ theorem freeEnergy_centeredSlab_tendsto_freeEnergyInfinite
       Filter.atTop (nhds (freeEnergyInfinite_centeredSlab hw p hf)) :=
   Classical.choose_spec (freeEnergy_centeredSlab_tendsto hw p hf)
 
+/-- **`centeredSlab widths n` is nonempty** when all widths are nonzero
+and `n ≥ 1`. Derived from `|centeredSlab widths n| = 2n · ∏ widths`. -/
+theorem centeredSlab_nonempty {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0) {n : ℕ} (hn : 1 ≤ n) :
+    (centeredSlab widths n).Nonempty := by
+  rw [← Finset.card_pos, centeredSlab_card]
+  have hprod : 0 < ∏ j : Fin d, widths j :=
+    Nat.pos_of_ne_zero (Finset.prod_ne_zero_iff.mpr (fun j _ => hw j))
+  have h2n : 0 < 2 * n := by linarith
+  exact Nat.mul_pos h2n hprod
+
+/-- **J=0 closed form for the centered-slab infinite-volume
+free-energy density**: `freeEnergyInfinite_centeredSlab hw ⟨0, h, β⟩ hf
+= log(2·cosh(β·h))` under ferromagnetic `0 ≤ h, 0 < β`. Parallel to
+`freeEnergyInfinite_slabBrick_J_zero`. -/
+theorem freeEnergyInfinite_centeredSlab_J_zero {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0)
+    {h β : ℝ} (hh : 0 ≤ h) (hβ : 0 < β) :
+    freeEnergyInfinite_centeredSlab hw
+        (⟨0, h, β⟩ : IsingParams ℝ) ⟨le_refl 0, hh, hβ⟩
+      = Real.log (2 * Real.cosh (β * h)) := by
+  have hconst : Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+          (centeredSlab widths n)) (⟨0, h, β⟩ : IsingParams ℝ))
+      Filter.atTop (nhds (Real.log (2 * Real.cosh (β * h)))) := by
+    refine Filter.Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+    have hne : (centeredSlab widths n).Nonempty := centeredSlab_nonempty hw hn
+    have hpos : 0 < Fintype.card (↑(centeredSlab widths n) : Type _) := by
+      rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+    exact (IsingModel.freeEnergy_J_zero _ h β hpos).symm
+  exact tendsto_nhds_unique
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ _) hconst
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -480,6 +480,44 @@ theorem freeEnergy_slabBrick_tendsto_freeEnergyInfinite
       Filter.atTop (nhds (freeEnergyInfinite_slabBrick hw p hf)) :=
   Classical.choose_spec (freeEnergy_slabBrick_tendsto hw p hf)
 
+/-- **`slabBrick widths n` is nonempty** when all widths are nonzero
+and `n ≥ 1`. Derived from the cardinality identity
+`|slabBrick widths n| = n · ∏ widths j`. -/
+theorem slabBrick_nonempty {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0) {n : ℕ} (hn : 1 ≤ n) :
+    (slabBrick widths n).Nonempty := by
+  rw [← Finset.card_pos, slabBrick_card]
+  have hprod : 0 < ∏ j : Fin d, widths j :=
+    Nat.pos_of_ne_zero (Finset.prod_ne_zero_iff.mpr (fun j _ => hw j))
+  exact Nat.mul_pos hn hprod
+
+/-- **J=0 closed form for the infinite-volume free-energy density**
+on the slab: `freeEnergyInfinite_slabBrick hw ⟨0, h, β⟩ hf = log(2·cosh(β·h))`.
+
+Per-stage value is constant `log(2·cosh(β·h))` for nonempty slabs
+(via `IsingModel.freeEnergy_J_zero`); the sequence is eventually
+constant along `atTop`, so `tendsto_nhds_unique` pins the named
+infinite-volume limit. -/
+theorem freeEnergyInfinite_slabBrick_J_zero {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0)
+    {h β : ℝ} (hh : 0 ≤ h) (hβ : 0 < β) :
+    freeEnergyInfinite_slabBrick hw
+        (⟨0, h, β⟩ : IsingParams ℝ) ⟨le_refl 0, hh, hβ⟩
+      = Real.log (2 * Real.cosh (β * h)) := by
+  have hconst : Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+          (slabBrick widths n)) (⟨0, h, β⟩ : IsingParams ℝ))
+      Filter.atTop (nhds (Real.log (2 * Real.cosh (β * h)))) := by
+    refine Filter.Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+    have hne : (slabBrick widths n).Nonempty := slabBrick_nonempty hw hn
+    have hpos : 0 < Fintype.card (↑(slabBrick widths n) : Type _) := by
+      rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+    exact (IsingModel.freeEnergy_J_zero _ h β hpos).symm
+  exact tendsto_nhds_unique
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ _) hconst
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #649.

Builds on #646.

Add J=0 trivial-slice closed form: `freeEnergyInfinite_slabBrick hw ⟨0, h, β⟩ hf = log(2·cosh(β·h))` under ferromagnetic `0 ≤ h, 0 < β`. Same for `freeEnergyInfinite_centeredSlab`. Proof: per-stage value is `log(2·cosh(β·h))` for nonempty slabs (via `IsingModel.freeEnergy_J_zero`), eventually constant along `atTop`, so `tendsto_nhds_unique` pins the named infinite-volume limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)