### PR TITLE
feat: §17.5 pseudoMassFromParamsAtPair_beta_zero trivial slice (Issue #1645)

### DIFF
--- a/IsingModel/PseudoMass.lean
+++ b/IsingModel/PseudoMass.lean
@@ -1117,4 +1117,23 @@ theorem pseudoMassFromParamsAtPair_eq_zero_of_corr_not_mem
     pseudoMassFromParamsAtPair hα hr d Λ p x z = 0 :=
   pseudoMassExt_of_not_mem hα hr hc
 
+/-- **`pseudoMassFromParamsAtPair` at `β = 0` (infinite-temperature
+trivial slice)**: equals 0 because the correlation vanishes. -/
+theorem pseudoMassFromParamsAtPair_beta_zero {α : ℕ} (hα : 1 ≤ α)
+    {r : ℝ} (hr : 0 < r) (d : ℕ)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
+                      (Λ.volume n)).edgeSet]
+    (J h : ℝ) (x z : Fin d → ℤ) :
+    pseudoMassFromParamsAtPair hα hr d Λ (⟨J, h, 0⟩ : IsingParams ℝ) x z = 0 := by
+  have hxz_ne : ({x, z} : Finset (Fin d → ℤ)).Nonempty :=
+    ⟨x, by simp⟩
+  have hcorr := Ambient.correlationInfinite_beta_zero_vanish
+    (IsingModel.latticeGraph d) Λ J h {x, z} hxz_ne
+  unfold pseudoMassFromParamsAtPair
+  rw [hcorr]
+  apply pseudoMassExt_of_not_mem
+  intro hmem
+  exact lt_irrefl 0 hmem.1
+
 end IsingModel


### PR DESCRIPTION
## Summary

§17.5 trivial slice property of the Step 117k bridge: at β = 0 (infinite-temperature), `pseudoMassFromParamsAtPair = 0`.

Proof: `correlationInfinite_beta_zero_vanish` gives correlation = 0 at β=0 for any non-empty pair, then `pseudoMassExt 0 = 0` since `0 ∉ Ioo 0 2`.

Part of #1645.

## Test plan
- [x] `lake build` clean (zero linter warnings)
- [x] `grep -rn "sorry" IsingModel/` = 0
- [x] `lake exe GKSTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>