### PR TITLE
refactor: inline h_mem_vac in latticeMass_pos_of_high_temp d=0 branch

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Inequalities.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Inequalities.lean
@@ -770,11 +770,10 @@ theorem latticeMass_pos_of_high_temp
         (⟨J, 0, β⟩ : IsingParams ℝ) (1 : ℝ) :=
       ⟨0, le_refl _, fun i j hij =>
         absurd (funext (fun x => Fin.elim0 x)) hij⟩
-    have h_mem_vac : ((1 : NNReal) : ENNReal) ∈ (fun α : NNReal => (α : ENNReal)) ''
-        {α : NNReal | HasExponentialDecay 0 (cubicExhaustion 0)
-            (⟨J, 0, β⟩ : IsingParams ℝ) (α : ℝ)} :=
-      ⟨1, h_vac, rfl⟩
-    exact lt_of_lt_of_le (by norm_num) (le_sSup h_mem_vac)
+    exact lt_of_lt_of_le (by norm_num)
+      (le_sSup (show ((1 : NNReal) : ENNReal) ∈ (fun α : NNReal => (α : ENNReal)) ''
+          {α : NNReal | HasExponentialDecay 0 (cubicExhaustion 0)
+              (⟨J, 0, β⟩ : IsingParams ℝ) (α : ℝ)} from ⟨1, h_vac, rfl⟩))
   · -- d ≥ 1: α₀ = -log(βJD) > 0
     have hβJD_pos : 0 < β * J * ↑(2 * d) :=
       mul_pos hβJ (Nat.cast_pos.mpr (by omega))


### PR DESCRIPTION
Remove unnecessary intermediate `have h_mem_vac` binding in `latticeMass_pos_of_high_temp`'s d=0 branch; inline the membership proof directly into `le_sSup`.

No semantic change.

## Checklist
- [x] `lake build` success
- [x] linter warnings = 0 in modified file