### PR TITLE
feat: §5.1 truncated3Infinite J=0 coincidence ℤ^d wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -8692,6 +8692,31 @@ theorem truncated3Infinite_latticeGraph_J_zero_of_pairwise_distinct
   truncated3Infinite_J_zero_of_pairwise_distinct (IsingModel.latticeGraph d) Λ
     h β hf hij hjk hik
 
+/-- **ℤ^d truncated3Infinite J=0 pair coincidence vanishes**
+(`i = j ≠ k`): concrete wrapper for
+`truncated3Infinite_J_zero_of_pair_coincidence` (#742). -/
+theorem truncated3Infinite_latticeGraph_J_zero_of_pair_coincidence
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (h β : ℝ)
+    (hf : Ferromagnetic (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ))
+    {i k : Fin d → ℤ} (hik : i ≠ k) :
+    truncated3Infinite (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ) i i k = 0 :=
+  truncated3Infinite_J_zero_of_pair_coincidence (IsingModel.latticeGraph d) Λ
+    h β hf hik
+
+/-- **ℤ^d truncated3Infinite J=0 all-coincident closed form**:
+`truncated3Infinite ⟨0,h,β⟩ i i i = t·(1-t)·(1-2t)` with `t = tanh(β·h)`.
+Concrete wrapper for `truncated3Infinite_J_zero_all_coincident` (#743). -/
+theorem truncated3Infinite_latticeGraph_J_zero_all_coincident
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (h β : ℝ)
+    (hf : Ferromagnetic (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ))
+    (i : Fin d → ℤ) :
+    truncated3Infinite (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ) i i i
+      = Real.tanh (β * h) * (1 - Real.tanh (β * h))
+          * (1 - 2 * Real.tanh (β * h)) :=
+  truncated3Infinite_J_zero_all_coincident (IsingModel.latticeGraph d) Λ h β hf i
+
 /-- **ℤ^d truncated4Infinite β=0 site-wise**: `= 0`. -/
 theorem truncated4Infinite_latticeGraph_beta_zero
     (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (J h : ℝ)


### PR DESCRIPTION
## Goal

ℤ^d wrappers for the newly-added truncated3Infinite J=0 coincidence lemmas:
- #742 `truncated3Infinite_J_zero_of_pair_coincidence` — `i = j ≠ k` → 0
- #743 `truncated3Infinite_J_zero_all_coincident` — `i = j = k` → `t·(1-t)·(1-2t)`

Pure algebra, no function theory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)