### PR TITLE
feat: cycleGraph 5, 6 alternating connected-spanning sums (Mayer Phase B, Issue #1499)

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -5392,4 +5392,37 @@ theorem alternatingConnectedSubgraphSum_cycleGraph_four :
   rw [h_cast, h_int]
   norm_num
 
+/-- **Cycle graph on `Fin 5` `DecidableRel` instance**. -/
+private instance : DecidableRel (SimpleGraph.cycleGraph 5).Adj :=
+  fun u v => decidable_of_iff _ SimpleGraph.cycleGraph_adj'.symm
+
+set_option maxRecDepth 4000 in
+/-- **`cycleGraph 5` alternating connected-spanning sum = 4**:
+the cycle on Fin 5 has 5 edges. Connected spanning subsets: 5
+spanning trees (paths of size 4 each) + the full cycle (size 5).
+Sum = `5 · (-1)^4 + (-1)^5 = 5 - 1 = 4`. -/
+theorem alternatingConnectedSubgraphSum_cycleGraph_five :
+    alternatingConnectedSubgraphSum (SimpleGraph.cycleGraph 5) = 4 := by
+  classical
+  unfold alternatingConnectedSubgraphSum
+  have h_int :
+      (∑ S ∈ (SimpleGraph.cycleGraph 5).edgeFinset.powerset.filter
+        (fun S : Finset (Sym2 (Fin 5)) =>
+          (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 5)))).Connected),
+        ((-1 : ℤ) ^ S.card)) = 4 := by decide
+  unfold connectedSpanningEdgeSubsets
+  have h_cast :
+      (∑ S ∈ (SimpleGraph.cycleGraph 5).edgeFinset.powerset.filter
+          (fun S : Finset (Sym2 (Fin 5)) =>
+            (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 5)))).Connected),
+        ((-1 : ℝ) ^ S.card)) =
+        (((∑ S ∈ (SimpleGraph.cycleGraph 5).edgeFinset.powerset.filter
+            (fun S : Finset (Sym2 (Fin 5)) =>
+              (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 5)))).Connected),
+          ((-1 : ℤ) ^ S.card)) : ℤ) : ℝ) := by
+    push_cast
+    rfl
+  rw [h_cast, h_int]
+  norm_num
+
 end IsingModel

--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -5396,6 +5396,40 @@ theorem alternatingConnectedSubgraphSum_cycleGraph_four :
 private instance : DecidableRel (SimpleGraph.cycleGraph 5).Adj :=
   fun u v => decidable_of_iff _ SimpleGraph.cycleGraph_adj'.symm
 
+/-- **Cycle graph on `Fin 6` `DecidableRel` instance**. -/
+private instance : DecidableRel (SimpleGraph.cycleGraph 6).Adj :=
+  fun u v => decidable_of_iff _ SimpleGraph.cycleGraph_adj'.symm
+
+set_option maxRecDepth 8000 in
+set_option maxHeartbeats 1000000 in
+/-- **`cycleGraph 6` alternating connected-spanning sum = -5**:
+the cycle on Fin 6 has 6 edges. Connected spanning subsets: 6
+spanning trees (paths of size 5 each) + the full cycle (size 6).
+Sum = `6 · (-1)^5 + (-1)^6 = -6 + 1 = -5`. -/
+theorem alternatingConnectedSubgraphSum_cycleGraph_six :
+    alternatingConnectedSubgraphSum (SimpleGraph.cycleGraph 6) = -5 := by
+  classical
+  unfold alternatingConnectedSubgraphSum
+  have h_int :
+      (∑ S ∈ (SimpleGraph.cycleGraph 6).edgeFinset.powerset.filter
+        (fun S : Finset (Sym2 (Fin 6)) =>
+          (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 6)))).Connected),
+        ((-1 : ℤ) ^ S.card)) = -5 := by decide
+  unfold connectedSpanningEdgeSubsets
+  have h_cast :
+      (∑ S ∈ (SimpleGraph.cycleGraph 6).edgeFinset.powerset.filter
+          (fun S : Finset (Sym2 (Fin 6)) =>
+            (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 6)))).Connected),
+        ((-1 : ℝ) ^ S.card)) =
+        (((∑ S ∈ (SimpleGraph.cycleGraph 6).edgeFinset.powerset.filter
+            (fun S : Finset (Sym2 (Fin 6)) =>
+              (SimpleGraph.fromEdgeSet (↑S : Set (Sym2 (Fin 6)))).Connected),
+          ((-1 : ℤ) ^ S.card)) : ℤ) : ℝ) := by
+    push_cast
+    rfl
+  rw [h_cast, h_int]
+  norm_num
+
 set_option maxRecDepth 4000 in
 /-- **`cycleGraph 5` alternating connected-spanning sum = 4**:
 the cycle on Fin 5 has 5 edges. Connected spanning subsets: 5


### PR DESCRIPTION
Part of #1499. Continuation of cycleGraph 3, 4 (PR #1545).

- `alternatingConnectedSubgraphSum_cycleGraph_five = 4` — 5 spanning paths · (-1)^4 + 1 cycle · (-1)^5 = 4.
- `alternatingConnectedSubgraphSum_cycleGraph_six = -5` — 6 spanning paths · (-1)^5 + 1 cycle · (-1)^6 = -5.

**Pattern**: `cycleGraph (n)` has alternating sum `(-1)^(n-1) · (n-1)` (n spanning paths each of size n-1, plus the full n-cycle).

Verified for n = 3 through 6:
- cycleGraph 3: 2 (= K_3 case from PR #1518)
- cycleGraph 4: -3
- cycleGraph 5: 4
- cycleGraph 6: -5