### PR TITLE
feat: 5.1 Simon-Lieb prep CurrentBounded weightSum tendsto iSup bundled Issue 780 step 67

### DIFF
--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -1990,6 +1990,26 @@ theorem CurrentBounded.weightSum_mono (G : SimpleGraph V) (Λ : Finset V)
   · exact Current.weight_nonneg G Λ hβJ n
   · exact le_refl 0
 
+set_option linter.unusedDecidableInType false in
+/-- **Monotone convergence of `CurrentBounded.weightSum`** under
+non-negative coupling and bounded-above hypothesis:
+\(Tendsto (fun N => CurrentBounded.weightSum N A β J) atTop
+  (nhds (⨆ N, CurrentBounded.weightSum N A β J))\).
+Combines `CurrentBounded.weightSum_mono` (#860) with
+`tendsto_atTop_ciSup`. Avoids the explicit `Summable` hypothesis
+of `tendsto_weightSum_atTop_currentWeightSum` (#859). -/
+theorem CurrentBounded.tendsto_weightSum_atTop_iSup
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (A : Finset ↑Λ) {β J : ℝ} (hβJ : 0 ≤ β * J)
+    (hbdd : BddAbove (Set.range (fun N =>
+      CurrentBounded.weightSum G Λ N A β J))) :
+    Filter.Tendsto (fun N : ℕ => CurrentBounded.weightSum G Λ N A β J)
+      Filter.atTop
+      (nhds (⨆ N : ℕ, CurrentBounded.weightSum G Λ N A β J)) :=
+  tendsto_atTop_ciSup
+    (fun _ _ h => CurrentBounded.weightSum_mono G Λ A hβJ h) hbdd
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #780.

Adds CurrentBounded.tendsto_weightSum_atTop_iSup: under non-negative coupling and BddAbove,
Tendsto (fun N => CurrentBounded.weightSum N A β J) atTop (nhds (⨆ N, CurrentBounded.weightSum N A β J)).

The monotone-convergence version of the RHS-side N → ∞ limit. Uses CurrentBounded.weightSum_mono (#860) and tendsto_atTop_ciSup. Avoids the explicit summability hypothesis of #859 — the BddAbove + monotone combination gives tendsto-to-sup directly.