### PR TITLE
feat: §5.1 Simon-Lieb prep — singleton sources card = 2 (bundled, Issue #780 step 19)

### DIFF
--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -554,6 +554,22 @@ theorem Current.fromEdgeFinset_singleton_sources
       Sym2.mem_toFinset]
   by_cases hv : v ∈ (e₀ : Sym2 ↑Λ) <;> simp [hv]
 
+omit [DecidableEq V] in
+/-- **Cardinality of `fromEdgeFinset {e₀}.sources` is `2`**: a
+singleton-edge indicator current has exactly two sources, the two
+endpoints of `e₀` in `↑Λ`. Distinctness comes from
+`SimpleGraph.not_isDiag_of_mem_edgeSet` (the underlying
+`inducedGraph` is loopless). -/
+@[simp]
+theorem Current.fromEdgeFinset_singleton_sources_card
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (e₀ : (inducedGraph G Λ).edgeSet) :
+    ((Current.fromEdgeFinset G Λ {e₀}).sources G Λ).card = 2 := by
+  rw [Current.fromEdgeFinset_singleton_sources,
+    Sym2.card_toFinset_of_not_isDiag _
+      ((inducedGraph G Λ).not_isDiag_of_mem_edgeSet e₀.2)]
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #780.

Adds `Current.fromEdgeFinset_singleton_sources_card`: `((fromEdgeFinset G Λ {e₀}).sources G Λ).card = 2`. Direct consequence of `fromEdgeFinset_singleton_sources` and `Sym2.card_toFinset_of_not_isDiag` (using `SimpleGraph.not_isDiag_of_mem_edgeSet` since `inducedGraph` is loopless).

Prepares the 2-source case used in the random-current expression of `⟨σ_x σ_y⟩^Λ` (FV §3.7), the building block of Simon-Lieb (FV Prop 9.31).