### PR TITLE
feat: §17.5 pseudoMassFromParamsAtPair at J=0 distinct = pseudoMass(tanh^2) (Issue #1645)

### DIFF
--- a/IsingModel/PseudoMass.lean
+++ b/IsingModel/PseudoMass.lean
@@ -1996,4 +1996,34 @@ theorem pseudoMassFromParamsAtPair_at_h_zero_sandwich_pseudoMass
    pseudoMassFromParamsAtPair_at_h_zero_le_pseudoMass_of_truncated2_ge
       hα hr d Λ J β x z hc_min htrunc hge⟩
 
+/-- **At `J = 0` distinct pair, `pseudoMassFromParamsAtPair` equals
+the typed `pseudoMass(tanh(β·h)^2)`** when `0 < h` and `0 < β`
+(ferromagnetic with strict positivity): `tanh(β·h) ∈ (0, 1)`, so
+`tanh(β·h)^2 ∈ Ioo 0 1 ⊂ Ioo 0 2`, hence the totalisation collapses
+to the typed `pseudoMass`. Combines `_at_J_zero_distinct_eq` (gives
+`pseudoMassExt(tanh(β·h)^2)`) with `pseudoMassExt_of_mem`. -/
+theorem pseudoMassFromParamsAtPair_at_J_zero_distinct_eq_pseudoMass
+    {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) (d : ℕ)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
+                      (Λ.volume n)).edgeSet]
+    {h β : ℝ} (hh : 0 < h) (hβ : 0 < β) {x z : Fin d → ℤ} (hxz : x ≠ z) :
+    ∃ hmem : Real.tanh (β * h) ^ 2 ∈ Set.Ioo (0 : ℝ) 2,
+      pseudoMassFromParamsAtPair hα hr d Λ
+          (⟨0, h, β⟩ : IsingParams ℝ) x z = pseudoMass hα hr hmem := by
+  have hf : Ferromagnetic (⟨(0 : ℝ), h, β⟩ : IsingParams ℝ) :=
+    ⟨le_refl 0, hh.le, hβ⟩
+  have habs : |Real.tanh (β * h)| < 1 := Real.abs_tanh_lt_one _
+  have hlt_one : Real.tanh (β * h) < 1 := lt_of_abs_lt habs
+  have hgt_neg_one : -1 < Real.tanh (β * h) := neg_lt_of_abs_lt habs
+  have htanh_pos : 0 < Real.tanh (β * h) := by
+    rw [Real.tanh_eq_sinh_div_cosh]
+    exact div_pos (Real.sinh_pos_iff.mpr (mul_pos hβ hh)) (Real.cosh_pos _)
+  have hmem : Real.tanh (β * h) ^ 2 ∈ Set.Ioo (0 : ℝ) 2 := by
+    refine ⟨by positivity, ?_⟩
+    nlinarith
+  refine ⟨hmem, ?_⟩
+  rw [pseudoMassFromParamsAtPair_at_J_zero_distinct_eq hα hr d Λ hf hxz]
+  exact pseudoMassExt_of_mem hα hr hmem
+
 end IsingModel


### PR DESCRIPTION
Part of #1645

## Summary

Add `pseudoMassFromParamsAtPair_at_J_zero_distinct_eq_pseudoMass`: when `0 < h` and `0 < β` (ferromagnetic strict-positive) at distinct pair, the bridge equals the typed `pseudoMass(tanh(β·h)^2)` (not just `pseudoMassExt`).

Returns the `tanh(β·h)^2 ∈ Ioo 0 2` membership proof + equality as `∃ hmem, ... = pseudoMass _ hmem`, exposing the typed form for derivative API access.

## Test plan

- [x] `lake build IsingModel.PseudoMass` succeeds
- [x] No new sorrys / project axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)