### PR TITLE
feat: §10.6 Euclidean dot product distributes over addition

### DIFF
--- a/IsingModel/Conditioning.lean
+++ b/IsingModel/Conditioning.lean
@@ -303,6 +303,26 @@ theorem euclidean_inner_one_right {n : ℕ} (x : Fin n → ℝ) :
   intros i _
   ring
 
+/-- **Euclidean dot product distributes over left addition**:
+`∑ (xᵢ + yᵢ) · zᵢ = ∑ xᵢ · zᵢ + ∑ yᵢ · zᵢ`. -/
+theorem euclidean_inner_add_left {n : ℕ} (x y z : Fin n → ℝ) :
+    ∑ i : Fin n, (x i + y i) * z i
+      = (∑ i : Fin n, x i * z i) + (∑ i : Fin n, y i * z i) := by
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intros i _
+  ring
+
+/-- **Euclidean dot product distributes over right addition**:
+`∑ xᵢ · (yᵢ + zᵢ) = ∑ xᵢ · yᵢ + ∑ xᵢ · zᵢ`. -/
+theorem euclidean_inner_add_right {n : ℕ} (x y z : Fin n → ℝ) :
+    ∑ i : Fin n, x i * (y i + z i)
+      = (∑ i : Fin n, x i * y i) + (∑ i : Fin n, x i * z i) := by
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intros i _
+  ring
+
 /-- **Constant-diagonal instance**: if `f : α → ℝ` is nonneg, then
 the form `fun x _ => f x` (constant in the second argument) is
 reflection positive. -/


### PR DESCRIPTION
`∑ (x+y)·z = ∑ x·z + ∑ y·z` and right-hand version.