### PR TITLE
feat: §17.5 Step 117h pseudoMassG_hasStrictDerivAt (Issue #1645 first step)

### DIFF
--- a/IsingModel/PseudoMass.lean
+++ b/IsingModel/PseudoMass.lean
@@ -255,6 +255,48 @@ theorem pseudoMassG_hasDerivAt (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r
   have hdiv := hf.div hh hne
   convert hdiv using 1; ring
 
+/-- **Step 117h (Issue #1645): `pseudoMassG α r` has a STRICT derivative
+at any `t ≥ 0`** (`HasStrictDerivAt`, not just `HasDerivAt`).
+
+Proof: `pseudoMassG α r t = 2 · exp(-(t·r)) / (1 + (t·r)^α)`, and each
+component is built from `HasStrictDerivAt` primitives:
+- `t ↦ -(t·r)` is affine.
+- `t ↦ Real.exp(...)` is `HasStrictDerivAt` via `Real.exp.hasStrictDerivAt` chain.
+- `t ↦ (t·r)^α` is polynomial.
+- `1 + (t·r)^α ≠ 0` (denominator non-zero), so division preserves
+  `HasStrictDerivAt`.
+
+This is the prerequisite for the implicit function theorem application
+to deduce `HasDerivAt` for `pseudoMass` (the inverse), unlocking the
+substantive bridge of GJ §17.5 Lemma 17.5.2 (Issue #1645). -/
+theorem pseudoMassG_hasStrictDerivAt (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r) :
+    HasStrictDerivAt (pseudoMassG α r)
+      ((-2 * r * Real.exp (-(t * r)) * (1 + (t * r) ^ α) -
+        2 * Real.exp (-(t * r)) * (↑α * (t * r) ^ (α - 1) * r)) /
+       (1 + (t * r) ^ α) ^ 2) t := by
+  have hne : (1 + (t * r) ^ α : ℝ) ≠ 0 := by
+    have h : 0 ≤ (t * r) ^ α := pow_nonneg (mul_nonneg ht hr.le) α
+    linarith
+  -- t ↦ t * r has strict derivative r
+  have h_mul : HasStrictDerivAt (fun t : ℝ => t * r) r t := by
+    have h := (hasStrictDerivAt_id t).mul_const r
+    simpa using h
+  -- t ↦ -(t * r) has strict derivative -r
+  -- t ↦ 2 * exp(-(t * r)) has strict derivative 2 * (exp(-(t*r)) * (-r))
+  have hf : HasStrictDerivAt (fun t : ℝ => 2 * Real.exp (-(t * r)))
+      (2 * (Real.exp (-(t * r)) * (-r))) t :=
+    h_mul.neg.exp.const_mul 2
+  -- t ↦ 1 + (t * r)^α has strict derivative ↑α * (t*r)^(α-1) * r
+  have hh : HasStrictDerivAt (fun t => 1 + (t * r) ^ α)
+      (↑α * (t * r) ^ (α - 1) * r) t := by
+    have h := (hasStrictDerivAt_const t (1 : ℝ)).add (h_mul.pow α)
+    convert h using 1
+    simp
+  -- Division gives the quotient rule derivative
+  unfold pseudoMassG
+  have hdiv := hf.div hh hne
+  convert hdiv using 1; ring
+
 /-- The derivative of `pseudoMassG α r` at `t > 0` is strictly negative,
 confirming the strict antitonicity on `(0, ∞)`. -/
 theorem pseudoMassG_deriv_neg (α : ℕ) {r t : ℝ} (ht : 0 < t) (hr : 0 < r) :


### PR DESCRIPTION
## Summary

§17.5 Lemma 17.5.2 (full) substantive completion — first step (Issue #1645 Step 117h).

Adds `pseudoMassG_hasStrictDerivAt`: the strict-derivative version of the existing `pseudoMassG_hasDerivAt`.

The strict-derivative form is a **prerequisite** for applying the implicit function theorem to deduce that `pseudoMass` (the inverse of `pseudoMassG α r` at fixed α, r) is differentiable as a function of `c`. Mathlib's inverse-function machinery requires `HasStrictDerivAt`, not just `HasDerivAt`.

**Proof structure**: builds via `HasStrictDerivAt` primitives:
- `t ↦ t * r` strict (linear).
- `t ↦ exp(-(t * r))` strict via `Real.exp.hasStrictDerivAt` chain.
- `t ↦ (t * r)^α` strict via `HasStrictDerivAt.pow`.
- `t ↦ 1 + (t * r)^α` via `HasStrictDerivAt.add` + `convert` for pointwise rewrite.
- Quotient rule via `HasStrictDerivAt.div` (denominator `1 + (tr)^α ≠ 0` for `t ≥ 0`, `r > 0`).

This unblocks Step 117i+ (concrete `pseudoMassFromParams` definition + `pseudoMass` differentiability via implicit function theorem), part of the §17.5 Lemma 17.5.2 completion plan.

Part of #1645.

References: Glimm-Jaffe §17.5, pp. 311–312.

## Test plan
- [x] `lake build` clean (zero linter warnings)
- [x] `grep -rn "sorry" IsingModel/` = 0
- [x] `lake exe GKSTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>