### PR TITLE
feat: infinite-volume sandwich bounds for all concrete slab families (§4.6 Prop 4.6.1)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -557,6 +557,45 @@ theorem freeEnergyInfinite_centeredSlab_J_zero {widths : Fin d → ℕ}
   exact tendsto_nhds_unique
     (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ _) hconst
 
+/-- **Infinite-volume lower bound** on the centered slab. -/
+theorem freeEnergyInfinite_centeredSlab_ge_log_two {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+      ≤ freeEnergyInfinite_centeredSlab hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ := by
+  refine ge_of_tendsto
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ _) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (centeredSlab widths n).Nonempty := centeredSlab_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(centeredSlab widths n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_of_ferromagnetic _ _ ⟨hJ, hh, hβ⟩ hpos
+
+/-- **Infinite-volume upper bound** on the centered slab. -/
+theorem freeEnergyInfinite_centeredSlab_le {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0)
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    freeEnergyInfinite_centeredSlab hw p hf
+      ≤ Real.log 2 + |p.β| * ((d + 1) * |p.J| + |p.h|) := by
+  refine le_of_tendsto
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw p hf) ?_
+  filter_upwards with n
+  exact centeredSlab_freeEnergy_le widths n p
+
+/-- **Infinite-volume sandwich** on the centered slab (ferromagnetic). -/
+theorem freeEnergyInfinite_centeredSlab_sandwich {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+        ≤ freeEnergyInfinite_centeredSlab hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+    ∧ freeEnergyInfinite_centeredSlab hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+        ≤ Real.log 2 + |β| * ((d + 1) * |J| + |h|) :=
+  ⟨freeEnergyInfinite_centeredSlab_ge_log_two hw hJ hh hβ,
+   freeEnergyInfinite_centeredSlab_le hw _ ⟨hJ, hh, hβ⟩⟩
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -335,6 +335,44 @@ theorem freeEnergyInfinite_linearBox_J_zero
   exact tendsto_nhds_unique
     (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ _) hconst
 
+/-- **Infinite-volume lower bound** `log 2 ≤ freeEnergyInfinite_linearBox`
+for ferromagnetic `0 ≤ J, 0 ≤ h, 0 < β`. Transports the per-stage
+`freeEnergy_ge_log_two_of_ferromagnetic` through the Fekete limit. -/
+theorem freeEnergyInfinite_linearBox_ge_log_two
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+      ≤ freeEnergyInfinite_linearBox (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ := by
+  refine ge_of_tendsto (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ _) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (linearBox n).Nonempty := linearBox_nonempty hn
+  have hpos : 0 < Fintype.card (↑(linearBox n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_of_ferromagnetic _ _ ⟨hJ, hh, hβ⟩ hpos
+
+/-- **Infinite-volume upper bound**
+`freeEnergyInfinite_linearBox ≤ log 2 + |β|·(|J| + |h|)`. Transports
+the per-stage `linearBox_freeEnergy_le` through the Fekete limit. -/
+theorem freeEnergyInfinite_linearBox_le
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    freeEnergyInfinite_linearBox p hf
+      ≤ Real.log 2 + |p.β| * (|p.J| + |p.h|) := by
+  refine le_of_tendsto (freeEnergy_linearBox_tendsto_freeEnergyInfinite p hf) ?_
+  filter_upwards with n
+  exact linearBox_freeEnergy_le n p
+
+/-- **Infinite-volume sandwich** on the 1D linearBox (ferromagnetic):
+`log 2 ≤ freeEnergyInfinite_linearBox ≤ log 2 + |β|·(|J| + |h|)`. -/
+theorem freeEnergyInfinite_linearBox_sandwich
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+        ≤ freeEnergyInfinite_linearBox
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+    ∧ freeEnergyInfinite_linearBox
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+        ≤ Real.log 2 + |β| * (|J| + |h|) :=
+  ⟨freeEnergyInfinite_linearBox_ge_log_two hJ hh hβ,
+   freeEnergyInfinite_linearBox_le _ ⟨hJ, hh, hβ⟩⟩
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -518,6 +518,45 @@ theorem freeEnergyInfinite_slabBrick_J_zero {widths : Fin d → ℕ}
   exact tendsto_nhds_unique
     (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ _) hconst
 
+/-- **Infinite-volume lower bound** on the slab. -/
+theorem freeEnergyInfinite_slabBrick_ge_log_two {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+      ≤ freeEnergyInfinite_slabBrick hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ := by
+  refine ge_of_tendsto
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ _) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (slabBrick widths n).Nonempty := slabBrick_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(slabBrick widths n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_of_ferromagnetic _ _ ⟨hJ, hh, hβ⟩ hpos
+
+/-- **Infinite-volume upper bound** on the slab. -/
+theorem freeEnergyInfinite_slabBrick_le {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0)
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    freeEnergyInfinite_slabBrick hw p hf
+      ≤ Real.log 2 + |p.β| * ((d + 1) * |p.J| + |p.h|) := by
+  refine le_of_tendsto
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw p hf) ?_
+  filter_upwards with n
+  exact slabBrick_freeEnergy_le widths n p
+
+/-- **Infinite-volume sandwich** on the slab (ferromagnetic). -/
+theorem freeEnergyInfinite_slabBrick_sandwich {widths : Fin d → ℕ}
+    (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+        ≤ freeEnergyInfinite_slabBrick hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+    ∧ freeEnergyInfinite_slabBrick hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+        ≤ Real.log 2 + |β| * ((d + 1) * |J| + |h|) :=
+  ⟨freeEnergyInfinite_slabBrick_ge_log_two hw hJ hh hβ,
+   freeEnergyInfinite_slabBrick_le hw _ ⟨hJ, hh, hβ⟩⟩
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -389,6 +389,44 @@ theorem freeEnergyInfinite_stripeBrick2D_J_zero
   exact tendsto_nhds_unique
     (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ _) hconst
 
+/-- **Infinite-volume lower bound** on the 2D stripe. -/
+theorem freeEnergyInfinite_stripeBrick2D_ge_log_two
+    {w : ℕ} (hw : w ≠ 0) {J h β : ℝ}
+    (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+      ≤ freeEnergyInfinite_stripeBrick2D hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ := by
+  refine ge_of_tendsto
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ _) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (stripeBrick2D w n).Nonempty := stripeBrick2D_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(stripeBrick2D w n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_of_ferromagnetic _ _ ⟨hJ, hh, hβ⟩ hpos
+
+/-- **Infinite-volume upper bound** on the 2D stripe. -/
+theorem freeEnergyInfinite_stripeBrick2D_le
+    {w : ℕ} (hw : w ≠ 0) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    freeEnergyInfinite_stripeBrick2D hw p hf
+      ≤ Real.log 2 + |p.β| * (2 * |p.J| + |p.h|) := by
+  refine le_of_tendsto
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw p hf) ?_
+  filter_upwards with n
+  exact stripeBrick2D_freeEnergy_le w n p
+
+/-- **Infinite-volume sandwich** on the 2D stripe (ferromagnetic). -/
+theorem freeEnergyInfinite_stripeBrick2D_sandwich
+    {w : ℕ} (hw : w ≠ 0) {J h β : ℝ}
+    (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log 2
+        ≤ freeEnergyInfinite_stripeBrick2D hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+    ∧ freeEnergyInfinite_stripeBrick2D hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+        ≤ Real.log 2 + |β| * (2 * |J| + |h|) :=
+  ⟨freeEnergyInfinite_stripeBrick2D_ge_log_two hw hJ hh hβ,
+   freeEnergyInfinite_stripeBrick2D_le hw _ ⟨hJ, hh, hβ⟩⟩
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #649.

Builds on #648.

## Summary

Transport the per-stage sandwich bound `log 2 ≤ freeEnergy ≤ log 2 + |β|·((d+1)·|J| + |h|)` through the Fekete limit to give

`log 2 ≤ freeEnergyInfinite_* ≤ log 2 + |β|·((d+1)·|J| + |h|)`

for all four concrete families:

- `freeEnergyInfinite_linearBox_ge_log_two` / `_le` / `_sandwich`.
- `freeEnergyInfinite_stripeBrick2D_*`.
- `freeEnergyInfinite_slabBrick_*`.
- `freeEnergyInfinite_centeredSlab_*`.

Proof strategy: take limits of eventually-satisfied inequalities along the Fekete-convergent sequence, using mathlib's `ge_of_tendsto` / `le_of_tendsto`.

## Test plan

- [ ] `lake build` zero warnings
- [ ] `lake exe GKSTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)