### PR TITLE
feat: Step 281 — partitionFunction high-temperature expansion (GJ §18.3)

### DIFF
--- a/IsingModel/Conditioning.lean
+++ b/IsingModel/Conditioning.lean
@@ -1152,6 +1152,65 @@ Gibbs state — the lattice analogue of Theorem 18.1.1.
 
 The key algebraic ingredient `exp_edgeSpin_decomp` is already formalized. -/
 
+/-- **Partition function high-temperature expansion** (lattice analogue of GJ §18.3).
+
+For any Ising parameter `p = (J, h, β)` and any finite simple graph `G`,
+\[
+Z(G; p) = (\cosh(\beta J))^{|E|} \sum_\sigma
+  \Bigl(\prod_{e \in E} (1 + \tanh(\beta J)\,\sigma_i\sigma_j)\Bigr)
+  \exp\!\bigl(\beta h \sum_i \sigma_i\bigr).
+\]
+
+Reference: Glimm–Jaffe, *Quantum Physics*, §18.1–18.3, pp. 378–386
+("Clustering and analyticity"); see also Friedli–Velenik §3.7.3
+("Uniqueness at high temperature"), eqs. (3.41)–(3.42), pp. 116–117
+(2017 ed.). The proof rewrites each edge factor via
+`exp_edgeSpin_decomp` (which gives `exp(α·s) = cosh α + sinh α · s`
+for `s ∈ {±1}`) and pulls out the common factor `cosh(βJ)`. -/
+theorem partitionFunction_high_temp_expansion
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) :
+    partitionFunction G p =
+      Real.cosh (p.β * p.J) ^ G.edgeFinset.card *
+      ∑ σ : Config ι,
+        (∏ e ∈ G.edgeFinset, (1 + Real.tanh (p.β * p.J) * edgeSpin σ e)) *
+        Real.exp (p.β * p.h * ∑ i : ι, Spin.sign ℝ (σ i)) := by
+  unfold partitionFunction boltzmannWeight hamiltonian
+    interactionEnergy externalFieldEnergy
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun σ _ => ?_)
+  have hexp_split :
+      Real.exp (-p.β *
+          (-p.J * ∑ e ∈ G.edgeFinset, edgeSpin σ e
+            + -p.h * ∑ i : ι, Spin.sign ℝ (σ i))) =
+        (∏ e ∈ G.edgeFinset, Real.exp (p.β * p.J * edgeSpin σ e)) *
+          Real.exp (p.β * p.h * ∑ i : ι, Spin.sign ℝ (σ i)) := by
+    have hrewrite :
+        -p.β *
+            (-p.J * ∑ e ∈ G.edgeFinset, edgeSpin σ e
+              + -p.h * ∑ i : ι, Spin.sign ℝ (σ i))
+          = (∑ e ∈ G.edgeFinset, p.β * p.J * edgeSpin σ e)
+            + p.β * p.h * ∑ i : ι, Spin.sign ℝ (σ i) := by
+      rw [show
+          -p.β *
+              (-p.J * ∑ e ∈ G.edgeFinset, edgeSpin σ e
+                + -p.h * ∑ i : ι, Spin.sign ℝ (σ i))
+            = (p.β * p.J) * (∑ e ∈ G.edgeFinset, edgeSpin σ e)
+              + p.β * p.h * (∑ i : ι, Spin.sign ℝ (σ i)) from by ring,
+          Finset.mul_sum]
+    rw [hrewrite, Real.exp_add, Real.exp_sum]
+  rw [hexp_split]
+  have hedge_decomp : ∀ e ∈ G.edgeFinset,
+      Real.exp (p.β * p.J * edgeSpin σ e) =
+        Real.cosh (p.β * p.J) * (1 + Real.tanh (p.β * p.J) * edgeSpin σ e) := by
+    intro e _
+    rw [exp_edgeSpin_decomp, Real.tanh_eq_sinh_div_cosh]
+    have hcosh_ne : Real.cosh (p.β * p.J) ≠ 0 := (Real.cosh_pos _).ne'
+    field_simp
+  rw [Finset.prod_congr rfl hedge_decomp, Finset.prod_mul_distrib,
+      Finset.prod_const]
+  ring
+
 /-- **High-temperature parameter**: `t = tanh(βJ)`.
 For `βJ ≥ 0`, `t ∈ [0, 1)`, and the high-temperature expansion
 converges when `t` is small. -/

--- a/docs/index.md
+++ b/docs/index.md
@@ -635,11 +635,11 @@ inventory (2026-04-17).
 
 ### Chapter 18 (Cluster expansion)
 
-| Section | Result | Status |
-|---|---|---|
-| §18.1 | High-temperature parameter | **Done** |
-| §18.2 | `exp(α·edgeSpin) = cosh α + sinh α · edgeSpin` | **Done** |
-| §18.3 | Clustering and analyticity | **Done (lattice)** |
+| Section | Result | Status | Comments |
+|---|---|---|---|
+| §18.1 | High-temperature parameter | **Done** | `highTempParam`, `abs_highTempParam_lt_one`, `highTempParam_lt_one` (`Conditioning.lean`). |
+| §18.2 | `exp(α·edgeSpin) = cosh α + sinh α · edgeSpin` | **Done** | `exp_edgeSpin_decomp` (`Inequalities/NonnegCorrelations.lean`). |
+| §18.3 | Clustering and analyticity (lattice high-temp expansion) | **Done (lattice)** | `partitionFunction_high_temp_expansion` (`Conditioning.lean`): `Z = (cosh βJ)^{\|E\|} · ∑_σ ∏_e (1 + tanh(βJ) σ_iσ_j) · exp(βh ∑ σ_i)`. Lattice analogue of the GJ §18.3 cluster expansion identity (cf. FV §3.7.3, eq. (3.42)). (PR #1118.) |
 | §18.4–18.7 | Cluster expansion machinery | **Out of scope** | QFT cluster expansion (Gaussian functional integrals, Schwartz spaces). Outside current Lean/Ising scope. |
 
 ### Chapter 19 (Reconstruction)

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3234,6 +3234,29 @@ $|t| = |\tanh(\beta J)| < 1$ for all finite $\beta J$.
 $t < 1$.
 \end{theorem}
 
+\begin{theorem}[\texttt{partitionFunction\_high\_temp\_expansion}; GJ~\S18.3,
+cf.\ FV~\S3.7.3 eq.\,(3.42)]
+For any Ising parameter $p = (J, h, \beta)$ on a finite simple graph
+$G = (\iota, E)$,
+\[
+Z(G; p) = (\cosh(\beta J))^{|E|}
+\sum_{\sigma}
+\Bigl(\prod_{\{i,j\} \in E} (1 + \tanh(\beta J)\,\sigma_i\sigma_j)\Bigr)
+\exp\!\Bigl(\beta h \sum_i \sigma_i\Bigr).
+\]
+\end{theorem}
+
+\textit{Proof.} The Hamiltonian factorises as
+$-\beta H = \beta J \sum_e \sigma_i\sigma_j + \beta h \sum_i \sigma_i$,
+so $e^{-\beta H} = \prod_e e^{\beta J \sigma_i\sigma_j} \cdot
+e^{\beta h \sum_i \sigma_i}$.
+Since $\sigma_i\sigma_j \in \{\pm 1\}$,
+$e^{\beta J \sigma_i\sigma_j} = \cosh(\beta J) + \sinh(\beta J)\sigma_i\sigma_j
+= \cosh(\beta J)(1 + \tanh(\beta J)\sigma_i\sigma_j)$
+by \texttt{exp\_edgeSpin\_decomp} and $\cosh(\beta J) > 0$.
+Multiplying over edges and pulling out $\cosh(\beta J)^{|E|}$ gives the claim.
+\hfill$\square$
+
 \section{Peierls argument (\texttt{Peierls.lean})}
 
 \par\noindent\textbf{Prerequisites:} \texttt{GibbsMeasure.lean},


### PR DESCRIPTION
## Summary

Formalize the lattice analogue of the Glimm–Jaffe §18.3 high-temperature expansion as an actual theorem:

`Z(G; p) = (cosh βJ)^|E| · Σ_σ ∏_e (1 + tanh(βJ) σ_iσ_j) · exp(βh Σ σ_i)`

Previously the identity was only described in the docstring. The proof rewrites each Boltzmann edge factor via `exp_edgeSpin_decomp` (`exp(α·s) = cosh α + sinh α · s` for `s ∈ {±1}`) and pulls the common `cosh(βJ)` out of the product.

References: GJ §18.1–18.3, pp. 378–386 ("Clustering and analyticity"); FV §3.7.3, eqs. (3.41)–(3.42), pp. 116–117 (2017 ed.).

Also updates `docs/index.md` (Chapter 18 progress table; §18.3 row now cites the theorem) and `tex/proof-guide.tex`.

## Status

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] `grep -rn "sorry" IsingModel/` returns zero
- [x] Linter clean
- [x] `codex exec` cross-check passed (FV citation corrected from §3.10.4 → §3.7.3 after first round; table column count fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)