### PR TITLE
feat: freeEnergyInfinite_* ≥ 0 for all concrete slab families (§4.6 Prop 4.6.1)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -612,6 +612,20 @@ theorem freeEnergyInfinite_centeredSlab_tendsto_shift
   exact (Ambient.freeEnergyΛ_vaddFinset_eq
     (IsingModel.latticeGraph (d + 1)) t (centeredSlab widths n) p).symm
 
+/-- **Nonnegativity** of `freeEnergyInfinite_centeredSlab` under
+ferromagnetic parameters. -/
+theorem freeEnergyInfinite_centeredSlab_nonneg
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    0 ≤ freeEnergyInfinite_centeredSlab hw p hf := by
+  refine ge_of_tendsto
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw p hf) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (centeredSlab widths n).Nonempty := centeredSlab_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(centeredSlab widths n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_nonneg_of_ferromagnetic _ p hf hpos
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -388,6 +388,19 @@ theorem freeEnergyInfinite_linearBox_tendsto_shift
   exact (Ambient.freeEnergyΛ_vaddFinset_eq
     (IsingModel.latticeGraph 1) t (linearBox n) p).symm
 
+/-- **Nonnegativity** of `freeEnergyInfinite_linearBox` under
+ferromagnetic parameters. Transport per-stage
+`freeEnergy_nonneg_of_ferromagnetic` through the Fekete limit. -/
+theorem freeEnergyInfinite_linearBox_nonneg
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    0 ≤ freeEnergyInfinite_linearBox p hf := by
+  refine ge_of_tendsto (freeEnergy_linearBox_tendsto_freeEnergyInfinite p hf) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (linearBox n).Nonempty := linearBox_nonempty hn
+  have hpos : 0 < Fintype.card (↑(linearBox n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_nonneg_of_ferromagnetic _ p hf hpos
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -640,6 +640,20 @@ theorem freeEnergyInfinite_slabBrick_tendsto_shift
   exact (Ambient.freeEnergyΛ_vaddFinset_eq
     (IsingModel.latticeGraph (d + 1)) t (slabBrick widths n) p).symm
 
+/-- **Nonnegativity** of `freeEnergyInfinite_slabBrick` under
+ferromagnetic parameters. -/
+theorem freeEnergyInfinite_slabBrick_nonneg
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    0 ≤ freeEnergyInfinite_slabBrick hw p hf := by
+  refine ge_of_tendsto
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw p hf) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (slabBrick widths n).Nonempty := slabBrick_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(slabBrick widths n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_nonneg_of_ferromagnetic _ p hf hpos
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -443,6 +443,19 @@ theorem freeEnergyInfinite_stripeBrick2D_tendsto_shift
   exact (Ambient.freeEnergyΛ_vaddFinset_eq
     (IsingModel.latticeGraph 2) t (stripeBrick2D w n) p).symm
 
+/-- **Nonnegativity** of `freeEnergyInfinite_stripeBrick2D` under
+ferromagnetic parameters. -/
+theorem freeEnergyInfinite_stripeBrick2D_nonneg
+    {w : ℕ} (hw : w ≠ 0) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    0 ≤ freeEnergyInfinite_stripeBrick2D hw p hf := by
+  refine ge_of_tendsto
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw p hf) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (stripeBrick2D w n).Nonempty := stripeBrick2D_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(stripeBrick2D w n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_nonneg_of_ferromagnetic _ p hf hpos
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #649.

Elementary nonneg lemma: `0 ≤ freeEnergyInfinite_*` for the four named Fekete limits, under ferromagnetic parameters. Transport per-stage `freeEnergy_nonneg_of_ferromagnetic` through the limit via `ge_of_tendsto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)