### PR TITLE
Narrow remaining ambient umbrella imports

### DIFF
--- a/IsingModel/AmbientComplexAnalyticity.lean
+++ b/IsingModel/AmbientComplexAnalyticity.lean
@@ -1,4 +1,3 @@
-import IsingModel.AmbientLattice
 import IsingModel.AmbientLatticeSum
 import IsingModel.ComplexAnalyticity
 

--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -5,7 +5,9 @@ import IsingModel.AmbientLattice.SpecialCases.Legacy
 
 This module is intentionally a thin re-export. The legacy monolithic body lives
 in `IsingModel.AmbientLattice.SpecialCases.Legacy`. Non-analytic free-energy
-special cases live in `IsingModel.AmbientLattice.SpecialCases.FreeEnergy`; new
-narrow APIs should be added in dedicated child modules and re-exported here only
-when they belong to the public ambient special-cases surface.
+special cases live in `IsingModel.AmbientLattice.SpecialCases.FreeEnergy`, and
+lightweight infinite-volume aliases live in
+`IsingModel.AmbientLattice.SpecialCases.InfiniteVolume`. New narrow APIs should
+be added in dedicated child modules and re-exported here only when they belong
+to the public ambient special-cases surface.
 -/

--- a/IsingModel/AmbientLattice/SpecialCases/InfiniteVolume.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/InfiniteVolume.lean
@@ -1,0 +1,70 @@
+import IsingModel.AmbientLattice.TruncatedFunctions
+
+/-!
+# Infinite-volume special-case aliases
+
+This module contains lightweight ambient special-case APIs that depend only on
+the infinite-volume truncated-correlation layer. Keeping them outside the legacy
+special-cases body lets concrete correlation modules use these aliases without
+importing the analytic or cluster-expansion stack.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+omit [DecidableEq V] in
+/-- **Induced subgraph of the empty graph is empty**:
+`inducedGraph (⊥ : SimpleGraph V) Λ = ⊥`.
+
+`inducedGraph = induce = comap` and `SimpleGraph.comap_bot`.
+Useful rewrite when the ambient graph is `⊥` (free-spin limit). -/
+@[simp]
+theorem inducedGraph_bot (Λ : Finset V) :
+    inducedGraph (⊥ : SimpleGraph V) Λ = (⊥ : SimpleGraph (↑Λ : Type _)) :=
+  SimpleGraph.comap_bot _
+
+/-! ## Critical exponents at infinite volume (GJ §17.7 Thm 17.7.1) -/
+
+/-- **η ≥ 0 at infinite volume** (GJ §17.7 Thm 17.7.1, infinite-volume
+lattice version). Explicit alias of `truncated2Infinite_nonneg` matching the
+`eta_nonneg_finite_vol` naming convention. -/
+theorem eta_nonneg_infinite_vol
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
+    0 ≤ truncated2Infinite G Λ p i j :=
+  truncated2Infinite_nonneg G Λ p hf i j
+
+/-- **ζ ≥ 0 at infinite volume** (GJ §17.7 Thm 17.7.1, infinite-volume
+lattice version, at `h = 0`). Explicit alias of
+`truncated4Infinite_nonpos_h_zero`: `U₄^∞ ≤ 0` for pairwise-distinct sites at
+`h = 0`. -/
+theorem zeta_nonneg_infinite_vol
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩)
+    {i j k l : V}
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    truncated4Infinite G Λ ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  truncated4Infinite_nonpos_h_zero G Λ J β hf hij hik hil hjk hjl hkl
+
+/-- **Absence of even bound states, infinite-volume lattice form**
+(Glimm-Jaffe §17.2, pp. 311-313). Infinite-volume version of
+`IsingModel.absence_of_even_bound_states_finite_vol`: `U₄^∞(i,j,k,l) ≤ 0` for
+ferromagnetic `⟨J, 0, β⟩` and pairwise-distinct sites. Explicit alias of
+`truncated4Infinite_nonpos_h_zero`. -/
+theorem absence_of_even_bound_states_infinite_vol
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩)
+    {i j k l : V}
+    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
+    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
+    truncated4Infinite G Λ ⟨J, 0, β⟩ i j k l ≤ 0 :=
+  truncated4Infinite_nonpos_h_zero G Λ J β hf hij hik hil hjk hjl hkl
+
+end Ambient
+end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -1,4 +1,5 @@
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
+import IsingModel.AmbientLattice.SpecialCases.InfiniteVolume
 import IsingModel.AmbientLattice.Analyticity
 
 /-!
@@ -2336,17 +2337,6 @@ theorem correlationAlongExhaustion_high_temp_h_zero_at_singleton_ferromagnetic
         (⟨J, 0, β⟩ : IsingParams ℝ) ({i} : Finset V) n = 0 :=
   correlationAlongExhaustion_high_temp_h_zero_at_singleton G Λ J β i n
 
-omit [DecidableEq V] in
-/-- **Induced subgraph of the empty graph is empty**:
-`inducedGraph (⊥ : SimpleGraph V) Λ = ⊥`.
-
-`inducedGraph = induce = comap` and `SimpleGraph.comap_bot`.
-Useful rewrite when the ambient graph is `⊥` (free-spin limit). -/
-@[simp]
-theorem inducedGraph_bot (Λ : Finset V) :
-    inducedGraph (⊥ : SimpleGraph V) Λ = (⊥ : SimpleGraph (↑Λ : Type _)) :=
-  SimpleGraph.comap_bot _
-
 /-! ## h-symmetry / `|h|`-monotonicity along exhaustion
 
 Specializations of `IsingModel.freeEnergy_neg_h`, `freeEnergy_eq_abs_h`,
@@ -2391,52 +2381,6 @@ theorem partitionFunctionAlongExhaustion_monotone_abs_h
     partitionFunctionAlongExhaustion G Λ (⟨J, h₁, β⟩ : IsingParams ℝ) n
       ≤ partitionFunctionAlongExhaustion G Λ (⟨J, h₂, β⟩ : IsingParams ℝ) n :=
   partitionFunctionΛ_monotone_abs_h G (Λ.volume n) J β hJ hβ hh
-
-/-! ## Critical exponents at ∞-volume (GJ §17.7 Thm 17.7.1)
-
-Explicit ∞-vol named aliases for the critical-exponent bounds
-`η ≥ 0` and `ζ ≥ 0`, matching the finite-volume
-`IsingModel.eta_nonneg_finite_vol` / `zeta_nonneg_finite_vol`
-pattern. Direct pass-throughs of `truncated2Infinite_nonneg` (GKS-II
-at ∞-vol) and `truncated4Infinite_nonpos_h_zero` (Cor 4.3.3 at ∞-vol). -/
-
-/-- **η ≥ 0 at ∞-volume** (GJ §17.7 Thm 17.7.1, ∞-vol lattice version).
-Explicit alias of `truncated2Infinite_nonneg` matching the
-`eta_nonneg_finite_vol` naming convention. -/
-theorem eta_nonneg_infinite_vol
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i j : V) :
-    0 ≤ truncated2Infinite G Λ p i j :=
-  truncated2Infinite_nonneg G Λ p hf i j
-
-/-- **ζ ≥ 0 at ∞-volume** (GJ §17.7 Thm 17.7.1, ∞-vol lattice version,
-at `h = 0`). Explicit alias of `truncated4Infinite_nonpos_h_zero` —
-`U₄^∞ ≤ 0` for pairwise-distinct sites at `h = 0`. -/
-theorem zeta_nonneg_infinite_vol
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩)
-    {i j k l : V}
-    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
-    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
-    truncated4Infinite G Λ ⟨J, 0, β⟩ i j k l ≤ 0 :=
-  truncated4Infinite_nonpos_h_zero G Λ J β hf hij hik hil hjk hjl hkl
-
-/-- **Absence of even bound states — ∞-volume lattice** (Glimm–Jaffe
-§17.2, pp. 311–313). ∞-vol version of
-`IsingModel.absence_of_even_bound_states_finite_vol`:
-`U₄^∞(i,j,k,l) ≤ 0` for ferromagnetic `⟨J, 0, β⟩` and pairwise-distinct
-sites. Explicit alias of `truncated4Infinite_nonpos_h_zero`. -/
-theorem absence_of_even_bound_states_infinite_vol
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩)
-    {i j k l : V}
-    (hij : i ≠ j) (hik : i ≠ k) (hil : i ≠ l)
-    (hjk : j ≠ k) (hjl : j ≠ l) (hkl : k ≠ l) :
-    truncated4Infinite G Λ ⟨J, 0, β⟩ i j k l ≤ 0 :=
-  truncated4Infinite_nonpos_h_zero G Λ J β hf hij hik hil hjk hjl hkl
 
 /-! ## §18.5 cluster-expansion convergence-radius along-exhaustion wraps
 

--- a/IsingModel/ComplexAnalyticity.lean
+++ b/IsingModel/ComplexAnalyticity.lean
@@ -519,7 +519,7 @@ theorem exp_beta_J_sign_mul_sign_eq
     | down =>
       simp only [Spin.sign, Spin.toSign, Int.cast_neg, Int.cast_one,
         neg_mul_neg, one_mul]
-      rw [if_pos (by simp)]; ring
+      rw [if_pos (by simp)]; ring_nf
 
 omit [DecidableEq ι] in
 /-- Product over sites of the external-field exponential factorises as

--- a/IsingModel/Concrete/CubicExhaustion.lean
+++ b/IsingModel/Concrete/CubicExhaustion.lean
@@ -1,4 +1,4 @@
-import IsingModel.AmbientLattice
+import IsingModel.AmbientLattice.Exhaustion
 import IsingModel.Lattice
 import IsingModel.TranslationInvariance
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Inequalities.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Inequalities.lean
@@ -6,6 +6,7 @@ import IsingModel.TranslationInvariance
 import IsingModel.PhaseTransition
 import IsingModel.Inequalities.FKG
 import IsingModel.AmbientFKG
+import IsingModel.AmbientLattice.BetaDerivative
 import IsingModel.Inequalities.HighTemp
 import IsingModel.LatticeExpSum
 import IsingModel.BetaDerivative

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -19,6 +19,7 @@ import IsingModel.ComplexAnalyticity
 import IsingModel.PeierlsInfinite
 import IsingModel.AmbientComplexAnalyticity
 import IsingModel.AmbientFKG
+import IsingModel.AmbientLattice.SpecialCases.Legacy
 
 /-!
 # Concrete translation invariance for the ℤ^d Ising correlation

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -19,6 +19,8 @@ import IsingModel.ComplexAnalyticity
 import IsingModel.PeierlsInfinite
 import IsingModel.AmbientComplexAnalyticity
 import IsingModel.AmbientFKG
+import IsingModel.AmbientLattice.JDerivative
+import IsingModel.AmbientLattice.FieldDerivative
 import IsingModel.AmbientLattice.SpecialCases.Legacy
 
 /-!

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -19,6 +19,7 @@ import IsingModel.ComplexAnalyticity
 import IsingModel.PeierlsInfinite
 import IsingModel.AmbientComplexAnalyticity
 import IsingModel.AmbientFKG
+import IsingModel.AmbientLattice.BetaDerivative
 import IsingModel.AmbientLattice.JDerivative
 import IsingModel.AmbientLattice.FieldDerivative
 import IsingModel.AmbientLattice.SpecialCases.Legacy

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PerStage.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PerStage.lean
@@ -5,6 +5,7 @@ import IsingModel.ComplexAnalyticity
 import IsingModel.PeierlsInfinite
 import IsingModel.AmbientComplexAnalyticity
 import IsingModel.AmbientFKG
+import IsingModel.AmbientLattice.SpecialCases.InfiniteVolume
 
 /-!
 # Per-stage complex analyticity, convergence, and critical-exponent bounds at ℤ^d

--- a/IsingModel/Concrete/LatticeGraphCorrelation/TwoPoint.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/TwoPoint.lean
@@ -11,6 +11,7 @@ import IsingModel.TranslationInvariance
 import IsingModel.PhaseTransition
 import IsingModel.Inequalities.FKG
 import IsingModel.AmbientFKG
+import IsingModel.AmbientLattice.SpecialCases.InfiniteVolume
 
 open scoped symmDiff
 

--- a/IsingModel/Inequalities/HighTemp.lean
+++ b/IsingModel/Inequalities/HighTemp.lean
@@ -1,4 +1,4 @@
-import IsingModel.AmbientLattice
+import IsingModel.AmbientLattice.TruncatedFunctions
 import IsingModel.Inequalities.SimonLieb
 import IsingModel.Concrete.LatticeGraphBED
 

--- a/IsingModel/TranslationInvariance.lean
+++ b/IsingModel/TranslationInvariance.lean
@@ -1,4 +1,3 @@
-import IsingModel.AmbientLattice
 import IsingModel.AmbientLatticeSum
 import IsingModel.Hamiltonian
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,8 @@ View* (2nd ed., 1987).
 > `IsingModel.AmbientLattice.SpecialCases.Legacy`. New narrow APIs should
 > prefer dedicated child modules such as
 > `IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay` and
-> `IsingModel.AmbientLattice.SpecialCases.FreeEnergy` for faster targeted
+> `IsingModel.AmbientLattice.SpecialCases.FreeEnergy` /
+> `IsingModel.AmbientLattice.SpecialCases.InfiniteVolume` for faster targeted
 > checks.
 
 All theorems are formally proved with **zero `sorry`**.


### PR DESCRIPTION
Part of #1850

This PR finishes the direct broad ambient-umbrella import cleanup by removing every remaining `import IsingModel.AmbientLattice` from `IsingModel/` implementation modules, while keeping downstream concrete correlation modules on explicit narrow imports.

Changes:
- `TranslationInvariance` now relies on `AmbientLatticeSum` directly without the broad umbrella.
- `AmbientComplexAnalyticity` now relies on `AmbientLatticeSum` directly without the broad umbrella.
- `Concrete/CubicExhaustion` now imports `AmbientLattice.Exhaustion` instead of the broad umbrella.
- `Inequalities/HighTemp` now imports `AmbientLattice.TruncatedFunctions` instead of the broad umbrella.
- Added `IsingModel.AmbientLattice.SpecialCases.InfiniteVolume` for lightweight aliases such as `inducedGraph_bot`, `eta_nonneg_infinite_vol`, `zeta_nonneg_infinite_vol`, and `absence_of_even_bound_states_infinite_vol`.
- Concrete correlation child modules now import lightweight ambient children explicitly instead of relying on an indirect broad umbrella path.
- Concrete legacy now imports ambient beta/J/field derivative modules explicitly for the APIs it calls.
- `ComplexAnalyticity` replaces one `ring` call with Lean suggested `ring_nf` to remove a build-log info message.

Verification:
- `lake env lean IsingModel/TranslationInvariance.lean`
- `lake env lean IsingModel/AmbientComplexAnalyticity.lean`
- `lake build IsingModel.Concrete.CubicExhaustion`
- `lake build IsingModel.Inequalities.HighTemp`
- `lake build IsingModel.Concrete.LatticeGraphCorrelation.Inequalities`
- `lake build IsingModel.AmbientLattice.BetaDerivative IsingModel.AmbientLattice.JDerivative IsingModel.AmbientLattice.FieldDerivative`
- `lake build IsingModel.AmbientLattice.SpecialCases.InfiniteVolume IsingModel.Concrete.LatticeGraphCorrelation.PerStage IsingModel.Concrete.LatticeGraphCorrelation.TwoPoint IsingModel.Concrete.LatticeGraphCorrelation.Inequalities IsingModel.TranslationInvariance IsingModel.AmbientComplexAnalyticity IsingModel.Concrete.CubicExhaustion IsingModel.Inequalities.HighTemp`
- `git diff --check`
- `rg -n "sorry" IsingModel` (no matches)
- `rg -n "^import IsingModel\\.AmbientLattice$" IsingModel` (no matches)
- `lake exe GKSTest`

Cross-check:
- `codex exec` review found one explicit-import weakness in concrete legacy beta derivative usage; fixed by `ddcea9e`.