### PR TITLE
feat: Step 627 — polymerFreeEnergy ContinuousOn (Set.Ici 0) (Mayer expansion, GJ §18.4)

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -3332,6 +3332,14 @@ theorem polymerFreeEnergy_differentiableOn_Ici_zero
   fun _ ht =>
     ((polymerFreeEnergy_analyticAt G ht).differentiableAt).differentiableWithinAt
 
+/-- **`polymerFreeEnergy` ContinuousOn `[0, ∞)`** (Step 627). -/
+theorem polymerFreeEnergy_continuousOn_Ici_zero
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet] :
+    ContinuousOn (fun s : ℝ => polymerFreeEnergy G s) (Set.Ici 0) :=
+  fun _ ht =>
+    ((polymerFreeEnergy_analyticAt G ht).continuousAt).continuousWithinAt
+
 /-- **`polymerFreeEnergy` HasDerivAt** (Step 625): explicit derivative
 of `polymerFreeEnergy G t = Real.log (vdPolymerFamilies_sum G t)` via
 the log-derivative formula `(log f)' = f' / f`. The derivative of


### PR DESCRIPTION
Part of #1344. `ContinuousOn polymerFreeEnergy (Set.Ici 0)` via per-point AnalyticAt → ContinuousAt → ContinuousWithinAt.