### PR TITLE
feat: freeEnergyInfinite_* ≥ log(2·cosh(β·h)) tighter lower bound (§4.6)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -629,6 +629,21 @@ theorem freeEnergyInfinite_centeredSlab_nonneg
     rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
   exact IsingModel.freeEnergy_nonneg_of_ferromagnetic _ p hf hpos
 
+/-- **Tighter lower bound** `log(2·cosh(β·h)) ≤ freeEnergyInfinite_centeredSlab`. -/
+theorem freeEnergyInfinite_centeredSlab_ge_log_two_cosh
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+      ≤ freeEnergyInfinite_centeredSlab hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ := by
+  refine ge_of_tendsto
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ⟩) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (centeredSlab widths n).Nonempty := centeredSlab_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(centeredSlab widths n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hpos
+
 /-! ## 1D consistency: `centeredSlab (d=0) = shift_(-n) (linearBox (2n))`
 
 The `d = 0` centered slab is, at each index `n`, a negative-`n` shift

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -401,6 +401,22 @@ theorem freeEnergyInfinite_linearBox_nonneg
     rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
   exact IsingModel.freeEnergy_nonneg_of_ferromagnetic _ p hf hpos
 
+/-- **Tighter lower bound** `log(2·cosh(β·h)) ≤ freeEnergyInfinite_linearBox`
+under ferromagnetic `0 ≤ J, 0 ≤ h, 0 < β`. Sharper than
+`freeEnergyInfinite_linearBox_ge_log_two` (PR #650) when `h > 0`. -/
+theorem freeEnergyInfinite_linearBox_ge_log_two_cosh
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+      ≤ freeEnergyInfinite_linearBox
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ := by
+  refine ge_of_tendsto
+    (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ ⟨hJ, hh, hβ⟩) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (linearBox n).Nonempty := linearBox_nonempty hn
+  have hpos : 0 < Fintype.card (↑(linearBox n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hpos
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -654,6 +654,21 @@ theorem freeEnergyInfinite_slabBrick_nonneg
     rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
   exact IsingModel.freeEnergy_nonneg_of_ferromagnetic _ p hf hpos
 
+/-- **Tighter lower bound** `log(2·cosh(β·h)) ≤ freeEnergyInfinite_slabBrick`. -/
+theorem freeEnergyInfinite_slabBrick_ge_log_two_cosh
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+      ≤ freeEnergyInfinite_slabBrick hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ := by
+  refine ge_of_tendsto
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ⟩) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (slabBrick widths n).Nonempty := slabBrick_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(slabBrick widths n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hpos
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -456,6 +456,21 @@ theorem freeEnergyInfinite_stripeBrick2D_nonneg
     rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
   exact IsingModel.freeEnergy_nonneg_of_ferromagnetic _ p hf hpos
 
+/-- **Tighter lower bound** `log(2·cosh(β·h)) ≤ freeEnergyInfinite_stripeBrick2D`. -/
+theorem freeEnergyInfinite_stripeBrick2D_ge_log_two_cosh
+    {w : ℕ} (hw : w ≠ 0) {J h β : ℝ}
+    (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+      ≤ freeEnergyInfinite_stripeBrick2D hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ := by
+  refine ge_of_tendsto
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ⟩) ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hne : (stripeBrick2D w n).Nonempty := stripeBrick2D_nonempty hw hn
+  have hpos : 0 < Fintype.card (↑(stripeBrick2D w n) : Type _) := by
+    rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
+  exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hpos
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #658.

Tighten the infinite-volume lower bound on all four concrete Fekete families: `log(2·cosh(β·h)) ≤ freeEnergyInfinite_*` (strictly sharper than PR #650's `log 2` bound when h > 0).

Transport per-stage `freeEnergy_ge_log_two_cosh` (FreeEnergy.lean) through Fekete via `ge_of_tendsto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)