### PR TITLE
feat: §17.5 pseudoMass(c) ≤ (2-c)/(c·r) sharper bound near c=2 (Issue #1645)

### DIFF
--- a/IsingModel/PseudoMass.lean
+++ b/IsingModel/PseudoMass.lean
@@ -679,6 +679,29 @@ theorem pseudoMass_pos {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) {c : �
     rw [← h, pseudoMassG_zero hα r] at hspec
     linarith [hc.2]
 
+/-- **`pseudoMass(c) ≤ (2-c)/(c·r)`**: sharper bound near `c = 2`,
+where `log(2/c) ≤ 2/c - 1 = (2-c)/c` via `Real.log_le_sub_one_of_pos`.
+Captures the boundary behavior `pseudoMass(c) → 0` linearly as
+`c → 2-`. -/
+theorem pseudoMass_le_two_sub_div_mul_r {α : ℕ} (hα : 1 ≤ α) {r : ℝ}
+    (hr : 0 < r) {c : ℝ} (hc : c ∈ Ioo 0 2) :
+    pseudoMass hα hr hc ≤ (2 - c) / (c * r) := by
+  have hc_pos : 0 < c := hc.1
+  have hcr_pos : 0 < c * r := mul_pos hc_pos hr
+  have h2c_pos : 0 < (2 : ℝ) / c := by positivity
+  have h_log_le : Real.log (2 / c) ≤ 2 / c - 1 :=
+    Real.log_le_sub_one_of_pos h2c_pos
+  have h_eq : (2 : ℝ) / c - 1 = (2 - c) / c := by field_simp
+  have h_step1 : pseudoMass hα hr hc ≤ Real.log (2 / c) / r :=
+    pseudoMass_le_log_two_div hα hr hc
+  have h_step2 : Real.log (2 / c) / r ≤ (2 - c) / c / r := by
+    apply div_le_div_of_nonneg_right
+    · rw [← h_eq]; exact h_log_le
+    · exact hr.le
+  have h_div : (2 - c) / c / r = (2 - c) / (c * r) := by
+    rw [div_div]
+  linarith [h_step1, h_step2, h_div.symm.le, h_div.le]
+
 /-- **`pseudoMass(c) < log(2/c)/r`** (strict version of
 `pseudoMass_le_log_two_div`): since `pseudoMass(c) > 0` (pseudoMass_pos)
 for `c ∈ Ioo 0 2` and `α ≥ 1`, the denominator `1 + (pm·r)^α > 1`


### PR DESCRIPTION
Sharper bound captures linear vanishing as c → 2-.

Part of #1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)