### PR TITLE
feat: §18.4 polymerFreeEnergy ferromagnetic strict / iff GJ-命題-bundle

### DIFF
--- a/IsingModel/ClusterExpansion.lean
+++ b/IsingModel/ClusterExpansion.lean
@@ -6219,4 +6219,112 @@ theorem mayerPartialSum_zero_eq_zero
   rw [show Finset.range (0 + 1) = {0} from rfl, Finset.sum_singleton]
   exact mayerExpansionTerm_zero G t
 
+/-! ## §18.4 ferromagnetic strict / iff bundle (J ≥ 0, β ≥ 0)
+
+Ferromagnetic forms of the recent tanh-based iff / strict-mono /
+strict-pos theorems. Convention: `J ≥ 0` and `β ≥ 0` (ferromagnetic
+high-temperature regime), so `0 ≤ β·J` follows from `mul_nonneg`. -/
+
+/-- **Ferromagnetic: `polymerFreeEnergy_tanh_lt_eps_iff_eps_pos`** under
+`J ≥ 0` and `β ≥ 0`. -/
+theorem polymerFreeEnergy_tanh_lt_eps_iff_eps_pos_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) :
+    polymerFreeEnergy G (Real.tanh (β * J)) <
+        ∑ Γ ∈ (vdCompatiblePolymerFamilies G).erase ∅,
+          ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card ↔
+      0 < ∑ Γ ∈ (vdCompatiblePolymerFamilies G).erase ∅,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
+  polymerFreeEnergy_tanh_lt_eps_iff_eps_pos G (mul_nonneg hβ hJ)
+
+/-- **Ferromagnetic: `polymerFreeEnergy_tanh_eq_zero_iff_eps_eq_zero`** under
+`J ≥ 0` and `β ≥ 0`. -/
+theorem polymerFreeEnergy_tanh_eq_zero_iff_eps_eq_zero_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) :
+    polymerFreeEnergy G (Real.tanh (β * J)) = 0 ↔
+      (∑ Γ ∈ (vdCompatiblePolymerFamilies G).erase ∅,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) = 0 :=
+  polymerFreeEnergy_tanh_eq_zero_iff_eps_eq_zero G (mul_nonneg hβ hJ)
+
+/-- **Ferromagnetic: `polymerFreeEnergy_tanh_pos_iff_eps_pos`** under
+`J ≥ 0` and `β ≥ 0`. -/
+theorem polymerFreeEnergy_tanh_pos_iff_eps_pos_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) :
+    0 < polymerFreeEnergy G (Real.tanh (β * J)) ↔
+      0 < ∑ Γ ∈ (vdCompatiblePolymerFamilies G).erase ∅,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
+  polymerFreeEnergy_tanh_pos_iff_eps_pos G (mul_nonneg hβ hJ)
+
+/-- **Ferromagnetic: `polymerFreeEnergy_tanh_pos_iff`** characterising via
+`tanh > 0 ∧ polymers exist` under `J ≥ 0` and `β ≥ 0`. -/
+theorem polymerFreeEnergy_tanh_pos_iff_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) :
+    0 < polymerFreeEnergy G (Real.tanh (β * J)) ↔
+      0 < Real.tanh (β * J) ∧ (allPolymers G).Nonempty :=
+  polymerFreeEnergy_tanh_pos_iff G (mul_nonneg hβ hJ)
+
+/-- **Ferromagnetic: `polymerFreeEnergy_tanh_eq_zero_iff`** characterising
+via `tanh = 0 ∨ no polymers` under `J ≥ 0` and `β ≥ 0`. -/
+theorem polymerFreeEnergy_tanh_eq_zero_iff_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) :
+    polymerFreeEnergy G (Real.tanh (β * J)) = 0 ↔
+      Real.tanh (β * J) = 0 ∨ allPolymers G = ∅ :=
+  polymerFreeEnergy_tanh_eq_zero_iff G (mul_nonneg hβ hJ)
+
+/-- **Ferromagnetic: `vdSum > 1 ↔ tanh > 0 ∧ polymers exist`** under
+`J ≥ 0` and `β ≥ 0`. -/
+theorem vdPolymerFamilies_sum_tanh_gt_one_iff_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) :
+    1 < (∑ Γ ∈ vdCompatiblePolymerFamilies G,
+          ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ↔
+      0 < Real.tanh (β * J) ∧ (allPolymers G).Nonempty :=
+  vdPolymerFamilies_sum_tanh_gt_one_iff G (mul_nonneg hβ hJ)
+
+/-- **Ferromagnetic: `vdSum = 1 ↔ tanh = 0 ∨ no polymers`** under
+`J ≥ 0` and `β ≥ 0`. -/
+theorem vdPolymerFamilies_sum_tanh_eq_one_iff_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) :
+    (∑ Γ ∈ vdCompatiblePolymerFamilies G,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) = 1 ↔
+      Real.tanh (β * J) = 0 ∨ allPolymers G = ∅ :=
+  vdPolymerFamilies_sum_tanh_eq_one_iff G (mul_nonneg hβ hJ)
+
+/-- **Ferromagnetic: `polymerFreeEnergy_tanh_lt_pow_sub_one_of_eps_pos`**
+under `J ≥ 0` and `β ≥ 0`. -/
+theorem polymerFreeEnergy_tanh_lt_pow_sub_one_of_eps_pos_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J)
+    (h_eps_pos : 0 < ∑ Γ ∈ (vdCompatiblePolymerFamilies G).erase ∅,
+      ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :
+    polymerFreeEnergy G (Real.tanh (β * J)) <
+      (1 + Real.tanh (β * J)) ^ G.edgeFinset.card - 1 :=
+  polymerFreeEnergy_tanh_lt_pow_sub_one_of_eps_pos G (mul_nonneg hβ hJ) h_eps_pos
+
+/-- **Ferromagnetic: `polymerFreeEnergy_tanh_lt_eps_of_eps_pos`** under
+`J ≥ 0` and `β ≥ 0`. -/
+theorem polymerFreeEnergy_tanh_lt_eps_of_eps_pos_ferromagnetic
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J)
+    (h_eps_pos : 0 < ∑ Γ ∈ (vdCompatiblePolymerFamilies G).erase ∅,
+      ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :
+    polymerFreeEnergy G (Real.tanh (β * J)) <
+      ∑ Γ ∈ (vdCompatiblePolymerFamilies G).erase ∅,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
+  polymerFreeEnergy_tanh_lt_eps_of_eps_pos G (mul_nonneg hβ hJ) h_eps_pos
+
 end IsingModel


### PR DESCRIPTION
Part of #1499. Ferromagnetic (J ≥ 0, β ≥ 0) versions of recent strict-mono / strict-pos / iff theorems for tanh-substituted polymerFreeEnergy.