### PR TITLE
feat: §5.1 Switching prep cast_indicator_parity + sources_card_even bundled (Issue #780 step 98, GJ命題-unit)

### DIFF
--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -3380,6 +3380,41 @@ theorem Current.sum_parity_eq_zero
   rw [show (2 : ZMod 2) = 0 from by decide]
   ring
 
+omit [DecidableEq V] in
+set_option linter.unusedDecidableInType false in
+/-- **Indicator cast to `ZMod 2` equals parity**: since `parity v`
+takes values only in `{0, 1} ⊆ ZMod 2`, the ℕ-valued indicator
+`if parity v ≠ 0 then 1 else 0` casts back to `parity v`. -/
+theorem Current.cast_indicator_parity
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) (v : ↑Λ) :
+    ((if n.parity G Λ v ≠ 0 then 1 else 0 : ℕ) : ZMod 2) = n.parity G Λ v := by
+  generalize n.parity G Λ v = p
+  fin_cases p <;> decide
+
+omit [DecidableEq V] in
+set_option linter.unusedDecidableInType false in
+/-- **Source set has even cardinality**: `|(∂n)|` is always even.
+Derived from `sum_parity_eq_zero` by casting the filter-card formula
+through `ZMod 2`: `|sources| ≡ ∑_v parity v = 0 (mod 2)`.
+This is the switching-lemma prerequisite; Aizenman's argument reduces
+to the 2-source case `∂n = {i, j}`, which requires `|∂n|` even. -/
+theorem Current.sources_card_even
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] [DecidableEq ↑Λ]
+    (n : Current G Λ) :
+    Even (n.sources G Λ).card := by
+  have h : ((n.sources G Λ).card : ZMod 2) = 0 := by
+    calc ((n.sources G Λ).card : ZMod 2)
+        = ∑ v : ↑Λ, n.parity G Λ v := by
+          rw [Current.sources, Finset.card_filter, Nat.cast_sum]
+          apply Finset.sum_congr rfl
+          intro v _
+          exact Current.cast_indicator_parity G Λ n v
+      _ = 0 := Current.sum_parity_eq_zero G Λ n
+  exact ZMod.natCast_eq_zero_iff_even.mp h
+
 end Ambient
 
 end IsingModel


### PR DESCRIPTION
Part of #780 (step 98).

## Summary

Cast the ZMod 2 identity `∑ v, parity v = 0` (step 97 / PR #893) back to ℕ to conclude that `|n.sources|` is always even. Two-lemma bundle:

1. `Current.cast_indicator_parity`: `((if parity v ≠ 0 then 1 else 0 : ℕ) : ZMod 2) = parity v`. Proved by `generalize`+`fin_cases`+`decide` on the two elements of ZMod 2.
2. `Current.sources_card_even`: `Even (n.sources G Λ).card`. Calc chain: `Finset.card_filter` → `Nat.cast_sum` → `cast_indicator_parity` → `sum_parity_eq_zero` → `ZMod.natCast_eq_zero_iff_even`.

This is the switching-lemma prerequisite: Aizenman's argument reduces to the 2-source case `∂n = {i, j}`, which requires `|∂n|` even.

## Test plan

- [x] `lake build`
- [x] `lake exe GKSTest`
- [x] linter warning 0
- [x] `codex exec` cross-check (copilot quota exhausted; codex confirmed math correctness and proof soundness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)