### PR TITLE
feat: §17.5 pseudoMassFromParamsAtPair J=0 distinct joint ContinuousAt in (β, h) (Issue #1645)

### DIFF
--- a/IsingModel/PseudoMass.lean
+++ b/IsingModel/PseudoMass.lean
@@ -2313,4 +2313,48 @@ theorem pseudoMassFromParamsAtPair_at_J_zero_distinct_continuousAt_h_pos
     ((fun s : ℝ => pseudoMassExt hα hr (Real.tanh s ^ 2)) ∘ (fun y : ℝ => β * y)) h
   exact ContinuousAt.comp houter hmul
 
+/-- **At `J = 0` distinct pair, `pseudoMassFromParamsAtPair` is jointly
+`ContinuousAt` in `(β, h)` for `β > 0, h > 0`**: composition of
+`(β, h) ↦ β·h` (joint continuous) with `pseudoMassExt(tanh(t)^2)`
+continuous at `β·h > 0` (PR #1685). -/
+theorem pseudoMassFromParamsAtPair_at_J_zero_distinct_continuousAt_betaH_pos
+    {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) (d : ℕ)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
+                      (Λ.volume n)).edgeSet]
+    {h β : ℝ} (hh : 0 < h) (hβ : 0 < β) {x z : Fin d → ℤ} (hxz : x ≠ z) :
+    ContinuousAt
+      (fun p : ℝ × ℝ => pseudoMassFromParamsAtPair hα hr d Λ
+                          (⟨0, p.2, p.1⟩ : IsingParams ℝ) x z) (β, h) := by
+  have hf_at : ∀ p : ℝ × ℝ, 0 < p.1 → 0 < p.2 →
+                  Ferromagnetic (⟨(0 : ℝ), p.2, p.1⟩ : IsingParams ℝ) :=
+    fun p hp1 hp2 => ⟨le_refl 0, hp2.le, hp1⟩
+  have hβ_nhd : ∀ᶠ p : ℝ × ℝ in nhds (β, h), 0 < p.1 ∧ 0 < p.2 := by
+    have h1 : ∀ᶠ p : ℝ × ℝ in nhds (β, h), 0 < p.1 := by
+      have hcont : ContinuousAt (fun p : ℝ × ℝ => p.1) (β, h) :=
+        continuous_fst.continuousAt
+      exact hcont.eventually_const_lt hβ
+    have h2 : ∀ᶠ p : ℝ × ℝ in nhds (β, h), 0 < p.2 := by
+      have hcont : ContinuousAt (fun p : ℝ × ℝ => p.2) (β, h) :=
+        continuous_snd.continuousAt
+      exact hcont.eventually_const_lt hh
+    filter_upwards [h1, h2] with p hp1 hp2 using ⟨hp1, hp2⟩
+  have hEq : (fun p : ℝ × ℝ => pseudoMassFromParamsAtPair hα hr d Λ
+                                  (⟨0, p.2, p.1⟩ : IsingParams ℝ) x z) =ᶠ[nhds (β, h)]
+              (fun p : ℝ × ℝ => pseudoMassExt hα hr (Real.tanh (p.1 * p.2) ^ 2)) := by
+    filter_upwards [hβ_nhd] with p ⟨hp1, hp2⟩
+    exact pseudoMassFromParamsAtPair_at_J_zero_distinct_eq hα hr d Λ
+            (hf_at p hp1 hp2) hxz
+  refine (ContinuousAt.congr ?_ hEq.symm)
+  have hβh_pos : 0 < β * h := mul_pos hβ hh
+  have hmul : ContinuousAt (fun p : ℝ × ℝ => p.1 * p.2) (β, h) :=
+    (continuous_fst.mul continuous_snd).continuousAt
+  have houter : ContinuousAt
+                  (fun s : ℝ => pseudoMassExt hα hr (Real.tanh s ^ 2)) (β * h) :=
+    pseudoMassExt_tanh_sq_continuousAt_pos hα hr hβh_pos
+  change ContinuousAt
+    ((fun s : ℝ => pseudoMassExt hα hr (Real.tanh s ^ 2)) ∘
+      (fun p : ℝ × ℝ => p.1 * p.2)) (β, h)
+  exact ContinuousAt.comp houter hmul
+
 end IsingModel


### PR DESCRIPTION
Part of #1645

Joint continuity at `(β, h)` with both > 0 in the J=0 distinct slice. Composition: joint multiplication `(β, h) ↦ β·h` (continuous) with `pseudoMassExt_tanh_sq_continuousAt_pos` (PR #1685).

Completes the regularity package for J=0 reference slice (PRs #1686-#1688).

🤖 Generated with [Claude Code](https://claude.com/claude-code)