### PR TITLE
feat: Issue #888 Step P3 - CI wiring for sentinel property suite

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -18,8 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
-      - name: Run tests
+      - name: Run GKS numerical tests
         run: lake exe GKSTest
+      - name: Build sentinel property suite (Issue #888 Step P3)
+        run: lake build test.IsingModel.SentinelProps
 
   # NOTE: docs generation via `leanprover-community/docgen-action` has been
   # temporarily disabled because every main-push run takes ~1 hour and


### PR DESCRIPTION
Part of #888

## Summary

Adds `lake build test.IsingModel.SentinelProps` to the CI build job, ensuring that all `native_decide` sentinel checks in `SentinelProps.lean` are verified on every push/PR.

The sentinel suite catches refactoring regressions: if any of the pinned values (Z=5, Z=25/2, Z=19, ⟨σ₀σ₁⟩=3/5, GKS-I/II) change due to a refactor, `native_decide` will fail and CI will catch it.

## Test plan

- CI passes with the new `lake build test.IsingModel.SentinelProps` step
- Estimated additional CI time: < 30 seconds (test library compiles after main library is cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)