### PR TITLE
feat: freeEnergyInfinite_* > 0 strict positivity (§4.6 polish)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -702,6 +702,15 @@ theorem freeEnergyInfinite_centeredSlab_monotone_J
   intro n
   exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
 
+/-- **Strict positivity** `0 < freeEnergyInfinite_centeredSlab`. -/
+theorem freeEnergyInfinite_centeredSlab_pos
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    0 < freeEnergyInfinite_centeredSlab hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ :=
+  lt_of_lt_of_le (Real.log_pos (by norm_num))
+    (freeEnergyInfinite_centeredSlab_ge_log_two hw hJ hh hβ)
+
 /-- **Fekete convergence for any real h** on the centered slab. -/
 theorem freeEnergy_centeredSlab_tendsto_of_abs_h
     {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -474,6 +474,16 @@ theorem freeEnergyInfinite_linearBox_monotone_J
   intro n
   exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
 
+/-- **Strict positivity** `0 < freeEnergyInfinite_linearBox` under
+ferromagnetic parameters. Immediate from
+`freeEnergyInfinite_linearBox_ge_log_two` and `0 < log 2`. -/
+theorem freeEnergyInfinite_linearBox_pos
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    0 < freeEnergyInfinite_linearBox
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ :=
+  lt_of_lt_of_le (Real.log_pos (by norm_num))
+    (freeEnergyInfinite_linearBox_ge_log_two hJ hh hβ)
+
 /-- **Fekete convergence for any real h** (not just `h ≥ 0`): the 1D
 linearBox free-energy sequence at `⟨J, h, β⟩` converges to
 `freeEnergyInfinite_linearBox ⟨J, |h|, β⟩` (ferromagnetic at |h|).

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -727,6 +727,15 @@ theorem freeEnergyInfinite_slabBrick_monotone_J
   intro n
   exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
 
+/-- **Strict positivity** `0 < freeEnergyInfinite_slabBrick`. -/
+theorem freeEnergyInfinite_slabBrick_pos
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    0 < freeEnergyInfinite_slabBrick hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ :=
+  lt_of_lt_of_le (Real.log_pos (by norm_num))
+    (freeEnergyInfinite_slabBrick_ge_log_two hw hJ hh hβ)
+
 /-- **Fekete convergence for any real h** on the slab. -/
 theorem freeEnergy_slabBrick_tendsto_of_abs_h
     {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -529,6 +529,15 @@ theorem freeEnergyInfinite_stripeBrick2D_monotone_J
   intro n
   exact IsingModel.freeEnergy_monotone_J _ h β hh hβ hJ₁ hJ₂ hJle
 
+/-- **Strict positivity** `0 < freeEnergyInfinite_stripeBrick2D`. -/
+theorem freeEnergyInfinite_stripeBrick2D_pos
+    {w : ℕ} (hw : w ≠ 0) {J h β : ℝ}
+    (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    0 < freeEnergyInfinite_stripeBrick2D hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ :=
+  lt_of_lt_of_le (Real.log_pos (by norm_num))
+    (freeEnergyInfinite_stripeBrick2D_ge_log_two hw hJ hh hβ)
+
 /-- **Fekete convergence for any real h** on the 2D stripe. -/
 theorem freeEnergy_stripeBrick2D_tendsto_of_abs_h
     {w : ℕ} (hw : w ≠ 0) {J β : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (h : ℝ) :


### PR DESCRIPTION
Part of #665. Strict positivity `0 < freeEnergyInfinite_*` for all four concrete families under ferromagnetic. Immediate from `log 2 ≤ freeEnergyInfinite_*` (PR #650) and `0 < log 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)