### PR TITLE
feat: §17.5 pseudoMassG α r AnalyticAt at t ≥ 0 (Issue #1645)

### DIFF
--- a/IsingModel/PseudoMass.lean
+++ b/IsingModel/PseudoMass.lean
@@ -144,6 +144,30 @@ theorem pseudoMassG_strictAntiOn
       pow_nonneg (mul_nonneg (Set.mem_Ici.mp hs) hr.le) α
     linarith
 
+/-- **`pseudoMassG α r` is `AnalyticAt` at every `t ≥ 0`** (for `r > 0`):
+the function `2 · exp(-(t·r)) / (1 + (t·r)^α)` is a quotient of analytic
+functions with non-vanishing denominator on `[0, ∞)`, hence analytic
+everywhere on the closed half-line. -/
+theorem pseudoMassG_analyticAt (α : ℕ) {r : ℝ} (hr : 0 < r) {t : ℝ} (ht : 0 ≤ t) :
+    AnalyticAt ℝ (pseudoMassG α r) t := by
+  unfold pseudoMassG
+  have h_tr : AnalyticAt ℝ (fun x : ℝ => x * r) t :=
+    analyticAt_id.mul (analyticAt_const)
+  have h_neg_tr : AnalyticAt ℝ (fun x : ℝ => -(x * r)) t :=
+    h_tr.neg
+  have h_exp : AnalyticAt ℝ (fun x : ℝ => Real.exp (-(x * r))) t :=
+    analyticAt_rexp.comp h_neg_tr
+  have h_two_exp : AnalyticAt ℝ (fun x : ℝ => 2 * Real.exp (-(x * r))) t :=
+    analyticAt_const.mul h_exp
+  have h_pow : AnalyticAt ℝ (fun x : ℝ => (x * r) ^ α) t :=
+    h_tr.pow α
+  have h_denom : AnalyticAt ℝ (fun x : ℝ => 1 + (x * r) ^ α) t :=
+    analyticAt_const.add h_pow
+  have h_denom_ne : (1 + (t * r) ^ α) ≠ 0 := by
+    have h_pow_nn : 0 ≤ (t * r) ^ α := pow_nonneg (mul_nonneg ht hr.le) α
+    linarith
+  exact h_two_exp.div h_denom h_denom_ne
+
 /-- **`pseudoMassG α r t < 2` for `t > 0` (strict at positive `t`)**:
 direct corollary of `pseudoMassG_strictAntiOn` (strict anti on `Ici 0`)
 and `pseudoMassG_zero` (`g(0) = 2`). Sharpens `pseudoMassG_le_two`


### PR DESCRIPTION
Part of #1645

Strengthen `pseudoMassG` regularity from continuous/differentiable to real-analytic. Quotient of analytic numerator and non-vanishing analytic denominator on `[0, ∞)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)