### PR TITLE
feat: §5.1 Switching prep Current.supportAt at vertex + non-empty from source bundled (Issue #780 step 95, GJ命題-unit)

### DIFF
--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -3208,6 +3208,54 @@ theorem Current.not_mem_sources_of_isolated
   obtain ⟨u, hadj⟩ := Current.exists_adj_of_mem_sources G Λ n hmem
   exact hv u hadj
 
+/-- **Active edges incident to a vertex**: for a current `n` and a
+vertex `v : ↑Λ`, the Finset of edges `e ∈ n.support` containing `v`.
+The Finset form of `exists_support_edge_of_mem_sources`, usable in
+downstream counting / partitioning arguments for the switching lemma
+(Aizenman 1982 / FV §3.7). -/
+noncomputable def Current.supportAt (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) (v : ↑Λ) :
+    Finset ((inducedGraph G Λ).edgeSet) :=
+  (n.support G Λ).filter (fun e => v ∈ (e : Sym2 ↑Λ))
+
+omit [DecidableEq V] in
+set_option linter.unusedDecidableInType false in
+/-- **Membership in `Current.supportAt`**: `e ∈ n.supportAt v ↔
+e ∈ n.support ∧ v ∈ (e : Sym2 ↑Λ)`. -/
+theorem Current.mem_supportAt_iff (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) (v : ↑Λ) (e : (inducedGraph G Λ).edgeSet) :
+    e ∈ n.supportAt G Λ v ↔ e ∈ n.support G Λ ∧ v ∈ (e : Sym2 ↑Λ) := by
+  classical
+  unfold Current.supportAt
+  exact Finset.mem_filter
+
+omit [DecidableEq V] in
+set_option linter.unusedDecidableInType false in
+/-- **`supportAt` is contained in `support`**: edges at a vertex are
+in particular active edges. -/
+theorem Current.supportAt_subset_support (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) (v : ↑Λ) :
+    n.supportAt G Λ v ⊆ n.support G Λ := by
+  classical
+  unfold Current.supportAt
+  exact Finset.filter_subset _ _
+
+omit [DecidableEq V] in
+set_option linter.unusedDecidableInType false in
+/-- **Source vertices have non-empty `supportAt`**: the Finset form
+of `exists_support_edge_of_mem_sources`. If `v ∈ n.sources`, then
+`(n.supportAt v).Nonempty`. -/
+theorem Current.supportAt_nonempty_of_mem_sources
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) {v : ↑Λ} (hv : v ∈ n.sources G Λ) :
+    (n.supportAt G Λ v).Nonempty := by
+  obtain ⟨e, he_supp, hve⟩ := Current.exists_support_edge_of_mem_sources G Λ n hv
+  exact ⟨e, (Current.mem_supportAt_iff G Λ n v e).mpr ⟨he_supp, hve⟩⟩
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #780 (step 95).

## Summary

Finset-level refinement of step 94: introduce `Current.supportAt v` — the Finset of active edges incident to a vertex — and show it is non-empty when `v` is a source.

1. `def Current.supportAt`: `n.support.filter (fun e => v ∈ (e : Sym2 ↑Λ))`.
2. `theorem Current.mem_supportAt_iff` (membership).
3. `theorem Current.supportAt_subset` (⊆ support).
4. `theorem Current.supportAt_nonempty_of_mem_sources` (non-emptiness from sources, Finset form of #890's `exists_support_edge_of_mem_sources`).

## Why GJ-proposition-unit

4 entries form the minimal natural bundle: definition + membership iff + subset + non-emptiness. Downstream switching-lemma proofs that count / partition incident active edges will use `supportAt` directly.

## Test plan

- [ ] `lake build`
- [ ] `lake exe GKSTest`
- [ ] linter warning 0
- [ ] `copilot -p` / `codex exec` / `gemini -p` cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)