### PR TITLE
feat: freeEnergyInfinite_* monotone in β (§4.6)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -657,6 +657,21 @@ theorem freeEnergyInfinite_centeredSlab_sandwich_cosh
   ⟨freeEnergyInfinite_centeredSlab_ge_log_two_cosh hw hJ hh hβ,
    freeEnergyInfinite_centeredSlab_le hw _ ⟨hJ, hh, hβ⟩⟩
 
+/-- **β-monotonicity** of `freeEnergyInfinite_centeredSlab`. -/
+theorem freeEnergyInfinite_centeredSlab_monotone_beta
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h)
+    {β₁ β₂ : ℝ} (hβ₁ : 0 < β₁) (hβ₂ : 0 < β₂) (hβle : β₁ ≤ β₂) :
+    freeEnergyInfinite_centeredSlab hw
+        (⟨J, h, β₁⟩ : IsingParams ℝ) ⟨hJ, hh, hβ₁⟩
+      ≤ freeEnergyInfinite_centeredSlab hw
+        (⟨J, h, β₂⟩ : IsingParams ℝ) ⟨hJ, hh, hβ₂⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ₁⟩)
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ₂⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_beta _ J hJ h hh hβ₁ hβ₂ hβle
+
 /-! ## 1D consistency: `centeredSlab (d=0) = shift_(-n) (linearBox (2n))`
 
 The `d = 0` centered slab is, at each index `n`, a negative-`n` shift

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -430,6 +430,22 @@ theorem freeEnergyInfinite_linearBox_sandwich_cosh
   ⟨freeEnergyInfinite_linearBox_ge_log_two_cosh hJ hh hβ,
    freeEnergyInfinite_linearBox_le _ ⟨hJ, hh, hβ⟩⟩
 
+/-- **β-monotonicity** of `freeEnergyInfinite_linearBox` on `Set.Ioi 0`:
+for ferromagnetic `0 ≤ J, 0 ≤ h`, `0 < β₁ ≤ β₂` implies
+`freeEnergyInfinite_linearBox ⟨J, h, β₁⟩ ≤ freeEnergyInfinite_linearBox ⟨J, h, β₂⟩`. -/
+theorem freeEnergyInfinite_linearBox_monotone_beta
+    {J h : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h)
+    {β₁ β₂ : ℝ} (hβ₁ : 0 < β₁) (hβ₂ : 0 < β₂) (hβle : β₁ ≤ β₂) :
+    freeEnergyInfinite_linearBox
+        (⟨J, h, β₁⟩ : IsingParams ℝ) ⟨hJ, hh, hβ₁⟩
+      ≤ freeEnergyInfinite_linearBox
+        (⟨J, h, β₂⟩ : IsingParams ℝ) ⟨hJ, hh, hβ₂⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ ⟨hJ, hh, hβ₁⟩)
+    (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ ⟨hJ, hh, hβ₂⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_beta _ J hJ h hh hβ₁ hβ₂ hβle
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -682,6 +682,21 @@ theorem freeEnergyInfinite_slabBrick_sandwich_cosh
   ⟨freeEnergyInfinite_slabBrick_ge_log_two_cosh hw hJ hh hβ,
    freeEnergyInfinite_slabBrick_le hw _ ⟨hJ, hh, hβ⟩⟩
 
+/-- **β-monotonicity** of `freeEnergyInfinite_slabBrick`. -/
+theorem freeEnergyInfinite_slabBrick_monotone_beta
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h)
+    {β₁ β₂ : ℝ} (hβ₁ : 0 < β₁) (hβ₂ : 0 < β₂) (hβle : β₁ ≤ β₂) :
+    freeEnergyInfinite_slabBrick hw
+        (⟨J, h, β₁⟩ : IsingParams ℝ) ⟨hJ, hh, hβ₁⟩
+      ≤ freeEnergyInfinite_slabBrick hw
+        (⟨J, h, β₂⟩ : IsingParams ℝ) ⟨hJ, hh, hβ₂⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ₁⟩)
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ₂⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_beta _ J hJ h hh hβ₁ hβ₂ hβle
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -484,6 +484,21 @@ theorem freeEnergyInfinite_stripeBrick2D_sandwich_cosh
   ⟨freeEnergyInfinite_stripeBrick2D_ge_log_two_cosh hw hJ hh hβ,
    freeEnergyInfinite_stripeBrick2D_le hw _ ⟨hJ, hh, hβ⟩⟩
 
+/-- **β-monotonicity** of `freeEnergyInfinite_stripeBrick2D`. -/
+theorem freeEnergyInfinite_stripeBrick2D_monotone_beta
+    {w : ℕ} (hw : w ≠ 0)
+    {J h : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h)
+    {β₁ β₂ : ℝ} (hβ₁ : 0 < β₁) (hβ₂ : 0 < β₂) (hβle : β₁ ≤ β₂) :
+    freeEnergyInfinite_stripeBrick2D hw
+        (⟨J, h, β₁⟩ : IsingParams ℝ) ⟨hJ, hh, hβ₁⟩
+      ≤ freeEnergyInfinite_stripeBrick2D hw
+        (⟨J, h, β₂⟩ : IsingParams ℝ) ⟨hJ, hh, hβ₂⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ₁⟩)
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh, hβ₂⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_beta _ J hJ h hh hβ₁ hβ₂ hβle
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #658. Transport per-stage `freeEnergy_monotone_beta` through Fekete: `freeEnergyInfinite_*` is monotone in β on `Set.Ioi 0` for all four concrete families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)