### PR TITLE
Split concrete pointwise regularity wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -7,6 +7,7 @@ This module is intentionally a thin re-export. The legacy monolithic
 implementation lives in `IsingModel.Concrete.LatticeGraphCorrelation.Legacy`;
 new narrow APIs should be added in dedicated child modules and re-exported
 here only when they belong to the public concrete correlation surface. For
-concrete derivative wrappers, import
-`IsingModel.Concrete.LatticeGraphCorrelation.Regularity` directly.
+concrete derivative and pointwise regularity wrappers, import
+`IsingModel.Concrete.LatticeGraphCorrelation.Regularity` or
+`IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity` directly.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -7,7 +7,9 @@ This module is intentionally a thin re-export. The legacy monolithic
 implementation lives in `IsingModel.Concrete.LatticeGraphCorrelation.Legacy`;
 new narrow APIs should be added in dedicated child modules and re-exported
 here only when they belong to the public concrete correlation surface. For
-concrete derivative and pointwise regularity wrappers, import
-`IsingModel.Concrete.LatticeGraphCorrelation.Regularity` or
+concrete `HasDerivAt` wrappers, import
+`IsingModel.Concrete.LatticeGraphCorrelation.Regularity` directly. For
+concrete J-direction `correlationAlongExhaustion` `ContinuousAt` /
+`DifferentiableAt` wrappers, import
 `IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity` directly.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -13,6 +13,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.UniformMag
 import IsingModel.Concrete.LatticeGraphCorrelation.Base
 import IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay
 import IsingModel.Concrete.LatticeGraphCorrelation.Regularity
+import IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity
 import IsingModel.TranslationInvariance
 import IsingModel.PhaseTransition
 import IsingModel.Inequalities.FKG
@@ -14687,33 +14688,6 @@ theorem magnetizationAlongExhaustion_latticeGraph_differentiable_beta
         Λ (⟨J, h, β'⟩ : IsingParams ℝ) i n) :=
   Ambient.magnetizationAlongExhaustion_differentiable_beta
     (IsingModel.latticeGraph d) Λ J h i n
-
-/-! ### ℤ^d along-ex pointwise (ContinuousAt / DifferentiableAt)
-wrappers, lifting the ambient general-G versions from PR #1635 -/
-
-/-- **ℤ^d along-ex: `correlationAlongExhaustion` ContinuousAt J**. -/
-theorem correlationAlongExhaustion_latticeGraph_continuousAt_J
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
-    ContinuousAt (fun J' =>
-      Ambient.correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) A n) J :=
-  Ambient.correlationAlongExhaustion_continuousAt_J_gen
-    (IsingModel.latticeGraph d) Λ J h β A n
-
-/-- **ℤ^d along-ex: `correlationAlongExhaustion` DifferentiableAt J**. -/
-theorem correlationAlongExhaustion_latticeGraph_differentiableAt_J
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
-    DifferentiableAt ℝ (fun J' =>
-      Ambient.correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) A n) J :=
-  Ambient.correlationAlongExhaustion_differentiableAt_J_gen
-    (IsingModel.latticeGraph d) Λ J h β A n
 
 /-- **ℤ^d along-ex: `magnetizationAlongExhaustion` ContinuousAt β** (general h). -/
 theorem magnetizationAlongExhaustion_latticeGraph_continuousAt_beta

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PointwiseRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PointwiseRegularity.lean
@@ -1,0 +1,49 @@
+import IsingModel.Lattice
+import IsingModel.AmbientLattice.JDerivative
+
+/-!
+# Concrete pointwise regularity wrappers for the ℤ^d Ising correlation
+
+This module contains concrete `latticeGraph` specializations of ambient
+`ContinuousAt` and `DifferentiableAt` APIs for J-direction along-exhaustion
+correlation. It is split out of the legacy concrete correlation module so
+future pointwise regularity work can build a narrower child path.
+-/
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-! ### ℤ^d along-ex pointwise (ContinuousAt / DifferentiableAt)
+wrappers, lifting the ambient general-G versions from PR #1635 -/
+
+/-- **ℤ^d along-ex: `correlationAlongExhaustion` ContinuousAt J**. -/
+theorem correlationAlongExhaustion_latticeGraph_continuousAt_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
+    ContinuousAt (fun J' =>
+      Ambient.correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) A n) J :=
+  Ambient.correlationAlongExhaustion_continuousAt_J_gen
+    (IsingModel.latticeGraph d) Λ J h β A n
+
+/-- **ℤ^d along-ex: `correlationAlongExhaustion` DifferentiableAt J**. -/
+theorem correlationAlongExhaustion_latticeGraph_differentiableAt_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
+    DifferentiableAt ℝ (fun J' =>
+      Ambient.correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) A n) J :=
+  Ambient.correlationAlongExhaustion_differentiableAt_J_gen
+    (IsingModel.latticeGraph d) Λ J h β A n
+
+
+
+end Ambient
+
+end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,11 @@ View* (2nd ed., 1987).
 > `IsingModel.Concrete.LatticeGraphCorrelation.Legacy` and
 > `IsingModel.AmbientLattice.SpecialCases.Legacy`. New narrow APIs should
 > prefer dedicated child modules such as
-> `IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay` and
-> `IsingModel.Concrete.LatticeGraphCorrelation.Regularity` /
-> `IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity`, plus
+> `IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay`,
+> `IsingModel.Concrete.LatticeGraphCorrelation.Regularity` for concrete
+> `HasDerivAt` wrappers, and
+> `IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity` for
+> concrete J-direction `correlationAlongExhaustion` pointwise wrappers, plus
 > `IsingModel.AmbientLattice.SpecialCases.FreeEnergy` /
 > `IsingModel.AmbientLattice.SpecialCases.InfiniteVolume` for faster targeted
 > checks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,8 @@ View* (2nd ed., 1987).
 > `IsingModel.AmbientLattice.SpecialCases.Legacy`. New narrow APIs should
 > prefer dedicated child modules such as
 > `IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay` and
-> `IsingModel.Concrete.LatticeGraphCorrelation.Regularity`, plus
+> `IsingModel.Concrete.LatticeGraphCorrelation.Regularity` /
+> `IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity`, plus
 > `IsingModel.AmbientLattice.SpecialCases.FreeEnergy` /
 > `IsingModel.AmbientLattice.SpecialCases.InfiniteVolume` for faster targeted
 > checks.


### PR DESCRIPTION
Summary: Split the concrete J-direction correlationAlongExhaustion ContinuousAt/DifferentiableAt wrappers into IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity while preserving the public theorem names through the concrete umbrella. Clarified import notes so Regularity is scoped to concrete HasDerivAt wrappers and PointwiseRegularity is scoped to J-direction pointwise wrappers. Verification: lake build IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity; direct lake env lean import/#check for both moved public names; git diff --check; added-diff Japanese check; sorry check. Pre-merge cross-check: codex exec found the import note over-scoped; fixed in 109cbca.