### PR TITLE
feat: freeEnergyInfinite_* ≠ 0 (§4.6 polish)

### DIFF
--- a/IsingModel/Concrete/CenteredSlab.lean
+++ b/IsingModel/Concrete/CenteredSlab.lean
@@ -711,6 +711,14 @@ theorem freeEnergyInfinite_centeredSlab_pos
   lt_of_lt_of_le (Real.log_pos (by norm_num))
     (freeEnergyInfinite_centeredSlab_ge_log_two hw hJ hh hβ)
 
+/-- **Non-vanishing** `freeEnergyInfinite_centeredSlab ≠ 0`. -/
+theorem freeEnergyInfinite_centeredSlab_ne_zero
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    freeEnergyInfinite_centeredSlab hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ ≠ 0 :=
+  ne_of_gt (freeEnergyInfinite_centeredSlab_pos hw hJ hh hβ)
+
 /-- **Fekete convergence for any real h** on the centered slab. -/
 theorem freeEnergy_centeredSlab_tendsto_of_abs_h
     {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)

--- a/IsingModel/Concrete/LinearBrick.lean
+++ b/IsingModel/Concrete/LinearBrick.lean
@@ -484,6 +484,13 @@ theorem freeEnergyInfinite_linearBox_pos
   lt_of_lt_of_le (Real.log_pos (by norm_num))
     (freeEnergyInfinite_linearBox_ge_log_two hJ hh hβ)
 
+/-- **Non-vanishing** `freeEnergyInfinite_linearBox ≠ 0` under ferromagnetic. -/
+theorem freeEnergyInfinite_linearBox_ne_zero
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    freeEnergyInfinite_linearBox
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ ≠ 0 :=
+  ne_of_gt (freeEnergyInfinite_linearBox_pos hJ hh hβ)
+
 /-- **Fekete convergence for any real h** (not just `h ≥ 0`): the 1D
 linearBox free-energy sequence at `⟨J, h, β⟩` converges to
 `freeEnergyInfinite_linearBox ⟨J, |h|, β⟩` (ferromagnetic at |h|).

--- a/IsingModel/Concrete/SlabBrick.lean
+++ b/IsingModel/Concrete/SlabBrick.lean
@@ -736,6 +736,14 @@ theorem freeEnergyInfinite_slabBrick_pos
   lt_of_lt_of_le (Real.log_pos (by norm_num))
     (freeEnergyInfinite_slabBrick_ge_log_two hw hJ hh hβ)
 
+/-- **Non-vanishing** `freeEnergyInfinite_slabBrick ≠ 0`. -/
+theorem freeEnergyInfinite_slabBrick_ne_zero
+    {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    freeEnergyInfinite_slabBrick hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ ≠ 0 :=
+  ne_of_gt (freeEnergyInfinite_slabBrick_pos hw hJ hh hβ)
+
 /-- **Fekete convergence for any real h** on the slab. -/
 theorem freeEnergy_slabBrick_tendsto_of_abs_h
     {widths : Fin d → ℕ} (hw : ∀ j : Fin d, widths j ≠ 0)

--- a/IsingModel/Concrete/StripeBrick2D.lean
+++ b/IsingModel/Concrete/StripeBrick2D.lean
@@ -538,6 +538,14 @@ theorem freeEnergyInfinite_stripeBrick2D_pos
   lt_of_lt_of_le (Real.log_pos (by norm_num))
     (freeEnergyInfinite_stripeBrick2D_ge_log_two hw hJ hh hβ)
 
+/-- **Non-vanishing** `freeEnergyInfinite_stripeBrick2D ≠ 0`. -/
+theorem freeEnergyInfinite_stripeBrick2D_ne_zero
+    {w : ℕ} (hw : w ≠ 0) {J h β : ℝ}
+    (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) :
+    freeEnergyInfinite_stripeBrick2D hw
+          (⟨J, h, β⟩ : IsingParams ℝ) ⟨hJ, hh, hβ⟩ ≠ 0 :=
+  ne_of_gt (freeEnergyInfinite_stripeBrick2D_pos hw hJ hh hβ)
+
 /-- **Fekete convergence for any real h** on the 2D stripe. -/
 theorem freeEnergy_stripeBrick2D_tendsto_of_abs_h
     {w : ℕ} (hw : w ≠ 0) {J β : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (h : ℝ) :


### PR DESCRIPTION
Part of #665. Trivial `freeEnergyInfinite_* ≠ 0` from strict positivity (PR #666).

🤖 Generated with [Claude Code](https://claude.com/claude-code)