### PR TITLE
feat: §5.1 Simon-Lieb prep — Current.parity at vertex (bundled, Issue #780 step 2)

### DIFF
--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -37,6 +37,45 @@ instance Current.instAdd (G : SimpleGraph V) (Λ : Finset V)
     [Fintype (inducedGraph G Λ).edgeSet] : Add (Current G Λ) :=
   ⟨fun n m => fun e => n e + m e⟩
 
+/-- **Parity at a vertex**: for a current `n` and a vertex
+`v : ↑Λ`, the parity (mod 2) of the sum of `n e` over edges `e`
+incident to `v`. The source set of `n` is the set of vertices
+where the parity is non-zero; the parity drives the source/sink
+characterisation and the Aizenman switching lemma in subsequent
+PRs (FV §3.7). -/
+def Current.parity (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) (v : ↑Λ) : ZMod 2 :=
+  ∑ e : (inducedGraph G Λ).edgeSet,
+    if v ∈ (e : Sym2 ↑Λ) then ((n e : ℕ) : ZMod 2) else 0
+
+omit [DecidableEq V] in
+/-- **Zero parity**: the zero current has parity `0` at every
+vertex (each summand vanishes). -/
+@[simp]
+theorem Current.zero_parity (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (v : ↑Λ) :
+    (0 : Current G Λ).parity G Λ v = 0 := by
+  unfold Current.parity
+  simp only [show ((0 : Current G Λ) : (inducedGraph G Λ).edgeSet → ℕ) = fun _ => 0
+    from rfl]
+  simp
+
+omit [DecidableEq V] in
+/-- **Additive parity**: parity distributes over addition of
+currents (sum of parities equals parity of the sum). -/
+theorem Current.add_parity (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n m : Current G Λ) (v : ↑Λ) :
+    (n + m).parity G Λ v = n.parity G Λ v + m.parity G Λ v := by
+  unfold Current.parity
+  rw [← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl (fun e _ => ?_)
+  by_cases hv : v ∈ (e : Sym2 ↑Λ)
+  · simp [hv, show ((n + m) e : ℕ) = n e + m e from rfl, Nat.cast_add]
+  · simp [hv]
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #780. **Step 2 of the §5.1 Simon-Lieb random current series (after PR #796).**

## Summary

Adds the parity-at-vertex notion for currents, with basic lemmas
(`zero_parity`, `add_parity`). The parity drives the source/sink
characterisation and the Aizenman switching lemma in subsequent
PRs of the series.

## Definitions and theorems

`IsingModel/RandomCurrent.lean`:

- `Current.parity (n : Current G Λ) (v : ↑Λ) : ZMod 2`: sum of
  `n e mod 2` over edges `e ∈ (inducedGraph G Λ).edgeSet` with
  `v ∈ e`.
- `Current.zero_parity`: `(0 : Current G Λ).parity v = 0`.
- `Current.add_parity`: `(n + m).parity v = n.parity v + m.parity v`.

## Test plan

- [ ] `lake build` passes
- [ ] linter warnings: 0 on touched files
- [ ] cross-check (codex)