### PR TITLE
feat: pathGraph 6, 7 alternating sums (Mayer Phase B path-shaped, Issue #1499)

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -5219,4 +5219,36 @@ theorem alternatingConnectedSubgraphSum_pathGraph_five :
   rw [h_cast, h_int]
   norm_num
 
+/-- **Path graph on `Fin 6` `DecidableRel` instance**. -/
+private instance : DecidableRel (SimpleGraph.pathGraph 6).Adj :=
+  fun u v => decidable_of_iff _ SimpleGraph.pathGraph_adj.symm
+
+set_option maxRecDepth 2000 in
+/-- **`pathGraph 6` alternating connected-spanning sum = -1**: 5 edges,
+only the full path is connected spanning, sum = `(-1)^5 = -1`. Ursell
+coefficient for n=6 path cluster: `ϕ^T = -1/6! = -1/720`. -/
+theorem alternatingConnectedSubgraphSum_pathGraph_six :
+    alternatingConnectedSubgraphSum (SimpleGraph.pathGraph 6) = -1 := by
+  classical
+  unfold alternatingConnectedSubgraphSum
+  have h_int :
+      (∑ S ∈ (SimpleGraph.pathGraph 6).edgeFinset.powerset.filter
+        (fun S : Finset (Sym2 (Fin 6)) =>
+          (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 6)))).Connected),
+        ((-1 : ℤ) ^ S.card)) = -1 := by decide
+  unfold connectedSpanningEdgeSubsets
+  have h_cast :
+      (∑ S ∈ (SimpleGraph.pathGraph 6).edgeFinset.powerset.filter
+          (fun S : Finset (Sym2 (Fin 6)) =>
+            (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 6)))).Connected),
+        ((-1 : ℝ) ^ S.card)) =
+        (((∑ S ∈ (SimpleGraph.pathGraph 6).edgeFinset.powerset.filter
+            (fun S : Finset (Sym2 (Fin 6)) =>
+              (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 6)))).Connected),
+          ((-1 : ℤ) ^ S.card)) : ℤ) : ℝ) := by
+    push_cast
+    rfl
+  rw [h_cast, h_int]
+  norm_num
+
 end IsingModel

--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -5223,6 +5223,38 @@ theorem alternatingConnectedSubgraphSum_pathGraph_five :
 private instance : DecidableRel (SimpleGraph.pathGraph 6).Adj :=
   fun u v => decidable_of_iff _ SimpleGraph.pathGraph_adj.symm
 
+/-- **Path graph on `Fin 7` `DecidableRel` instance**. -/
+private instance : DecidableRel (SimpleGraph.pathGraph 7).Adj :=
+  fun u v => decidable_of_iff _ SimpleGraph.pathGraph_adj.symm
+
+set_option maxRecDepth 4000 in
+/-- **`pathGraph 7` alternating connected-spanning sum = 1**: 6 edges,
+only the full path is connected spanning, sum = `(-1)^6 = 1`. Ursell
+coefficient for n=7 path cluster: `ϕ^T = 1/7! = 1/5040`. -/
+theorem alternatingConnectedSubgraphSum_pathGraph_seven :
+    alternatingConnectedSubgraphSum (SimpleGraph.pathGraph 7) = 1 := by
+  classical
+  unfold alternatingConnectedSubgraphSum
+  have h_int :
+      (∑ S ∈ (SimpleGraph.pathGraph 7).edgeFinset.powerset.filter
+        (fun S : Finset (Sym2 (Fin 7)) =>
+          (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 7)))).Connected),
+        ((-1 : ℤ) ^ S.card)) = 1 := by decide
+  unfold connectedSpanningEdgeSubsets
+  have h_cast :
+      (∑ S ∈ (SimpleGraph.pathGraph 7).edgeFinset.powerset.filter
+          (fun S : Finset (Sym2 (Fin 7)) =>
+            (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 7)))).Connected),
+        ((-1 : ℝ) ^ S.card)) =
+        (((∑ S ∈ (SimpleGraph.pathGraph 7).edgeFinset.powerset.filter
+            (fun S : Finset (Sym2 (Fin 7)) =>
+              (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 7)))).Connected),
+          ((-1 : ℤ) ^ S.card)) : ℤ) : ℝ) := by
+    push_cast
+    rfl
+  rw [h_cast, h_int]
+  norm_num
+
 set_option maxRecDepth 2000 in
 /-- **`pathGraph 6` alternating connected-spanning sum = -1**: 5 edges,
 only the full path is connected spanning, sum = `(-1)^5 = -1`. Ursell


### PR DESCRIPTION
Part of #1499. Continuation of PR #1542 (pathGraph 3, 4, 5):

- `alternatingConnectedSubgraphSum_pathGraph_six = -1` — n=6 path cluster (`ϕ^T = -1/720`, 32 powerset elements, `maxRecDepth 2000`)
- `alternatingConnectedSubgraphSum_pathGraph_seven = 1` — n=7 path cluster (`ϕ^T = 1/5040`, 64 powerset elements, `maxRecDepth 4000`)

**Pattern**: For `pathGraph (n+1)` on `Fin (n+1)`, the only connected spanning edge subset is the full path (`n` edges); the alternating sum is `(-1)^n`. Confirmed for n=2 through n=6.

The general identity `alternatingConnectedSubgraphSum (pathGraph n) = (-1)^(n-1)` for n ≥ 2 would require a structural induction argument; remains deferred.