### PR TITLE
feat: freeEnergyInfinite_* monotone in h and J (§4.6)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -672,6 +672,36 @@ theorem freeEnergyInfinite_centeredSlab_monotone_beta
   intro n
   exact IsingModel.freeEnergy_monotone_beta _ J hJ h hh hβ₁ hβ₂ hβle
 
+/-- **h-monotonicity** of `freeEnergyInfinite_centeredSlab`. -/
+theorem freeEnergyInfinite_centeredSlab_monotone_h
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh₁ : 0 ≤ h₁) (hh₂ : 0 ≤ h₂) (hhle : h₁ ≤ h₂) :
+    freeEnergyInfinite_centeredSlab hw
+        (⟨J, h₁, β⟩ : IsingParams ℝ) ⟨hJ, hh₁, hβ⟩
+      ≤ freeEnergyInfinite_centeredSlab hw
+        (⟨J, h₂, β⟩ : IsingParams ℝ) ⟨hJ, hh₂, hβ⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh₁, hβ⟩)
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh₂, hβ⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_h _ J β hJ hβ hh₁ hh₂ hhle
+
+/-- **J-monotonicity** of `freeEnergyInfinite_centeredSlab`. -/
+theorem freeEnergyInfinite_centeredSlab_monotone_J
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β)
+    {J₁ J₂ : ℝ} (hJ₁ : 0 ≤ J₁) (hJ₂ : 0 ≤ J₂) (hJle : J₁ ≤ J₂) :
+    freeEnergyInfinite_centeredSlab hw
+        (⟨J₁, h, β⟩ : IsingParams ℝ) ⟨hJ₁, hh, hβ⟩
+      ≤ freeEnergyInfinite_centeredSlab hw
+        (⟨J₂, h, β⟩ : IsingParams ℝ) ⟨hJ₂, hh, hβ⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ ⟨hJ₁, hh, hβ⟩)
+    (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw _ ⟨hJ₂, hh, hβ⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
+
 /-! ## 1D consistency: `centeredSlab (d=0) = shift_(-n) (linearBox (2n))`
 
 The `d = 0` centered slab is, at each index `n`, a negative-`n` shift

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -446,6 +446,34 @@ theorem freeEnergyInfinite_linearBox_monotone_beta
   intro n
   exact IsingModel.freeEnergy_monotone_beta _ J hJ h hh hβ₁ hβ₂ hβle
 
+/-- **h-monotonicity** of `freeEnergyInfinite_linearBox` on `Set.Ici 0`. -/
+theorem freeEnergyInfinite_linearBox_monotone_h
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh₁ : 0 ≤ h₁) (hh₂ : 0 ≤ h₂) (hhle : h₁ ≤ h₂) :
+    freeEnergyInfinite_linearBox
+        (⟨J, h₁, β⟩ : IsingParams ℝ) ⟨hJ, hh₁, hβ⟩
+      ≤ freeEnergyInfinite_linearBox
+        (⟨J, h₂, β⟩ : IsingParams ℝ) ⟨hJ, hh₂, hβ⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ ⟨hJ, hh₁, hβ⟩)
+    (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ ⟨hJ, hh₂, hβ⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_h _ J β hJ hβ hh₁ hh₂ hhle
+
+/-- **J-monotonicity** of `freeEnergyInfinite_linearBox` on `Set.Ici 0`. -/
+theorem freeEnergyInfinite_linearBox_monotone_J
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β)
+    {J₁ J₂ : ℝ} (hJ₁ : 0 ≤ J₁) (hJ₂ : 0 ≤ J₂) (hJle : J₁ ≤ J₂) :
+    freeEnergyInfinite_linearBox
+        (⟨J₁, h, β⟩ : IsingParams ℝ) ⟨hJ₁, hh, hβ⟩
+      ≤ freeEnergyInfinite_linearBox
+        (⟨J₂, h, β⟩ : IsingParams ℝ) ⟨hJ₂, hh, hβ⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ ⟨hJ₁, hh, hβ⟩)
+    (freeEnergy_linearBox_tendsto_freeEnergyInfinite _ ⟨hJ₂, hh, hβ⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -697,6 +697,36 @@ theorem freeEnergyInfinite_slabBrick_monotone_beta
   intro n
   exact IsingModel.freeEnergy_monotone_beta _ J hJ h hh hβ₁ hβ₂ hβle
 
+/-- **h-monotonicity** of `freeEnergyInfinite_slabBrick`. -/
+theorem freeEnergyInfinite_slabBrick_monotone_h
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh₁ : 0 ≤ h₁) (hh₂ : 0 ≤ h₂) (hhle : h₁ ≤ h₂) :
+    freeEnergyInfinite_slabBrick hw
+        (⟨J, h₁, β⟩ : IsingParams ℝ) ⟨hJ, hh₁, hβ⟩
+      ≤ freeEnergyInfinite_slabBrick hw
+        (⟨J, h₂, β⟩ : IsingParams ℝ) ⟨hJ, hh₂, hβ⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh₁, hβ⟩)
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh₂, hβ⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_h _ J β hJ hβ hh₁ hh₂ hhle
+
+/-- **J-monotonicity** of `freeEnergyInfinite_slabBrick`. -/
+theorem freeEnergyInfinite_slabBrick_monotone_J
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β)
+    {J₁ J₂ : ℝ} (hJ₁ : 0 ≤ J₁) (hJ₂ : 0 ≤ J₂) (hJle : J₁ ≤ J₂) :
+    freeEnergyInfinite_slabBrick hw
+        (⟨J₁, h, β⟩ : IsingParams ℝ) ⟨hJ₁, hh, hβ⟩
+      ≤ freeEnergyInfinite_slabBrick hw
+        (⟨J₂, h, β⟩ : IsingParams ℝ) ⟨hJ₂, hh, hβ⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ ⟨hJ₁, hh, hβ⟩)
+    (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw _ ⟨hJ₂, hh, hβ⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -499,6 +499,36 @@ theorem freeEnergyInfinite_stripeBrick2D_monotone_beta
   intro n
   exact IsingModel.freeEnergy_monotone_beta _ J hJ h hh hβ₁ hβ₂ hβle
 
+/-- **h-monotonicity** of `freeEnergyInfinite_stripeBrick2D`. -/
+theorem freeEnergyInfinite_stripeBrick2D_monotone_h
+    {w : ℕ} (hw : w ≠ 0)
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh₁ : 0 ≤ h₁) (hh₂ : 0 ≤ h₂) (hhle : h₁ ≤ h₂) :
+    freeEnergyInfinite_stripeBrick2D hw
+        (⟨J, h₁, β⟩ : IsingParams ℝ) ⟨hJ, hh₁, hβ⟩
+      ≤ freeEnergyInfinite_stripeBrick2D hw
+        (⟨J, h₂, β⟩ : IsingParams ℝ) ⟨hJ, hh₂, hβ⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh₁, hβ⟩)
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ ⟨hJ, hh₂, hβ⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_h _ J β hJ hβ hh₁ hh₂ hhle
+
+/-- **J-monotonicity** of `freeEnergyInfinite_stripeBrick2D`. -/
+theorem freeEnergyInfinite_stripeBrick2D_monotone_J
+    {w : ℕ} (hw : w ≠ 0)
+    {h : ℝ} (hh : 0 ≤ h) {β : ℝ} (hβ : 0 < β)
+    {J₁ J₂ : ℝ} (hJ₁ : 0 ≤ J₁) (hJ₂ : 0 ≤ J₂) (hJle : J₁ ≤ J₂) :
+    freeEnergyInfinite_stripeBrick2D hw
+        (⟨J₁, h, β⟩ : IsingParams ℝ) ⟨hJ₁, hh, hβ⟩
+      ≤ freeEnergyInfinite_stripeBrick2D hw
+        (⟨J₂, h, β⟩ : IsingParams ℝ) ⟨hJ₂, hh, hβ⟩ := by
+  refine le_of_tendsto_of_tendsto'
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ ⟨hJ₁, hh, hβ⟩)
+    (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw _ ⟨hJ₂, hh, hβ⟩) ?_
+  intro n
+  exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #658. Transport per-stage `freeEnergy_monotone_h` / `freeEnergy_monotone_J` through Fekete for all four concrete families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)