### PR TITLE
feat: §17.5 pseudoMassFromParamsAtPair J=0 distinct ContinuousAt in β (Issue #1645)

### DIFF
--- a/IsingModel/PseudoMass.lean
+++ b/IsingModel/PseudoMass.lean
@@ -2151,4 +2151,49 @@ theorem pseudoMassFromParamsAtPair_J_zero_h_zero_any_pair
     exact pseudoMassFromParamsAtPair_diag_h_zero hα hr d Λ 0 β x
   · exact pseudoMassFromParamsAtPair_at_J_zero_h_zero_eq_zero hα hr d Λ hβ hxz
 
+/-- **At `J = 0` distinct pair, `pseudoMassFromParamsAtPair` is
+`ContinuousAt` in `β` for `β > 0`** (with `h > 0` fixed): combines
+`_at_J_zero_distinct_eq` (the bridge equals `pseudoMassExt(tanh(β·h)^2)`)
+with `pseudoMassExt_tanh_sq_continuousAt_pos` (PR #1685). Useful for
+showing the J=0 reference slice is continuously parametrised by β. -/
+theorem pseudoMassFromParamsAtPair_at_J_zero_distinct_continuousAt_beta_pos
+    {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) (d : ℕ)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
+                      (Λ.volume n)).edgeSet]
+    {h β : ℝ} (hh : 0 < h) (hβ : 0 < β) {x z : Fin d → ℤ} (hxz : x ≠ z) :
+    ContinuousAt
+      (fun b : ℝ => pseudoMassFromParamsAtPair hα hr d Λ
+                      (⟨0, h, b⟩ : IsingParams ℝ) x z) β := by
+  have hf_at : ∀ b > 0, Ferromagnetic (⟨(0 : ℝ), h, b⟩ : IsingParams ℝ) :=
+    fun b hb => ⟨le_refl 0, hh.le, hb⟩
+  -- Use `pseudoMassFromParamsAtPair_at_J_zero_distinct_eq` to rewrite as
+  -- `pseudoMassExt(tanh(b·h)^2)`. The rewrite holds for ferromagnetic params,
+  -- which requires `b > 0`. Use `Filter.EventuallyEq` on a neighborhood of β.
+  have hβ_nhd : ∀ᶠ b in nhds β, 0 < b := by
+    rw [Metric.eventually_nhds_iff]
+    refine ⟨β / 2, by linarith, ?_⟩
+    intros y hy
+    rw [Real.dist_eq, abs_lt] at hy
+    linarith
+  have hEq : (fun b : ℝ => pseudoMassFromParamsAtPair hα hr d Λ
+                              (⟨0, h, b⟩ : IsingParams ℝ) x z) =ᶠ[nhds β]
+              (fun b : ℝ => pseudoMassExt hα hr (Real.tanh (b * h) ^ 2)) := by
+    filter_upwards [hβ_nhd] with b hb
+    exact pseudoMassFromParamsAtPair_at_J_zero_distinct_eq hα hr d Λ
+            (hf_at b hb) hxz
+  refine (ContinuousAt.congr ?_ hEq.symm)
+  -- Continuity of `b ↦ pseudoMassExt(tanh(b·h)^2)` at β:
+  -- Composition `(b ↦ b·h)` (continuous) then `pseudoMassExt(tanh(·)^2)`
+  -- (continuous at β·h > 0 by PR #1685).
+  have hβh_pos : 0 < β * h := mul_pos hβ hh
+  have hmul : ContinuousAt (fun b : ℝ => b * h) β :=
+    (continuous_id.mul continuous_const).continuousAt
+  have houter : ContinuousAt
+                  (fun s : ℝ => pseudoMassExt hα hr (Real.tanh s ^ 2)) (β * h) :=
+    pseudoMassExt_tanh_sq_continuousAt_pos hα hr hβh_pos
+  change ContinuousAt
+    ((fun s : ℝ => pseudoMassExt hα hr (Real.tanh s ^ 2)) ∘ (fun b : ℝ => b * h)) β
+  exact ContinuousAt.comp houter hmul
+
 end IsingModel


### PR DESCRIPTION
Part of #1645

Add `pseudoMassFromParamsAtPair_at_J_zero_distinct_continuousAt_beta_pos`: at the J=0 reference slice with `0 < h`, distinct pair `x ≠ z`, the function `β ↦ pseudoMassFromParamsAtPair ⟨0, h, β⟩ x z` is `ContinuousAt` at any `β > 0`.

Combines `_at_J_zero_distinct_eq` (eventually-equal rewrite on a neighborhood of β where ferromagnetic holds) with `pseudoMassExt_tanh_sq_continuousAt_pos` (PR #1685).

🤖 Generated with [Claude Code](https://claude.com/claude-code)