### PR TITLE
feat: §5.1 truncated2Infinite J=0 diagonal case

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -3341,6 +3341,31 @@ theorem truncated2Infinite_J_zero_of_ne
   rw [hcard_pair, hcard_i, hcard_j]
   ring
 
+/-- **∞-volume truncated 2-point at `J = 0` diagonal**:
+`truncated2Infinite ⟨0, h, β⟩ i i = tanh(β·h) · (1 − tanh(β·h))`
+(ferromagnetic). Complements `truncated2Infinite_J_zero_of_ne`
+(off-diagonal = 0). Uses the Finset collapse `{i,i} = {i}`, so
+`⟨σ_i σ_i⟩ = ⟨σ_i⟩` at the Finset level — the same caveat as
+`susceptibility_J_zero` and `twoPointFunction_zero`. Pure algebraic
+identity at `J = 0` via `correlationInfinite_J_zero`.
+
+Reference: Glimm–Jaffe *Quantum Physics* 2nd ed., §5.1 pp. 72–74. -/
+theorem truncated2Infinite_J_zero_diagonal
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (h β : ℝ)
+    (hf : Ferromagnetic (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ))
+    (i : V) :
+    truncated2Infinite G Λ (⟨0, h, β⟩ : IsingParams ℝ) i i
+      = Real.tanh (β * h) * (1 - Real.tanh (β * h)) := by
+  unfold truncated2Infinite
+  have hpair : ({i, i} : Finset V) = {i} := by simp
+  have h1 : correlationInfinite G Λ (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ) {i}
+      = Real.tanh (β * h) := by
+    rw [correlationInfinite_J_zero G Λ h β hf, Finset.card_singleton, pow_one]
+  rw [hpair, h1]
+  ring
+
 /-- **∞-volume truncated 2-point function vanishes at `β = 0`**
 for any `J, h` and any sites `i, j : V` (distinct or not).
 


### PR DESCRIPTION
## Goal

Complete the `truncated2Infinite` J=0 trivial-slice coverage: off-diagonal `i ≠ j` is already zero (`truncated2Infinite_J_zero_of_ne`); this PR adds the **diagonal** case `i = j`.

At `J = 0`, `⟨σ_i⟩_∞ = tanh(β·h)` via `correlationInfinite_J_zero`. Then

`truncated2Infinite ⟨0,h,β⟩ i i = ⟨σ_i·σ_i⟩ − ⟨σ_i⟩² = ⟨σ_i⟩ − ⟨σ_i⟩² = tanh(β·h) − tanh(β·h)²`

(Finset-based `{i,i}` collapses to `{i}`; same caveat as `susceptibility_J_zero` and `twoPointFunction_zero`).

Pure algebra, no function theory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)