### PR TITLE
Split concrete magnetization pointwise wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -11,5 +11,9 @@ concrete `HasDerivAt` wrappers, import
 `IsingModel.Concrete.LatticeGraphCorrelation.Regularity` directly. For
 concrete J-direction `correlationAlongExhaustion` `ContinuousAt` /
 `DifferentiableAt` wrappers, import
-`IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity` directly.
+`IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity` directly. For
+concrete per-parameter `magnetizationAlongExhaustion` pointwise wrappers,
+import
+`IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity`
+directly.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -14,6 +14,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.Base
 import IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay
 import IsingModel.Concrete.LatticeGraphCorrelation.Regularity
 import IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity
+import IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity
 import IsingModel.TranslationInvariance
 import IsingModel.PhaseTransition
 import IsingModel.Inequalities.FKG
@@ -14688,78 +14689,6 @@ theorem magnetizationAlongExhaustion_latticeGraph_differentiable_beta
         Λ (⟨J, h, β'⟩ : IsingParams ℝ) i n) :=
   Ambient.magnetizationAlongExhaustion_differentiable_beta
     (IsingModel.latticeGraph d) Λ J h i n
-
-/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` ContinuousAt β** (general h). -/
-theorem magnetizationAlongExhaustion_latticeGraph_continuousAt_beta
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    ContinuousAt (fun β' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
-  Ambient.magnetizationAlongExhaustion_continuousAt_beta
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` DifferentiableAt β** (general h). -/
-theorem magnetizationAlongExhaustion_latticeGraph_differentiableAt_beta
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    DifferentiableAt ℝ (fun β' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
-  Ambient.magnetizationAlongExhaustion_differentiableAt_beta
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` ContinuousAt h**. -/
-theorem magnetizationAlongExhaustion_latticeGraph_continuousAt_field
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    ContinuousAt (fun h' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
-  Ambient.magnetizationAlongExhaustion_continuousAt_field
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` DifferentiableAt h**. -/
-theorem magnetizationAlongExhaustion_latticeGraph_differentiableAt_field
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    DifferentiableAt ℝ (fun h' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
-  Ambient.magnetizationAlongExhaustion_differentiableAt_field
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` ContinuousAt J**. -/
-theorem magnetizationAlongExhaustion_latticeGraph_continuousAt_J
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    ContinuousAt (fun J' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
-  Ambient.magnetizationAlongExhaustion_continuousAt_J
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` DifferentiableAt J**. -/
-theorem magnetizationAlongExhaustion_latticeGraph_differentiableAt_J
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    DifferentiableAt ℝ (fun J' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
-  Ambient.magnetizationAlongExhaustion_differentiableAt_J
-    (IsingModel.latticeGraph d) Λ J h β i n
 
 /-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` ContinuousAt β at general h**. -/
 theorem susceptibilityAlongExhaustion_latticeGraph_continuousAt_beta_general_h

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationPointwiseRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationPointwiseRegularity.lean
@@ -1,0 +1,94 @@
+import IsingModel.Lattice
+import IsingModel.AmbientLattice.BetaDerivative
+
+/-!
+# Concrete pointwise regularity wrappers for lattice magnetization
+
+This module contains concrete `latticeGraph` specializations of ambient
+`ContinuousAt` and `DifferentiableAt` APIs for per-parameter
+`magnetizationAlongExhaustion` regularity. It is split out of the legacy
+concrete correlation module so future magnetization pointwise work can build a
+narrower child path.
+-/
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-! ### ℤ^d along-ex pointwise magnetization wrappers -/
+
+/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` ContinuousAt β** (general h). -/
+theorem magnetizationAlongExhaustion_latticeGraph_continuousAt_beta
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    ContinuousAt (fun β' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
+  (Ambient.magnetizationAlongExhaustion_continuous_beta_general_h_gen
+    (IsingModel.latticeGraph d) Λ J h i n).continuousAt
+
+/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` DifferentiableAt β** (general h). -/
+theorem magnetizationAlongExhaustion_latticeGraph_differentiableAt_beta
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    DifferentiableAt ℝ (fun β' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
+  (Ambient.magnetizationAlongExhaustion_differentiable_beta_general_h_gen
+    (IsingModel.latticeGraph d) Λ J h i n).differentiableAt
+
+/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` ContinuousAt h**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_continuousAt_field
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    ContinuousAt (fun h' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
+  (Ambient.magnetizationAlongExhaustion_continuous_field_gen
+    (IsingModel.latticeGraph d) Λ J β i n).continuousAt
+
+/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` DifferentiableAt h**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_differentiableAt_field
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    DifferentiableAt ℝ (fun h' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
+  (Ambient.magnetizationAlongExhaustion_differentiable_field_gen
+    (IsingModel.latticeGraph d) Λ J β i n).differentiableAt
+
+/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` ContinuousAt J**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_continuousAt_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    ContinuousAt (fun J' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
+  (Ambient.magnetizationAlongExhaustion_continuous_J_gen
+    (IsingModel.latticeGraph d) Λ h β i n).continuousAt
+
+/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` DifferentiableAt J**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_differentiableAt_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    DifferentiableAt ℝ (fun J' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
+  (Ambient.magnetizationAlongExhaustion_differentiable_J_gen
+    (IsingModel.latticeGraph d) Λ h β i n).differentiableAt
+
+end Ambient
+end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,10 @@ View* (2nd ed., 1987).
 > `IsingModel.Concrete.LatticeGraphCorrelation.Regularity` for concrete
 > `HasDerivAt` wrappers, and
 > `IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity` for
-> concrete J-direction `correlationAlongExhaustion` pointwise wrappers, plus
+> concrete J-direction `correlationAlongExhaustion` pointwise wrappers,
+> `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity`
+> for concrete per-parameter `magnetizationAlongExhaustion` pointwise wrappers,
+> plus
 > `IsingModel.AmbientLattice.SpecialCases.FreeEnergy` /
 > `IsingModel.AmbientLattice.SpecialCases.InfiniteVolume` for faster targeted
 > checks.


### PR DESCRIPTION
Summary: Split concrete per-parameter magnetizationAlongExhaustion ContinuousAt/DifferentiableAt wrappers into IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity while preserving public theorem names through the concrete umbrella. This continues the build-lightening refactor by giving magnetization pointwise work a fast child target instead of requiring the 15k-line concrete legacy module. Verification: lake build IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity; direct lake env lean import/#check for all six moved public names; git diff --cached --check; added-diff Japanese check; sorry check. Legacy build note: lake build IsingModel.Concrete.LatticeGraphCorrelation.Legacy was stopped after more than 6 minutes with no output, confirming the remaining monolith is still the build-latency target.