### PR TITLE
feat: Step 657 — vdPolymerFamilies_sum = 1 + (Γ ≠ ∅) (Mayer general-t, GJ §18.4)

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -3366,6 +3366,29 @@ theorem mayerPartialSum_zero_tanh_le_polymerFreeEnergy_ferromagnetic
       polymerFreeEnergy G (Real.tanh (β * J)) :=
   mayerPartialSum_zero_tanh_le_polymerFreeEnergy G (mul_nonneg hβ.le hJ)
 
+/-- **`vdPolymerFamilies_sum` split as 1 + (Γ ≠ ∅) contribution**
+(Step 657, Mayer general-t Phase A): writing
+`vdSum G t = 1 + ε(t)` where `ε(t) = ∑_{Γ ∈ vdCompat, Γ ≠ ∅} ∏ t^|P|`.
+Foundation for `log(1+ε)` Taylor expansion via Mayer combinatorics. -/
+theorem vdPolymerFamilies_sum_eq_one_add
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet] (t : ℝ) :
+    (∑ Γ ∈ vdCompatiblePolymerFamilies G, ∏ P ∈ Γ, t ^ P.card) =
+      1 + ∑ Γ ∈ (vdCompatiblePolymerFamilies G).erase ∅,
+            ∏ P ∈ Γ, t ^ P.card := by
+  classical
+  have h_empty_in :
+      (∅ : Finset (Finset (Sym2 ι))) ∈ vdCompatiblePolymerFamilies G := by
+    rw [mem_vdCompatiblePolymerFamilies]
+    exact ⟨Finset.empty_subset _, IsCompatiblePolymerFamilyVertexDisjoint.empty G⟩
+  rw [show vdCompatiblePolymerFamilies G =
+        insert (∅ : Finset (Finset (Sym2 ι)))
+          ((vdCompatiblePolymerFamilies G).erase ∅) from
+        (Finset.insert_erase h_empty_in).symm,
+      Finset.sum_insert (Finset.notMem_erase _ _),
+      Finset.prod_empty,
+      Finset.erase_insert (Finset.notMem_erase _ _)]
+
 /-- **`allPolymers G = ∅` when `G` has no edges** (Step 620): an
 edgeless graph has no even subgraph other than `∅`, which is excluded
 from `IsPolymer` by the non-emptiness clause. -/


### PR DESCRIPTION
Part of #1499

## Summary

Split `vdPolymerFamilies_sum G t = 1 + ∑_{Γ ∈ vdCompat, Γ ≠ ∅} ∏ t^|P|`.

This is the foundation for the general-t Mayer identity: writing
`vdSum = 1 + ε(t)` where `ε(t) → 0` as `t → 0`, allowing `log(1+ε)`
Taylor expansion in a neighbourhood of `t = 0`.

## Test plan

- [ ] `lake build` succeeds
- [ ] `lake exe GKSTest` passes
- [ ] `grep -rn "sorry" IsingModel/` is zero
- [ ] linter warning-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)