### PR TITLE
feat: §5.1 Simon-Lieb prep — prod_pow_degreeAt (bundled, Issue #780 step 27)

### DIFF
--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -772,6 +772,45 @@ theorem Current.sum_degreeAt_smul {M : Type*} [AddCommMonoid M]
   ext v
   simp
 
+omit [DecidableEq V] in
+/-- **Edge → vertex product identity (pow form)**: for any
+`g : ↑Λ → M` (`M` a `CommMonoid`),
+`∏_v g v ^ degreeAt n v = ∏_e (e.toFinset.prod g) ^ n e`. The
+multiplicative analogue of `sum_degreeAt_smul`; used to convert
+the per-vertex spin product `∏_v σ_v^(degree)` into the per-edge
+product `∏_e (σ_u σ_w)^(n e)` in the random-current expansion of
+the Ising partition function (FV §3.7). -/
+theorem Current.prod_pow_degreeAt {M : Type*} [CommMonoid M]
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) (g : ↑Λ → M) :
+    ∏ v ∈ (Finset.univ : Finset ↑Λ), g v ^ n.degreeAt G Λ v
+      = ∏ e : (inducedGraph G Λ).edgeSet,
+          ((e : Sym2 ↑Λ).toFinset.prod g) ^ n e := by
+  classical
+  simp only [Current.degreeAt]
+  -- ∏ v, g v ^ (∑ e, if v ∈ e then n e else 0)
+  --   = ∏ v, ∏ e, g v ^ (if v ∈ e then n e else 0)
+  simp_rw [← Finset.prod_pow_eq_pow_sum]
+  -- push pow through if
+  have hpush : ∀ (v : ↑Λ) (e : (inducedGraph G Λ).edgeSet),
+      g v ^ (if v ∈ (e : Sym2 ↑Λ) then n e else 0)
+        = if v ∈ (e : Sym2 ↑Λ) then g v ^ n e else 1 := by
+    intro v e
+    by_cases hv : v ∈ (e : Sym2 ↑Λ) <;> simp [hv]
+  simp_rw [hpush]
+  -- swap the two products
+  rw [Finset.prod_comm]
+  -- ∏ e, ∏ v, if v ∈ e then g v ^ n e else 1
+  --   = ∏ e, ∏ v ∈ univ.filter (· ∈ e), g v ^ n e
+  --   = ∏ e, (e.toFinset.prod g) ^ n e
+  congr 1
+  ext e
+  rw [← Finset.prod_filter, ← Finset.prod_pow]
+  congr 1
+  ext v
+  simp
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #780.

Adds `Current.prod_pow_degreeAt`: for any `g : ↑Λ → M` (`M` a CommMonoid),
`∏ v, g v ^ degreeAt n v = ∏ e, (e.toFinset.prod g) ^ n e`.

The multiplicative form of the edge-vertex identity. Together with `sum_degreeAt_smul`, completes the central combinatorial step of the random-current expansion (FV §3.7), used to convert the partition function product into a sum over currents.