### PR TITLE
feat: Step 628 — mayerPartialSum restriction wrappers (Mayer expansion, GJ §18.4)

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -3340,6 +3340,20 @@ theorem polymerFreeEnergy_continuousOn_Ici_zero
   fun _ ht =>
     ((polymerFreeEnergy_analyticAt G ht).continuousAt).continuousWithinAt
 
+/-- **`mayerPartialSum` ContinuousOn arbitrary set** (Step 628). -/
+theorem mayerPartialSum_continuousOn
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet] (N : ℕ) (s : Set ℝ) :
+    ContinuousOn (fun t : ℝ => mayerPartialSum G N t) s :=
+  (mayerPartialSum_continuous G N).continuousOn
+
+/-- **`mayerPartialSum` DifferentiableOn arbitrary set** (Step 628). -/
+theorem mayerPartialSum_differentiableOn
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet] (N : ℕ) (s : Set ℝ) :
+    DifferentiableOn ℝ (fun t : ℝ => mayerPartialSum G N t) s :=
+  (mayerPartialSum_differentiable G N).differentiableOn
+
 /-- **`polymerFreeEnergy` HasDerivAt** (Step 625): explicit derivative
 of `polymerFreeEnergy G t = Real.log (vdPolymerFamilies_sum G t)` via
 the log-derivative formula `(log f)' = f' / f`. The derivative of


### PR DESCRIPTION
Part of #1344. Trivial restrictions of Step 591 (Continuous/Differentiable on all of ℝ) to specific sets like Set.Ici 0.