### PR TITLE
feat: Fekete convergence at any real h via |h|-symmetry (§4.6)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -702,6 +702,23 @@ theorem freeEnergyInfinite_centeredSlab_monotone_J
   intro n
   exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
 
+/-- **Fekete convergence for any real h** on the centered slab. -/
+theorem freeEnergy_centeredSlab_tendsto_of_abs_h
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J β : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (h : ℝ) :
+    Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+          (centeredSlab widths n))
+        (⟨J, h, β⟩ : IsingParams ℝ))
+      Filter.atTop
+      (nhds (freeEnergyInfinite_centeredSlab hw
+        (⟨J, |h|, β⟩ : IsingParams ℝ) ⟨hJ, abs_nonneg h, hβ⟩)) := by
+  refine (freeEnergy_centeredSlab_tendsto_freeEnergyInfinite hw
+    (⟨J, |h|, β⟩ : IsingParams ℝ) ⟨hJ, abs_nonneg h, hβ⟩).congr ?_
+  intro n
+  exact (IsingModel.freeEnergy_eq_abs_h _ J h β).symm
+
 /-! ## 1D consistency: `centeredSlab (d=0) = shift_(-n) (linearBox (2n))`
 
 The `d = 0` centered slab is, at each index `n`, a negative-`n` shift

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -474,6 +474,27 @@ theorem freeEnergyInfinite_linearBox_monotone_J
   intro n
   exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
 
+/-- **Fekete convergence for any real h** (not just `h ≥ 0`): the 1D
+linearBox free-energy sequence at `⟨J, h, β⟩` converges to
+`freeEnergyInfinite_linearBox ⟨J, |h|, β⟩` (ferromagnetic at |h|).
+Proof: per-stage `freeEnergy_eq_abs_h` symmetry rewrites the sequence
+at any real h to the sequence at |h|, which is Fekete-convergent. -/
+theorem freeEnergy_linearBox_tendsto_of_abs_h
+    {J β : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (h : ℝ) :
+    Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph 1) (linearBox n))
+        (⟨J, h, β⟩ : IsingParams ℝ))
+      Filter.atTop
+      (nhds (freeEnergyInfinite_linearBox
+        (⟨J, |h|, β⟩ : IsingParams ℝ) ⟨hJ, abs_nonneg h, hβ⟩)) := by
+  refine (freeEnergy_linearBox_tendsto_freeEnergyInfinite
+    (⟨J, |h|, β⟩ : IsingParams ℝ) ⟨hJ, abs_nonneg h, hβ⟩).congr ?_
+  intro n
+  -- `freeEnergy G ⟨J, |h|, β⟩ = freeEnergy G ⟨J, h, β⟩` by
+  -- `IsingModel.freeEnergy_eq_abs_h` (symmetric).
+  exact (IsingModel.freeEnergy_eq_abs_h _ J h β).symm
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -727,6 +727,23 @@ theorem freeEnergyInfinite_slabBrick_monotone_J
   intro n
   exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
 
+/-- **Fekete convergence for any real h** on the slab. -/
+theorem freeEnergy_slabBrick_tendsto_of_abs_h
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J β : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (h : ℝ) :
+    Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph (d + 1))
+          (slabBrick widths n))
+        (⟨J, h, β⟩ : IsingParams ℝ))
+      Filter.atTop
+      (nhds (freeEnergyInfinite_slabBrick hw
+        (⟨J, |h|, β⟩ : IsingParams ℝ) ⟨hJ, abs_nonneg h, hβ⟩)) := by
+  refine (freeEnergy_slabBrick_tendsto_freeEnergyInfinite hw
+    (⟨J, |h|, β⟩ : IsingParams ℝ) ⟨hJ, abs_nonneg h, hβ⟩).congr ?_
+  intro n
+  exact (IsingModel.freeEnergy_eq_abs_h _ J h β).symm
+
 end Concrete
 
 end IsingModel

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -529,6 +529,21 @@ theorem freeEnergyInfinite_stripeBrick2D_monotone_J
   intro n
   exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
 
+/-- **Fekete convergence for any real h** on the 2D stripe. -/
+theorem freeEnergy_stripeBrick2D_tendsto_of_abs_h
+    {w : ℕ} (hw : w ≠ 0) {J β : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (h : ℝ) :
+    Filter.Tendsto
+      (fun n => IsingModel.freeEnergy
+        (Ambient.inducedGraph (IsingModel.latticeGraph 2) (stripeBrick2D w n))
+        (⟨J, h, β⟩ : IsingParams ℝ))
+      Filter.atTop
+      (nhds (freeEnergyInfinite_stripeBrick2D hw
+        (⟨J, |h|, β⟩ : IsingParams ℝ) ⟨hJ, abs_nonneg h, hβ⟩)) := by
+  refine (freeEnergy_stripeBrick2D_tendsto_freeEnergyInfinite hw
+    (⟨J, |h|, β⟩ : IsingParams ℝ) ⟨hJ, abs_nonneg h, hβ⟩).congr ?_
+  intro n
+  exact (IsingModel.freeEnergy_eq_abs_h _ J h β).symm
+
 end Concrete
 
 end IsingModel


### PR DESCRIPTION
Part of #658. Extend the slab Fekete convergence to ANY real h (not just h ≥ 0), using per-stage `freeEnergy_neg_h` symmetry + reduction to |h|. Gives non-ferromagnetic convergence statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)