### PR TITLE
feat: §5.3 A-6 ℤ^d wrappers for abs-h symmetry theorems (PRs #772-774)

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -10325,6 +10325,83 @@ theorem truncated4TwoPoint_nonpos_h_zero_of_distinct
   truncated4Infinite_nonpos_h_zero (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) J β hf hr hs hu hrs hru hsu
 
+/-! ## ℤ^d wrappers for §5.3 Z₂ h-symmetry abs-h theorems (issue #770 A-6) -/
+
+/-- **ℤ^d `|M_Λ(h)| = M_Λ(|h|)`** under ferromagnetism at `|h|`.
+Concrete `latticeGraph d` wrapper for PR #772's
+`abs_magnetizationΛ_eq_magnetizationΛ_abs_h`. -/
+theorem abs_magnetizationΛ_latticeGraph_eq_magnetizationΛ_latticeGraph_abs_h
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    (J h β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β) (i : ↑Λ) :
+    |magnetizationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β⟩ : IsingParams ℝ) i|
+      = magnetizationΛ (IsingModel.latticeGraph d) Λ
+          (⟨J, |h|, β⟩ : IsingParams ℝ) i :=
+  abs_magnetizationΛ_eq_magnetizationΛ_abs_h
+    (IsingModel.latticeGraph d) Λ J h β hJ hβ i
+
+/-- **ℤ^d `M_along(-h) n = -M_along(h) n`** (any parameters). Concrete
+`latticeGraph d` wrapper for PR #773's
+`magnetizationAlongExhaustion_neg_h`. -/
+theorem magnetizationAlongExhaustion_latticeGraph_neg_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, -h, β⟩ : IsingParams ℝ) i n
+      = -magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β⟩ : IsingParams ℝ) i n :=
+  magnetizationAlongExhaustion_neg_h (IsingModel.latticeGraph d) Λ J h β i n
+
+/-- **ℤ^d `|M_along(h) n| = M_along(|h|) n`** under ferromagnetism at
+`|h|`. Concrete `latticeGraph d` wrapper for PR #773's
+`abs_magnetizationAlongExhaustion_eq_magnetizationAlongExhaustion_abs_h`. -/
+theorem abs_magnetizationAlongExhaustion_latticeGraph_eq_abs_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β) (i : Fin d → ℤ) (n : ℕ) :
+    |magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β⟩ : IsingParams ℝ) i n|
+      = magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨J, |h|, β⟩ : IsingParams ℝ) i n :=
+  abs_magnetizationAlongExhaustion_eq_magnetizationAlongExhaustion_abs_h
+    (IsingModel.latticeGraph d) Λ J h β hJ hβ i n
+
+/-- **ℤ^d ∞-volume one-sided `|M_∞(h)| ≤ M_∞(|h|)`** under ferromagnetism
+at `|h|`. Concrete `latticeGraph d` wrapper for PR #773's
+`abs_magnetizationInfinite_le_magnetizationInfinite_abs_h`. -/
+theorem abs_magnetizationInfinite_latticeGraph_le_magnetizationInfinite_latticeGraph_abs_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β) (i : Fin d → ℤ) :
+    |magnetizationInfinite (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β⟩ : IsingParams ℝ) i|
+      ≤ magnetizationInfinite (IsingModel.latticeGraph d) Λ
+          (⟨J, |h|, β⟩ : IsingParams ℝ) i :=
+  abs_magnetizationInfinite_le_magnetizationInfinite_abs_h
+    (IsingModel.latticeGraph d) Λ J h β hJ hβ i
+
+/-- **ℤ^d `M_∞ ≤ 0` at `h ≤ 0`** under ferromagnetism. Concrete
+`latticeGraph d` wrapper for PR #774's
+`magnetizationInfinite_nonpos_of_nonpos_h`. -/
+theorem magnetizationInfinite_latticeGraph_nonpos_of_nonpos_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β) (hh : h ≤ 0)
+    (i : Fin d → ℤ) :
+    magnetizationInfinite (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β⟩ : IsingParams ℝ) i ≤ 0 :=
+  magnetizationInfinite_nonpos_of_nonpos_h
+    (IsingModel.latticeGraph d) Λ J h β hJ hβ hh i
+
+/-- **ℤ^d `M_∞ = 0` at `h ≤ 0` when some stage misses `i`**.
+Concrete `latticeGraph d` wrapper for PR #774's
+`magnetizationInfinite_eq_zero_of_exists_stage_not_mem`. -/
+theorem magnetizationInfinite_latticeGraph_eq_zero_of_exists_stage_not_mem
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (J h β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β) (hh : h ≤ 0)
+    (i : Fin d → ℤ) (hmiss : ∃ n, i ∉ Λ.volume n) :
+    magnetizationInfinite (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β⟩ : IsingParams ℝ) i = 0 :=
+  magnetizationInfinite_eq_zero_of_exists_stage_not_mem
+    (IsingModel.latticeGraph d) Λ J h β hJ hβ hh i hmiss
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #770 (A-6)

## Summary

Concrete `latticeGraph d` wrappers for the abstract ambient theorems
merged in PRs #772, #773, #774 (GJ §5.3 Z₂ h-symmetry absolute-h
series). Each is a trivial 1-line specialization.

Six theorems bundled:

**Λ-layer:**
- `abs_magnetizationΛ_latticeGraph_eq_magnetizationΛ_latticeGraph_abs_h`
  (PR #772 wrapper).

**Along-exhaustion:**
- `magnetizationAlongExhaustion_latticeGraph_neg_h` (PR #773 helper 1).
- `abs_magnetizationAlongExhaustion_latticeGraph_eq_abs_h`
  (PR #773 helper 2).

**∞-volume:**
- `abs_magnetizationInfinite_latticeGraph_le_magnetizationInfinite_latticeGraph_abs_h`
  (PR #773 main, one-sided inequality).
- `magnetizationInfinite_latticeGraph_nonpos_of_nonpos_h`
  (PR #774, sign control at h ≤ 0).
- `magnetizationInfinite_latticeGraph_eq_zero_of_exists_stage_not_mem`
  (PR #774, zero at h ≤ 0 with missed-stage hypothesis).

Location: `IsingModel/Concrete/LatticeGraphCorrelation.lean`,
immediately before the closing `end Ambient`.

Reference: Glimm-Jaffe §5.3 pp. 77-80 (background).

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] Linter 0 warnings
- [ ] cross-check pass (copilot -p → codex exec auto-fallback)