### PR TITLE
feat: polymerFreeEnergy / vdSum strict-monotonicity GJ-命題-bundle (§18.4, Issue #1499)

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -6003,4 +6003,82 @@ theorem vdPolymerFamilies_sum_tanh_eq_one_iff
   rw [vdPolymerFamilies_sum_eq_one_iff_eps_eq_zero]
   exact vdPolymerFamilies_sum_minus_one_eq_zero_iff G (real_tanh_nonneg hβJ)
 
+/-! ## §18.4 strict monotonicity bundle
+
+Strict monotonicity of `vdPolymerFamilies_sum` and `polymerFreeEnergy`
+in the activity `t` under the hypothesis that polymers exist. Bundle
+of GJ-命題 corollaries: if at least one polymer is present, then both
+`vdSum` and `polymerFreeEnergy` are strictly increasing on `[0, ∞)`. -/
+
+/-- **`vdPolymerFamilies_sum` strict monotonicity under polymers exist**
+(§18.4): for `0 ≤ s < t` and `(allPolymers G).Nonempty`,
+`vdPolymerFamilies_sum G s < vdPolymerFamilies_sum G t`.
+
+Proof: the singleton polymer family `{P}` (for any `P ∈ allPolymers G`)
+contributes `t^|P| > s^|P|` strictly when `s < t` and `|P| ≥ 1`. The
+remaining families contribute monotone-non-decreasing terms. -/
+theorem vdPolymerFamilies_sum_lt_of_lt_of_polymers_nonempty
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (h_poly : (allPolymers G).Nonempty)
+    {s t : ℝ} (hs : 0 ≤ s) (hst : s < t) :
+    (∑ Γ ∈ vdCompatiblePolymerFamilies G, ∏ P ∈ Γ, s ^ P.card) <
+      ∑ Γ ∈ vdCompatiblePolymerFamilies G, ∏ P ∈ Γ, t ^ P.card := by
+  obtain ⟨P, hP⟩ := h_poly
+  have hP_polymer : IsPolymer G P := mem_allPolymers.mp hP
+  have hP_card_pos : 0 < P.card := Finset.card_pos.mpr hP_polymer.nonempty
+  have h_singleton_in : ({P} : Finset (Finset (Sym2 ι))) ∈
+      vdCompatiblePolymerFamilies G := by
+    rw [mem_vdCompatiblePolymerFamilies]
+    refine ⟨?_, ?_⟩
+    · intro Q hQ
+      rw [Finset.mem_singleton] at hQ; rwa [hQ]
+    · exact (isCompatiblePolymerFamilyVertexDisjoint_singleton G P).mpr hP_polymer
+  apply Finset.sum_lt_sum
+  · intro Γ _
+    apply Finset.prod_le_prod (fun Q _ => pow_nonneg hs _)
+    intro Q _
+    exact pow_le_pow_left₀ hs hst.le _
+  · refine ⟨{P}, h_singleton_in, ?_⟩
+    rw [Finset.prod_singleton, Finset.prod_singleton]
+    exact pow_lt_pow_left₀ hst hs hP_card_pos.ne'
+
+/-- **`polymerFreeEnergy` strict monotonicity under polymers exist**
+(§18.4): for `0 ≤ s < t` and `(allPolymers G).Nonempty`,
+`polymerFreeEnergy G s < polymerFreeEnergy G t`. Direct corollary
+of `vdPolymerFamilies_sum_lt_of_lt_of_polymers_nonempty` plus
+`Real.log_lt_log` (positivity of vdSum from Step 605). -/
+theorem polymerFreeEnergy_lt_of_lt_of_polymers_nonempty
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (h_poly : (allPolymers G).Nonempty)
+    {s t : ℝ} (hs : 0 ≤ s) (hst : s < t) :
+    polymerFreeEnergy G s < polymerFreeEnergy G t := by
+  unfold polymerFreeEnergy
+  apply Real.log_lt_log
+  · exact vdPolymerFamilies_sum_pos_of_nonneg G hs
+  · exact vdPolymerFamilies_sum_lt_of_lt_of_polymers_nonempty G h_poly hs hst
+
+/-- **`polymerFreeEnergy` is `StrictMonoOn (Set.Ici 0)` when polymers
+exist** (§18.4 strict-mono bundle). -/
+theorem polymerFreeEnergy_strictMonoOn_of_polymers_nonempty
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (h_poly : (allPolymers G).Nonempty) :
+    StrictMonoOn (fun t : ℝ => polymerFreeEnergy G t) (Set.Ici 0) :=
+  fun _ hs _ _ hst =>
+    polymerFreeEnergy_lt_of_lt_of_polymers_nonempty G h_poly hs hst
+
+/-- **`vdPolymerFamilies_sum` is `StrictMonoOn (Set.Ici 0)` when
+polymers exist** (§18.4 strict-mono bundle). -/
+theorem vdPolymerFamilies_sum_strictMonoOn_of_polymers_nonempty
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (h_poly : (allPolymers G).Nonempty) :
+    StrictMonoOn
+      (fun t : ℝ => ∑ Γ ∈ vdCompatiblePolymerFamilies G, ∏ P ∈ Γ, t ^ P.card)
+      (Set.Ici 0) :=
+  fun _ hs _ _ hst =>
+    vdPolymerFamilies_sum_lt_of_lt_of_polymers_nonempty G h_poly hs hst
+
 end IsingModel


### PR DESCRIPTION
Part of #1499. GJ-命題-unit PR: strict monotonicity of vdSum / polymerFreeEnergy under polymers-exist hypothesis, plus tanh forms and Λ-layer corollaries.