### PR TITLE
feat: §5.1 truncated4Infinite J=0 coincidence ℤ^d wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -8738,6 +8738,52 @@ theorem truncated4Infinite_latticeGraph_J_zero_of_pairwise_distinct
   truncated4Infinite_J_zero_of_pairwise_distinct (IsingModel.latticeGraph d) Λ
     h β hf hij hik hil hjk hjl hkl
 
+/-- **ℤ^d truncated4Infinite J=0 one-pair coincidence** (#745). -/
+theorem truncated4Infinite_latticeGraph_J_zero_of_one_pair_coincidence
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (h β : ℝ)
+    (hf : Ferromagnetic (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ))
+    {i k l : Fin d → ℤ}
+    (hik : i ≠ k) (hil : i ≠ l) (hkl : k ≠ l) :
+    truncated4Infinite (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ) i i k l
+      = -2 * Real.tanh (β * h) ^ 4 :=
+  truncated4Infinite_J_zero_of_one_pair_coincidence
+    (IsingModel.latticeGraph d) Λ h β hf hik hil hkl
+
+/-- **ℤ^d truncated4Infinite J=0 two-pair coincidence** (#746). -/
+theorem truncated4Infinite_latticeGraph_J_zero_of_two_pair_coincidence
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (h β : ℝ)
+    (hf : Ferromagnetic (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ))
+    {i k : Fin d → ℤ} (hik : i ≠ k) :
+    truncated4Infinite (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ) i i k k
+      = -2 * Real.tanh (β * h) ^ 4 :=
+  truncated4Infinite_J_zero_of_two_pair_coincidence
+    (IsingModel.latticeGraph d) Λ h β hf hik
+
+/-- **ℤ^d truncated4Infinite J=0 triple coincidence** (#747):
+`t² − 3·t³`. -/
+theorem truncated4Infinite_latticeGraph_J_zero_of_triple_coincidence
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (h β : ℝ)
+    (hf : Ferromagnetic (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ))
+    {i l : Fin d → ℤ} (hil : i ≠ l) :
+    truncated4Infinite (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ) i i i l
+      = Real.tanh (β * h) ^ 2 - 3 * Real.tanh (β * h) ^ 3 :=
+  truncated4Infinite_J_zero_of_triple_coincidence
+    (IsingModel.latticeGraph d) Λ h β hf hil
+
+/-- **ℤ^d truncated4Infinite J=0 all-coincident** (#748): `t − 3·t²`. -/
+theorem truncated4Infinite_latticeGraph_J_zero_all_coincident
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (h β : ℝ)
+    (hf : Ferromagnetic (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ))
+    (i : Fin d → ℤ) :
+    truncated4Infinite (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ) i i i i
+      = Real.tanh (β * h) - 3 * Real.tanh (β * h) ^ 2 :=
+  truncated4Infinite_J_zero_all_coincident
+    (IsingModel.latticeGraph d) Λ h β hf i
+
 /-- **ℤ^d truncated3Infinite nonpos** (GHS) site-wise (any Exhaustion). -/
 theorem truncated3Infinite_latticeGraph_nonpos
     (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))


### PR DESCRIPTION
ℤ^d wrappers for #745 (one-pair), #746 (two-pair), #747 (triple), #748 (all-coincident). Pure pass-throughs.