### PR TITLE
feat: §5.3 correlation/truncated neg_h ℤ^d wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3303,6 +3303,79 @@ theorem partitionFunction_neg_h_latticeGraph
   IsingModel.partitionFunction_neg_h
     (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β
 
+/-- **ℤ^d correlation_neg_h direct** at Λ-induced: Z₂ odd-symmetry
+under `h → -h`. `correlation ⟨J,-h,β⟩ A = (-1)^|A| · correlation ⟨J,h,β⟩ A`.
+Concrete wrapper for `IsingModel.correlation_neg_h` (#754). -/
+theorem correlation_neg_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ) (A : Finset (↑Λ : Type _)) :
+    IsingModel.correlation
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, -h, β⟩ : IsingParams ℝ) A
+      = (-1) ^ A.card * IsingModel.correlation
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (⟨J, h, β⟩ : IsingParams ℝ) A :=
+  IsingModel.correlation_neg_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β A
+
+/-- **ℤ^d magnetization_neg_h direct** at Λ-induced.
+Concrete wrapper for `IsingModel.magnetization_neg_h` (#755). -/
+theorem magnetization_neg_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ) (i : (↑Λ : Type _)) :
+    IsingModel.magnetization
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, -h, β⟩ : IsingParams ℝ) i
+      = -IsingModel.magnetization
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (⟨J, h, β⟩ : IsingParams ℝ) i :=
+  IsingModel.magnetization_neg_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β i
+
+/-- **ℤ^d truncated2_neg_h direct** at Λ-induced (i ≠ j).
+Concrete wrapper for `IsingModel.truncated2_neg_h` (#756). -/
+theorem truncated2_neg_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ)
+    {i j : (↑Λ : Type _)} (hij : i ≠ j) :
+    IsingModel.truncated2
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, -h, β⟩ : IsingParams ℝ) i j
+      = IsingModel.truncated2
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (⟨J, h, β⟩ : IsingParams ℝ) i j :=
+  IsingModel.truncated2_neg_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β hij
+
+/-- **ℤ^d truncated3_neg_h direct** at Λ-induced (pairwise distinct):
+antisymmetric, `U_3(-h) = -U_3(h)`. Concrete wrapper for
+`IsingModel.truncated3_neg_h` (#758). -/
+theorem truncated3_neg_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ)
+    {i j k : (↑Λ : Type _)} (hij : i ≠ j) (hjk : j ≠ k) (hik : i ≠ k) :
+    IsingModel.truncated3
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, -h, β⟩ : IsingParams ℝ) i j k
+      = -IsingModel.truncated3
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (⟨J, h, β⟩ : IsingParams ℝ) i j k :=
+  IsingModel.truncated3_neg_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β hij hjk hik
+
+/-- **ℤ^d truncated4_neg_h direct** at Λ-induced (pairwise distinct):
+invariant under `h → -h`. Concrete wrapper for
+`IsingModel.truncated4_neg_h` (#757). -/
+theorem truncated4_neg_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ)
+    {i j k l : (↑Λ : Type _)}
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    IsingModel.truncated4
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (⟨J, -h, β⟩ : IsingParams ℝ) i j k l
+      = IsingModel.truncated4
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (⟨J, h, β⟩ : IsingParams ℝ) i j k l :=
+  IsingModel.truncated4_neg_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β hij hik hil hjk hjl hkl
+
 /-- **ℤ^d partitionFunction_eq_abs_h direct** at Λ-induced. -/
 theorem partitionFunction_eq_abs_h_latticeGraph
     (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ) :


### PR DESCRIPTION
ℤ^d wrappers for #754 (correlation), #755 (magnetization), #756 (truncated2), #757 (truncated4), #758 (truncated3).