### PR TITLE
feat: §5.1 Simon-Lieb prep — Current.sources additive structure (bundled, Issue #780 step 4)

### DIFF
--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -108,6 +108,35 @@ theorem Current.zero_sources (G : SimpleGraph V) (Λ : Finset V)
   ext v
   simp
 
+omit [DecidableEq V] in
+/-- **Parity zero iff not a source**: `n.parity v = 0` iff
+`v ∉ n.sources`. -/
+theorem Current.parity_eq_zero_iff (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) (v : ↑Λ) :
+    n.parity G Λ v = 0 ↔ v ∉ n.sources G Λ := by
+  rw [Current.mem_sources_iff, not_not]
+
+omit [DecidableEq V] in
+/-- **Sources of a sum is the symmetric difference**:
+`(n + m).sources = n.sources △ m.sources`.
+At each vertex `v`, `(n + m).parity v = n.parity v + m.parity v`
+in `ZMod 2`; this is non-zero iff exactly one summand is. -/
+theorem Current.add_sources_eq (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n m : Current G Λ) :
+    (n + m).sources G Λ
+      = symmDiff (n.sources G Λ) (m.sources G Λ) := by
+  classical
+  ext v
+  simp only [Current.mem_sources_iff, Finset.mem_symmDiff,
+    Current.add_parity]
+  -- Goal in ZMod 2: a + b ≠ 0 ↔ (a ≠ 0 ∧ ¬ b ≠ 0) ∨ (b ≠ 0 ∧ ¬ a ≠ 0).
+  generalize n.parity G Λ v = a
+  generalize m.parity G Λ v = b
+  revert a b
+  decide
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #780. Step 4 of the §5.1 Simon-Lieb random current series.

## Summary

Adds the additive structure for `Current.sources`: parity-iff
characterisation and the symmetric-difference identity for
sources of a sum. The latter is the pivotal identity feeding
into the Aizenman switching lemma in subsequent PRs.

## Theorems

`IsingModel/RandomCurrent.lean`:

- `Current.parity_eq_zero_iff`:
  `n.parity v = 0 ↔ v ∉ n.sources`.
- `Current.add_sources_eq`: `(n + m).sources = n.sources △ m.sources`
  (symmetric difference). At each `v`, the parities live in
  `ZMod 2`, where `(n + m).parity v = n.parity v + m.parity v`
  is non-zero iff exactly one of the summands is.

## Test plan

- [ ] `lake build` passes
- [ ] linter warnings: 0 on touched files