### PR TITLE
feat: Step 544 — each VD-family polymer equals its biUnion component (GJ §18.4)

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -966,6 +966,88 @@ theorem IsPolymer.polymerDecomposition_eq_singleton
   rw [h_image_eq]
   exact Finset.image_const hP.nonempty P
 
+/-- **Reachability in a VD-compatible biUnion stays within a polymer**:
+if `Γ` is vertex-disjoint compatible and `P ∈ Γ`, then any chain in
+`edgeAdjacentIn (Γ.biUnion id)` starting from an edge of `P` ends at
+an edge of `P`. -/
+private theorem reflTransGen_in_polymer_of_VD
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {G : SimpleGraph ι} [Fintype G.edgeSet]
+    {Γ : Finset (Finset (Sym2 ι))}
+    (hΓ : IsCompatiblePolymerFamilyVertexDisjoint G Γ)
+    {P : Finset (Sym2 ι)} (hP : P ∈ Γ)
+    {e f : Sym2 ι} (he : e ∈ P)
+    (h_chain : Relation.ReflTransGen (edgeAdjacentIn (Γ.biUnion id)) e f) :
+    f ∈ P := by
+  induction h_chain with
+  | refl => exact he
+  | tail _h_chain h_step ih =>
+    rename_i a b
+    -- ih : a ∈ P
+    -- h_step : edgeAdjacentIn biUnion a b
+    obtain ⟨_, hb_biU, v, hva, hvb⟩ := h_step
+    -- b ∈ biUnion ⇒ ∃ Q ∈ Γ, b ∈ Q
+    rw [Finset.mem_biUnion] at hb_biU
+    obtain ⟨Q, hQ, hbQ⟩ := hb_biU
+    -- v ∈ a ∈ P ⇒ v ∈ polymerSupport P
+    have hvP : v ∈ polymerSupport P :=
+      mem_polymerSupport.mpr ⟨a, ih, hva⟩
+    -- v ∈ b ∈ Q ⇒ v ∈ polymerSupport Q
+    have hvQ : v ∈ polymerSupport Q :=
+      mem_polymerSupport.mpr ⟨b, hbQ, hvb⟩
+    -- By VD: P, Q must be equal (else supports disjoint)
+    by_cases hPQ : P = Q
+    · exact hPQ ▸ hbQ
+    · exfalso
+      have h_disj : Disjoint (polymerSupport P) (polymerSupport Q) :=
+        hΓ.2 (Finset.mem_coe.mpr hP) (Finset.mem_coe.mpr hQ) hPQ
+      exact (Finset.disjoint_left.mp h_disj) hvP hvQ
+
+/-- **Lift edge-adjacency reachability from a subgraph to a superset**:
+if `P ⊆ Y`, any chain in `edgeAdjacentIn P` lifts to a chain in
+`edgeAdjacentIn Y`. -/
+private theorem reflTransGen_edgeAdjacentIn_mono
+    {ι : Type*} {P Y : Finset (Sym2 ι)} (hPY : P ⊆ Y) {e f : Sym2 ι}
+    (h : Relation.ReflTransGen (edgeAdjacentIn P) e f) :
+    Relation.ReflTransGen (edgeAdjacentIn Y) e f := by
+  induction h with
+  | refl => exact Relation.ReflTransGen.refl
+  | tail _h h_step ih =>
+    rename_i a b
+    have h_step' : edgeAdjacentIn Y a b :=
+      ⟨hPY h_step.1, hPY h_step.2.1, h_step.2.2⟩
+    exact Relation.ReflTransGen.tail ih h_step'
+
+/-- **Each VD-family polymer is its own biUnion component**: if `Γ` is
+vertex-disjoint compatible and `P ∈ Γ` with `e ∈ P`, then
+`edgeComponent (Γ.biUnion id) e = P`. -/
+theorem IsCompatiblePolymerFamilyVertexDisjoint.edgeComponent_biUnion_eq_polymer
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {G : SimpleGraph ι} [Fintype G.edgeSet]
+    {Γ : Finset (Finset (Sym2 ι))}
+    (hΓ : IsCompatiblePolymerFamilyVertexDisjoint G Γ)
+    {P : Finset (Sym2 ι)} (hP_mem : P ∈ Γ)
+    {e : Sym2 ι} (he : e ∈ P) :
+    edgeComponent (Γ.biUnion id) e = P := by
+  apply Finset.Subset.antisymm
+  · -- ⊆: chain stays in P
+    intro f hf
+    rw [mem_edgeComponent] at hf
+    exact reflTransGen_in_polymer_of_VD hΓ hP_mem he hf.2
+  · -- ⊇: P connected ⇒ chain in P → chain in biUnion
+    intro f hf
+    have hP_polymer := hΓ.1 P hP_mem
+    have h_in_biU : f ∈ Γ.biUnion id := by
+      rw [Finset.mem_biUnion]; exact ⟨P, hP_mem, hf⟩
+    rw [mem_edgeComponent]
+    refine ⟨h_in_biU, ?_⟩
+    have h_chain_in_P : Relation.ReflTransGen (edgeAdjacentIn P) e f :=
+      hP_polymer.connected e he f hf
+    have hP_sub : P ⊆ Γ.biUnion id := by
+      intro x hx
+      rw [Finset.mem_biUnion]; exact ⟨P, hP_mem, hx⟩
+    exact reflTransGen_edgeAdjacentIn_mono hP_sub h_chain_in_P
+
 /-- **Polymer model partition function (abstract)**: given a reference
 finite universe of polymer candidates `Ω : Finset (Finset (Sym2 ι))`
 and a weight function `z : Finset (Sym2 ι) → ℝ`, the polymer model


### PR DESCRIPTION
Part of #1344. **KEY MILESTONE**: each VD-family polymer P is exactly the connected component of any of its edges in the biUnion. Polymer family is recovered from biUnion by components.

## Verification
- lake build: success.
- grep sorry: 0.
- GKSTest: pass.