### PR TITLE
Narrow ambient auxiliary imports

### DIFF
--- a/IsingModel/AmbientFKG.lean
+++ b/IsingModel/AmbientFKG.lean
@@ -1,4 +1,4 @@
-import IsingModel.AmbientLattice
+import IsingModel.AmbientLattice.Exhaustion
 import IsingModel.Inequalities.FKG
 
 /-!

--- a/IsingModel/PeierlsInfinite.lean
+++ b/IsingModel/PeierlsInfinite.lean
@@ -1,5 +1,5 @@
 import IsingModel.Peierls
-import IsingModel.AmbientLattice
+import IsingModel.AmbientLattice.Exhaustion
 
 /-!
 # Peierls argument along an infinite-volume exhaustion

--- a/IsingModel/PseudoMass.lean
+++ b/IsingModel/PseudoMass.lean
@@ -1,4 +1,4 @@
-import IsingModel.AmbientLattice
+import IsingModel.AmbientLattice.TruncatedFunctions
 import IsingModel.BetaDerivative
 import IsingModel.PolyDecay
 import Mathlib.Topology.Order.IntermediateValue

--- a/IsingModel/RandomCurrent.lean
+++ b/IsingModel/RandomCurrent.lean
@@ -2,7 +2,6 @@ import IsingModel.RandomCurrent.Core
 import IsingModel.RandomCurrent.BoundedExpansion
 import IsingModel.RandomCurrent.Switching
 import IsingModel.RandomCurrent.Peeling
-import IsingModel.AmbientLattice
 import Mathlib.Analysis.SpecialFunctions.Exponential
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Finite
 

--- a/IsingModel/RandomCurrent/Core.lean
+++ b/IsingModel/RandomCurrent/Core.lean
@@ -1,4 +1,4 @@
-import IsingModel.AmbientLattice
+import IsingModel.AmbientLattice.Defs
 import Mathlib.Analysis.SpecialFunctions.Exponential
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Finite
 


### PR DESCRIPTION
Part of #1850.

## Summary

- replace broad `IsingModel.AmbientLattice` imports with narrow child imports in small auxiliary modules
- remove a redundant umbrella import from `IsingModel.RandomCurrent`
- keep heavier ambient-sum, complex-analyticity, translation, cubic-exhaustion, and high-temperature modules for follow-up work because they still pull special-case or analytic dependencies

## Verification

- `lake env lean IsingModel/AmbientFKG.lean`
- `lake env lean IsingModel/PeierlsInfinite.lean`
- `lake build IsingModel.RandomCurrent`
- `lake build IsingModel.PseudoMass`
- `git diff --check`
- `rg -n "sorry" IsingModel` (no matches)
- `lake exe GKSTest`
