### PR TITLE
feat: §5.1 Simon-Lieb prep — CurrentBounded type for finite sums (bundled, Issue #780 step 10)

### DIFF
--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -318,6 +318,22 @@ theorem Current.add_hasSources_iff (G : SimpleGraph V) (Λ : Finset V)
   unfold Current.HasSources
   rw [Current.add_sources_eq]
 
+/-- **Bounded current**: a current with each edge value bounded
+by `N`. Automatically `Fintype` (each edge contributes a finite
+choice from `Fin (N+1)`, and the edge set is itself `Fintype`),
+enabling finite-sum manipulations as a stepping stone toward the
+limit-based random-current expansion. -/
+abbrev CurrentBounded (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (N : ℕ) :=
+  (e : (inducedGraph G Λ).edgeSet) → Fin (N + 1)
+
+/-- **Coercion `CurrentBounded → Current`**: forget the bound
+on each edge value. -/
+def CurrentBounded.toCurrent (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] {N : ℕ}
+    (n : CurrentBounded G Λ N) : Current G Λ :=
+  fun e => (n e).val
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #780. Step 10 of the §5.1 Simon-Lieb random current series.

## Summary

Adds `CurrentBounded G Λ N`, the type of currents with each edge
value bounded by `N`. Automatically `Fintype` (`Fin (N+1)` per
edge × `Fintype edgeSet`), enabling finite-sum manipulations
that the unbounded `Current G Λ` requires `tsum` for. Used as
a stepping stone toward the limit-based random-current expansion.

## Definitions and theorems

`IsingModel/RandomCurrent.lean`:

- `CurrentBounded G Λ N : Type` :=
  `(e : (inducedGraph G Λ).edgeSet) → Fin (N+1)`. Automatically
  `Fintype` via `Pi.fintype`.
- `CurrentBounded.toCurrent`: coercion to `Current G Λ` via
  `(n e).val`.

## Test plan

- [ ] `lake build` passes
- [ ] linter warnings: 0 on touched files