### PR TITLE
feat: Step 282 — high-temp expansion at h = 0 corollary (GJ §18.3)

### DIFF
--- a/IsingModel/Conditioning.lean
+++ b/IsingModel/Conditioning.lean
@@ -1211,6 +1211,26 @@ theorem partitionFunction_high_temp_expansion
       Finset.prod_const]
   ring
 
+/-- **Partition function high-temperature expansion at zero field**
+(GJ §18.3 / FV §3.7.3 eq. (3.42)):
+\[
+Z(G; J, 0, \beta) = (\cosh(\beta J))^{|E|}
+\sum_\sigma \prod_{\{i,j\} \in E}
+  (1 + \tanh(\beta J)\,\sigma_i\sigma_j).
+\]
+
+Direct corollary of `partitionFunction_high_temp_expansion` at `h = 0`,
+where the field factor `exp(βh · Σ sign(σ_i))` collapses to `1`. -/
+theorem partitionFunction_high_temp_expansion_h_zero
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (J β : ℝ) :
+    partitionFunction G ⟨J, 0, β⟩ =
+      Real.cosh (β * J) ^ G.edgeFinset.card *
+      ∑ σ : Config ι,
+        ∏ e ∈ G.edgeFinset, (1 + Real.tanh (β * J) * edgeSpin σ e) := by
+  rw [partitionFunction_high_temp_expansion G ⟨J, 0, β⟩]
+  simp
+
 /-- **High-temperature parameter**: `t = tanh(βJ)`.
 For `βJ ≥ 0`, `t ∈ [0, 1)`, and the high-temperature expansion
 converges when `t` is small. -/

--- a/docs/index.md
+++ b/docs/index.md
@@ -639,7 +639,7 @@ inventory (2026-04-17).
 |---|---|---|---|
 | §18.1 | High-temperature parameter | **Done** | `highTempParam`, `abs_highTempParam_lt_one`, `highTempParam_lt_one` (`Conditioning.lean`). |
 | §18.2 | `exp(α·edgeSpin) = cosh α + sinh α · edgeSpin` | **Done** | `exp_edgeSpin_decomp` (`Inequalities/NonnegCorrelations.lean`). |
-| §18.3 | Clustering and analyticity (lattice high-temp expansion) | **Done (lattice)** | `partitionFunction_high_temp_expansion` (`Conditioning.lean`): `Z = (cosh βJ)^{\|E\|} · ∑_σ ∏_e (1 + tanh(βJ) σ_iσ_j) · exp(βh ∑ σ_i)`. Lattice analogue of the GJ §18.3 cluster expansion identity (cf. FV §3.7.3, eq. (3.42)). (PR #1118.) |
+| §18.3 | Clustering and analyticity (lattice high-temp expansion) | **Done (lattice)** | `partitionFunction_high_temp_expansion` (`Conditioning.lean`): `Z = (cosh βJ)^{\|E\|} · ∑_σ ∏_e (1 + tanh(βJ) σ_iσ_j) · exp(βh ∑ σ_i)`. Zero-field corollary `partitionFunction_high_temp_expansion_h_zero`: `Z(J,0,β) = (cosh βJ)^{\|E\|} · ∑_σ ∏_e (1 + tanh(βJ) σ_iσ_j)`. Lattice analogue of the GJ §18.3 cluster expansion identity (cf. FV §3.7.3, eq. (3.42)). (PRs #1118, #1119.) |
 | §18.4–18.7 | Cluster expansion machinery | **Out of scope** | QFT cluster expansion (Gaussian functional integrals, Schwartz spaces). Outside current Lean/Ising scope. |
 
 ### Chapter 19 (Reconstruction)

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -3257,6 +3257,19 @@ by \texttt{exp\_edgeSpin\_decomp} and $\cosh(\beta J) > 0$.
 Multiplying over edges and pulling out $\cosh(\beta J)^{|E|}$ gives the claim.
 \hfill$\square$
 
+\begin{theorem}[\texttt{partitionFunction\_high\_temp\_expansion\_h\_zero}; GJ~\S18.3 / FV~\S3.7.3 eq.\,(3.42)]
+At zero external field, the high-temperature expansion specialises to
+\[
+Z(G; J, 0, \beta) = (\cosh(\beta J))^{|E|}
+\sum_{\sigma}
+\prod_{\{i,j\} \in E} (1 + \tanh(\beta J)\,\sigma_i\sigma_j).
+\]
+\end{theorem}
+
+\textit{Proof.} Direct specialisation of the previous theorem at $h = 0$,
+where the field factor $\exp(\beta h \sum_i \sigma_i) = 1$.
+\hfill$\square$
+
 \section{Peierls argument (\texttt{Peierls.lean})}
 
 \par\noindent\textbf{Prerequisites:} \texttt{GibbsMeasure.lean},


### PR DESCRIPTION
## Summary

Add `partitionFunction_high_temp_expansion_h_zero`, the natural h = 0 specialization of `partitionFunction_high_temp_expansion` (Step 281, PR #1118):

`Z(G, ⟨J, 0, β⟩) = (cosh(βJ))^|E| · ∑_σ ∏_e (1 + tanh(βJ) σ_iσ_j)`

Proof: substitute `h = 0` in Step 281; the field factor `exp(βh · ∑ sign(σ_i))` collapses to `exp(0) = 1` and is removed by `simp`.

References: GJ §18.3; FV §3.7.3 eq. (3.42), p. 117 (2017 ed.).

## Status

- [x] `lake build` succeeds
- [x] `lake exe GKSTest` passes
- [x] `grep -rn "sorry" IsingModel/` returns zero
- [x] linter clean
- [x] `codex exec` cross-check passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)