### PR TITLE
feat: translation invariance of freeEnergyInfinite_* on slabs (§4.6 Prop 4.6.1)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -596,6 +596,22 @@ theorem freeEnergyInfinite_centeredSlab_sandwich {widths : Fin d → ℕ}
   ⟨freeEnergyInfinite_centeredSlab_ge_log_two hw hJ hh hβ,
    freeEnergyInfinite_centeredSlab_le hw _ ⟨hJ, hh, hβ⟩⟩
 
+/-- **Translation-invariance of the Fekete limit** on the centered
+slab: any coord-shift of the centered-slab sequence converges to the
+same `freeEnergyInfinite_centeredSlab hw p hf`. -/
+theorem freeEnergyInfinite_centeredSlab_tendsto_shift
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (t : Fin (d + 1) → ℤ) :
+    Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+          (Ambient.vaddFinset t (centeredSlab widths n))) p)
+      Filter.atTop (nhds (freeEnergyInfinite_centeredSlab hw p hf)) := by
+  refine (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw p hf).congr ?_
+  intro n
+  exact (Ambient.freeEnergyΛ_vaddFinset_eq
+    (IsingModel.latticeGraph (d + 1)) t (centeredSlab widths n) p).symm
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -373,6 +373,21 @@ theorem freeEnergyInfinite_linearBox_sandwich
   ⟨freeEnergyInfinite_linearBox_ge_log_two hJ hh hβ,
    freeEnergyInfinite_linearBox_le _ ⟨hJ, hh, hβ⟩⟩
 
+/-- **Translation-invariance of the Fekete limit** on the 1D
+linearBox: any coord-shift of the linearBox sequence converges to the
+same `freeEnergyInfinite_linearBox p hf`. -/
+theorem freeEnergyInfinite_linearBox_tendsto_shift
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (t : Fin 1 → ℤ) :
+    Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph 1)
+          (Ambient.vaddFinset t (linearBox n))) p)
+      Filter.atTop (nhds (freeEnergyInfinite_linearBox p hf)) := by
+  refine (freeEnergy_linearBox_tendsto_freeEnergyInfinite p hf).congr ?_
+  intro n
+  exact (Ambient.freeEnergyΛ_vaddFinset_eq
+    (IsingModel.latticeGraph 1) t (linearBox n) p).symm
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -615,6 +615,31 @@ theorem freeEnergyInfinite_stripeBrick2D_eq_slabBrick
     (@freeEnergy_slabBrick_tendsto_freeEnergyInfinite 1 (fun _ : Fin 1 => w)
       (fun _ => hw) p hf)).symm
 
+/-! ## Translation invariance of the named infinite-volume limit
+
+Any coord-shift of the slab sequence converges to the same
+`freeEnergyInfinite_slabBrick` value, via translation invariance of
+`freeEnergyΛ` on the (translation-invariant) `latticeGraph (d+1)`. -/
+
+/-- **Translation-invariance of the Fekete limit** on the slab: for
+any `t : Fin (d+1) → ℤ`, the shifted sequence
+`n ↦ freeEnergy (inducedGraph (latticeGraph (d+1)) (t +ᵥ slabBrick widths n))`
+converges to the same `freeEnergyInfinite_slabBrick hw p hf`. -/
+theorem freeEnergyInfinite_slabBrick_tendsto_shift
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (t : Fin (d + 1) → ℤ) :
+    Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+          (Ambient.vaddFinset t (slabBrick widths n))) p)
+      Filter.atTop (nhds (freeEnergyInfinite_slabBrick hw p hf)) := by
+  refine (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw p hf).congr ?_
+  intro n
+  -- `freeEnergy (inducedGraph G Λ) p = freeEnergy (inducedGraph G (t +ᵥ Λ)) p`
+  -- via `Ambient.freeEnergyΛ_vaddFinset_eq` (translation invariance of Λ-form).
+  exact (Ambient.freeEnergyΛ_vaddFinset_eq
+    (IsingModel.latticeGraph (d + 1)) t (slabBrick widths n) p).symm
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -427,6 +427,22 @@ theorem freeEnergyInfinite_stripeBrick2D_sandwich
   ⟨freeEnergyInfinite_stripeBrick2D_ge_log_two hw hJ hh hβ,
    freeEnergyInfinite_stripeBrick2D_le hw _ ⟨hJ, hh, hβ⟩⟩
 
+/-- **Translation-invariance of the Fekete limit** on the 2D stripe:
+any coord-shift of the stripe sequence converges to the same
+`freeEnergyInfinite_stripeBrick2D hw p hf`. -/
+theorem freeEnergyInfinite_stripeBrick2D_tendsto_shift
+    {w : ℕ} (hw : w ≠ 0) (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (t : Fin 2 → ℤ) :
+    Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph 2)
+          (Ambient.vaddFinset t (stripeBrick2D w n))) p)
+      Filter.atTop (nhds (freeEnergyInfinite_stripeBrick2D hw p hf)) := by
+  refine (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw p hf).congr ?_
+  intro n
+  exact (Ambient.freeEnergyΛ_vaddFinset_eq
+    (IsingModel.latticeGraph 2) t (stripeBrick2D w n) p).symm
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #649.

Translation-invariance lemma: for any integer shift `t : Fin (d+1) → ℤ`, the shifted Fekete sequence `t +ᵥ slabBrick widths n` converges to the same `freeEnergyInfinite_slabBrick hw p hf` as the original. Same for `centeredSlab`, `linearBox`, `stripeBrick2D`. Proof: per-stage `freeEnergyΛ_vaddFinset_eq` (PR #255) transports pointwise, plus `Tendsto.congr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)