### PR TITLE
feat: Step 553 — sharper VD polymer-family sum upper bound (GJ §18.5)

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -1332,6 +1332,20 @@ theorem one_le_vdPolymerFamilies_sum
   rw [evenSubgraphs_eq_inline_filter]
   exact one_le_sum_pow_tanh_even_subgraph G J β hβJ
 
+/-- **Sharper VD polymer-family sum upper bound**: under `0 ≤ β·J`,
+`∑_Γ ∏ tanh(β·J)^|P| ≤ (1 + tanh(β·J))^|E|`. Tightens Step 551
+(2^|E|) using Step 392 \`sum_pow_tanh_even_subgraph_le_one_plus_tanh_pow\`. -/
+theorem vdPolymerFamilies_sum_le_one_plus_tanh_pow
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβJ : 0 ≤ β * J) :
+    (∑ Γ ∈ vdCompatiblePolymerFamilies G,
+        ∏ P ∈ Γ, Real.tanh (β * J) ^ P.card)
+      ≤ (1 + Real.tanh (β * J)) ^ G.edgeFinset.card := by
+  rw [← evenSubgraphs_sum_eq_vdPolymerFamilies_sum G (Real.tanh (β * J))]
+  rw [evenSubgraphs_eq_inline_filter]
+  exact sum_pow_tanh_even_subgraph_le_one_plus_tanh_pow G J β hβJ
+
 /-- **VD polymer-family sum sandwich**: under `0 ≤ β·J`,
 `1 ≤ ∑_Γ ∏ tanh(β·J)^|P| ≤ 2^|E|`. Bundles Steps 550 and 551. -/
 theorem vdPolymerFamilies_sum_sandwich


### PR DESCRIPTION
Part of #1344. `∑_Γ ∏ tanh^|P| ≤ (1+tanh)^|E|` — sharper than 2^|E|.

## Verification
- lake build: success.
- grep sorry: 0.
- GKSTest: pass.