### PR TITLE
feat: §18.4 polymerFreeEnergy / vdSum / ε iff at β·J GJ-命題-bundle

### DIFF
--- a/IsingModel/AmbientLattice/Analyticity.lean
+++ b/IsingModel/AmbientLattice/Analyticity.lean
@@ -138,5 +138,116 @@ theorem partitionFunctionΛ_differentiable_h (G : SimpleGraph V) (Λ : Finset V)
     Differentiable ℝ (fun h' : ℝ => partitionFunctionΛ G Λ ⟨J, h', β⟩) :=
   IsingModel.partitionFunction_differentiable_h (inducedGraph G Λ) J β
 
+/-! ## §18.4 polymerFreeEnergy / vdSum / ε iff Λ-layer wrappers
+
+Direct lifts of the iff / strict-mono / strict-pos GJ-命題-bundle from
+`IsingModel/ClusterExpansion.lean` (PRs #1547-#1562) to the
+finite-volume Λ-restricted setting via `inducedGraph G Λ`. -/
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Λ-layer: `polymerFreeEnergy` strictly increasing under polymers
+exist** (§18.4 strict-mono Λ wrap). -/
+theorem polymerFreeEnergy_Λ_lt_of_lt_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (h_poly : (IsingModel.allPolymers (inducedGraph G Λ)).Nonempty)
+    {s t : ℝ} (hs : 0 ≤ s) (hst : s < t) :
+    IsingModel.polymerFreeEnergy (inducedGraph G Λ) s <
+      IsingModel.polymerFreeEnergy (inducedGraph G Λ) t :=
+  IsingModel.polymerFreeEnergy_lt_of_lt_of_polymers_nonempty
+    (inducedGraph G Λ) h_poly hs hst
+
+/-- **Λ-layer: `polymerFreeEnergy_strictMonoOn (Set.Ici 0)` under
+polymers exist** (§18.4 strict-mono Λ wrap). -/
+theorem polymerFreeEnergy_Λ_strictMonoOn_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    (h_poly : (IsingModel.allPolymers (inducedGraph G Λ)).Nonempty) :
+    StrictMonoOn (fun t : ℝ => IsingModel.polymerFreeEnergy (inducedGraph G Λ) t)
+      (Set.Ici 0) :=
+  IsingModel.polymerFreeEnergy_strictMonoOn_of_polymers_nonempty
+    (inducedGraph G Λ) h_poly
+
+/-- **Λ-layer: `polymerFreeEnergy > 0 ↔ 0 < t ∧ polymers exist`** (§18.4 Λ wrap). -/
+theorem polymerFreeEnergy_Λ_pos_iff
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) :
+    0 < IsingModel.polymerFreeEnergy (inducedGraph G Λ) t ↔
+      0 < t ∧ (IsingModel.allPolymers (inducedGraph G Λ)).Nonempty :=
+  IsingModel.polymerFreeEnergy_pos_iff (inducedGraph G Λ) ht
+
+/-- **Λ-layer: `polymerFreeEnergy = 0 ↔ t = 0 ∨ no polymers`** (§18.4 Λ wrap). -/
+theorem polymerFreeEnergy_Λ_eq_zero_iff
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) :
+    IsingModel.polymerFreeEnergy (inducedGraph G Λ) t = 0 ↔
+      t = 0 ∨ IsingModel.allPolymers (inducedGraph G Λ) = ∅ :=
+  IsingModel.polymerFreeEnergy_eq_zero_iff (inducedGraph G Λ) ht
+
+/-- **Λ-layer: `polymerFreeEnergy ≤ ε(t)` under `0 ≤ t`** (§18.4 Λ wrap). -/
+theorem polymerFreeEnergy_Λ_le_eps_of_nonneg
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) :
+    IsingModel.polymerFreeEnergy (inducedGraph G Λ) t ≤
+      ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies (inducedGraph G Λ)).erase ∅,
+        ∏ P ∈ Γ, t ^ P.card :=
+  IsingModel.polymerFreeEnergy_le_eps_of_nonneg (inducedGraph G Λ) ht
+
+/-- **Λ-layer: `polymerFreeEnergy < ε(t)` when `ε(t) > 0`** (§18.4 Λ wrap). -/
+theorem polymerFreeEnergy_Λ_lt_eps_of_eps_pos
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {t : ℝ} (h_eps_pos : 0 < ∑ Γ ∈
+      (IsingModel.vdCompatiblePolymerFamilies (inducedGraph G Λ)).erase ∅,
+      ∏ P ∈ Γ, t ^ P.card) :
+    IsingModel.polymerFreeEnergy (inducedGraph G Λ) t <
+      ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies (inducedGraph G Λ)).erase ∅,
+        ∏ P ∈ Γ, t ^ P.card :=
+  IsingModel.polymerFreeEnergy_lt_eps_of_eps_pos (inducedGraph G Λ) h_eps_pos
+
+/-- **Λ-layer: `polymerFreeEnergy ≤ (1+t)^|E| - 1` under `0 ≤ t`** (§18.4 Λ wrap). -/
+theorem polymerFreeEnergy_Λ_le_pow_sub_one_of_nonneg
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) :
+    IsingModel.polymerFreeEnergy (inducedGraph G Λ) t ≤
+      (1 + t) ^ (inducedGraph G Λ).edgeFinset.card - 1 :=
+  IsingModel.polymerFreeEnergy_le_pow_sub_one_of_nonneg (inducedGraph G Λ) ht
+
+/-- **Λ-layer: `polymerFreeEnergy < log 2` under `(1+t)^|E| < 2` and
+`0 ≤ t`** (§18.4 Λ wrap). -/
+theorem polymerFreeEnergy_Λ_lt_log_two_of_pow_lt_two
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t)
+    (h_pow : (1 + t) ^ (inducedGraph G Λ).edgeFinset.card < 2) :
+    IsingModel.polymerFreeEnergy (inducedGraph G Λ) t < Real.log 2 :=
+  IsingModel.polymerFreeEnergy_lt_log_two_of_pow_lt_two (inducedGraph G Λ) ht h_pow
+
+/-- **Λ-layer: `vdSum > 1 ↔ ε > 0` under `0 ≤ t`** (§18.4 Λ wrap). -/
+theorem vdPolymerFamilies_sum_Λ_gt_one_iff_eps_pos
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) :
+    1 < (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies (inducedGraph G Λ),
+            ∏ P ∈ Γ, t ^ P.card) ↔
+      0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies (inducedGraph G Λ)).erase ∅,
+        ∏ P ∈ Γ, t ^ P.card :=
+  IsingModel.vdPolymerFamilies_sum_gt_one_iff_eps_pos (inducedGraph G Λ) ht
+
+/-- **Λ-layer: `vdSum = 1 ↔ ε = 0`** (§18.4 Λ wrap). -/
+theorem vdPolymerFamilies_sum_Λ_eq_one_iff_eps_zero
+    (G : SimpleGraph V) (Λ : Finset V)
+    [Fintype (inducedGraph G Λ).edgeSet] (t : ℝ) :
+    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies (inducedGraph G Λ),
+        ∏ P ∈ Γ, t ^ P.card) = 1 ↔
+      (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies (inducedGraph G Λ)).erase ∅,
+        ∏ P ∈ Γ, t ^ P.card) = 0 :=
+  IsingModel.vdPolymerFamilies_sum_eq_one_iff_eps_eq_zero (inducedGraph G Λ) t
+
 end Ambient
 end IsingModel


### PR DESCRIPTION
Part of #1499. Tanh-substituted iff characterisations bundled for the ferromagnetic Ising activity `tanh(β·J)`.