### PR TITLE
feat: cosh-form sandwich bounds for freeEnergyInfinite_* (§4.6)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -644,6 +644,19 @@ theorem freeEnergyInfinite_centeredSlab_ge_log_two_cosh
     rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
   exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hpos
 
+/-- **Cosh-form sandwich** on the centered slab. -/
+theorem freeEnergyInfinite_centeredSlab_sandwich_cosh
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+        ≤ freeEnergyInfinite_centeredSlab hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+    ∧ freeEnergyInfinite_centeredSlab hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+        ≤ Real.log 2 + |β| * ((d + 1) * |J| + |h|) :=
+  ⟨freeEnergyInfinite_centeredSlab_ge_log_two_cosh hw hJ hh hβ,
+   freeEnergyInfinite_centeredSlab_le hw _ ⟨hJ, hh, hβ⟩⟩
+
 /-! ## 1D consistency: `centeredSlab (d=0) = shift_(-n) (linearBox (2n))`
 
 The `d = 0` centered slab is, at each index `n`, a negative-`n` shift

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -417,6 +417,19 @@ theorem freeEnergyInfinite_linearBox_ge_log_two_cosh
     rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
   exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hpos
 
+/-- **Cosh-form sandwich** on the 1D linearBox: combines the tighter
+`log(2·cosh(β·h))` lower bound with the upper bound `log 2 + |β|·(|J| + |h|)`. -/
+theorem freeEnergyInfinite_linearBox_sandwich_cosh
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+        ≤ freeEnergyInfinite_linearBox
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+    ∧ freeEnergyInfinite_linearBox
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+        ≤ Real.log 2 + |β| * (|J| + |h|) :=
+  ⟨freeEnergyInfinite_linearBox_ge_log_two_cosh hJ hh hβ,
+   freeEnergyInfinite_linearBox_le _ ⟨hJ, hh, hβ⟩⟩
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -669,6 +669,19 @@ theorem freeEnergyInfinite_slabBrick_ge_log_two_cosh
     rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
   exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hpos
 
+/-- **Cosh-form sandwich** on the slab. -/
+theorem freeEnergyInfinite_slabBrick_sandwich_cosh
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+        ≤ freeEnergyInfinite_slabBrick hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+    ∧ freeEnergyInfinite_slabBrick hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+        ≤ Real.log 2 + |β| * ((d + 1) * |J| + |h|) :=
+  ⟨freeEnergyInfinite_slabBrick_ge_log_two_cosh hw hJ hh hβ,
+   freeEnergyInfinite_slabBrick_le hw _ ⟨hJ, hh, hβ⟩⟩
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -471,6 +471,19 @@ theorem freeEnergyInfinite_stripeBrick2D_ge_log_two_cosh
     rw [Fintype.card_coe]; exact Finset.card_pos.mpr hne
   exact IsingModel.freeEnergy_ge_log_two_cosh _ hJ hh hβ hpos
 
+/-- **Cosh-form sandwich** on the 2D stripe. -/
+theorem freeEnergyInfinite_stripeBrick2D_sandwich_cosh
+    {w : ℕ} (hw : w ≠ 0) {J h β : ℝ}
+    (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    Real.log (2 * Real.cosh (β * h))
+        ≤ freeEnergyInfinite_stripeBrick2D hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+    ∧ freeEnergyInfinite_stripeBrick2D hw
+            (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩
+        ≤ Real.log 2 + |β| * (2 * |J| + |h|) :=
+  ⟨freeEnergyInfinite_stripeBrick2D_ge_log_two_cosh hw hJ hh hβ,
+   freeEnergyInfinite_stripeBrick2D_le hw _ ⟨hJ, hh, hβ⟩⟩
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #658.

Combine PR #659's tighter `log(2·cosh(β·h))` lower bound with the existing upper bound (PR #650) to give a sharpened sandwich statement:

`log(2·cosh(β·h)) ≤ freeEnergyInfinite_* ≤ log 2 + |β|·((d+1)·|J| + |h|)`

for all four concrete Fekete families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)