### PR TITLE
Split concrete susceptibility pointwise wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -7,7 +7,9 @@ This module is intentionally a thin re-export. The legacy monolithic body lives
 in `IsingModel.AmbientLattice.SpecialCases.Legacy`. Non-analytic free-energy
 special cases live in `IsingModel.AmbientLattice.SpecialCases.FreeEnergy`, and
 lightweight infinite-volume aliases live in
-`IsingModel.AmbientLattice.SpecialCases.InfiniteVolume`. New narrow APIs should
-be added in dedicated child modules and re-exported here only when they belong
-to the public ambient special-cases surface.
+`IsingModel.AmbientLattice.SpecialCases.InfiniteVolume`. General-graph
+`susceptibilityAlongExhaustion` pointwise regularity wrappers live in
+`IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity`.
+New narrow APIs should be added in dedicated child modules and re-exported here
+only when they belong to the public ambient special-cases surface.
 -/

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.InfiniteVolume
+import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity
 import IsingModel.AmbientLattice.Analyticity
 
 /-!
@@ -5364,102 +5365,6 @@ theorem magnetizationAlongExhaustion_differentiable_beta
   · simp only [hi, dif_neg, not_false_iff]
     exact differentiable_const _
 
-/-! ### susceptibility regularity along-ex wraps (general G).
-The `_gen` suffix distinguishes these general-graph versions from
-the ℤ^d-specialized variants in
-`Concrete/LatticeGraphCorrelation/Inequalities.lean` which share
-the unsuffixed names with `(IsingModel.latticeGraph d)` baked in. -/
-
-/-- **Along-ex: susceptibility Continuous in `β`** (general G, general h). -/
-theorem susceptibilityAlongExhaustion_continuous_beta_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h : ℝ) (i : V) (n : ℕ) :
-    Continuous (fun β' =>
-      susceptibilityAlongExhaustion G Λ
-        (⟨J, h, β'⟩ : IsingParams ℝ) i n) := by
-  unfold susceptibilityAlongExhaustion
-  by_cases hi : i ∈ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact susceptibilityΛ_continuous_beta G (Λ.volume n) J h _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact continuous_const
-
-/-- **Along-ex: susceptibility Differentiable in `β`** (general G, general h). -/
-theorem susceptibilityAlongExhaustion_differentiable_beta_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h : ℝ) (i : V) (n : ℕ) :
-    Differentiable ℝ (fun β' =>
-      susceptibilityAlongExhaustion G Λ
-        (⟨J, h, β'⟩ : IsingParams ℝ) i n) := by
-  unfold susceptibilityAlongExhaustion
-  by_cases hi : i ∈ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact susceptibilityΛ_differentiable_beta G (Λ.volume n) J h _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact differentiable_const _
-
-/-- **Along-ex: susceptibility Continuous in `h`** (general G). -/
-theorem susceptibilityAlongExhaustion_continuous_field_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (i : V) (n : ℕ) :
-    Continuous (fun h' =>
-      susceptibilityAlongExhaustion G Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i n) := by
-  unfold susceptibilityAlongExhaustion
-  by_cases hi : i ∈ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact susceptibilityΛ_continuous_field G (Λ.volume n) J β _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact continuous_const
-
-/-- **Along-ex: susceptibility Differentiable in `h`** (general G). -/
-theorem susceptibilityAlongExhaustion_differentiable_field_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (i : V) (n : ℕ) :
-    Differentiable ℝ (fun h' =>
-      susceptibilityAlongExhaustion G Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i n) := by
-  unfold susceptibilityAlongExhaustion
-  by_cases hi : i ∈ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact susceptibilityΛ_differentiable_field G (Λ.volume n) J β _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact differentiable_const _
-
-/-- **Along-ex: susceptibility Continuous in `J`** (general G). -/
-theorem susceptibilityAlongExhaustion_continuous_J_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (h β : ℝ) (i : V) (n : ℕ) :
-    Continuous (fun J' =>
-      susceptibilityAlongExhaustion G Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i n) := by
-  unfold susceptibilityAlongExhaustion
-  by_cases hi : i ∈ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact susceptibilityΛ_continuous_J G (Λ.volume n) h β _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact continuous_const
-
-/-- **Along-ex: susceptibility Differentiable in `J`** (general G). -/
-theorem susceptibilityAlongExhaustion_differentiable_J_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (h β : ℝ) (i : V) (n : ℕ) :
-    Differentiable ℝ (fun J' =>
-      susceptibilityAlongExhaustion G Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i n) := by
-  unfold susceptibilityAlongExhaustion
-  by_cases hi : i ∈ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact susceptibilityΛ_differentiable_J G (Λ.volume n) h β _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact differentiable_const _
-
 /-! ### ContinuousAt / DifferentiableAt along-ex wrappers -/
 
 /-- **Along-ex: magnetization ContinuousAt β** (general h). -/
@@ -5521,66 +5426,6 @@ theorem magnetizationAlongExhaustion_differentiableAt_J
       (fun J' => magnetizationAlongExhaustion G Λ
           (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
   (magnetizationAlongExhaustion_differentiable_J G Λ h β i n).differentiableAt
-
-/-- **Along-ex: susceptibility ContinuousAt β** (general G, general h). -/
-theorem susceptibilityAlongExhaustion_continuousAt_beta_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    ContinuousAt
-      (fun β' => susceptibilityAlongExhaustion G Λ
-          (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
-  (susceptibilityAlongExhaustion_continuous_beta_gen G Λ J h i n).continuousAt
-
-/-- **Along-ex: susceptibility DifferentiableAt β** (general G, general h). -/
-theorem susceptibilityAlongExhaustion_differentiableAt_beta_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    DifferentiableAt ℝ
-      (fun β' => susceptibilityAlongExhaustion G Λ
-          (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
-  (susceptibilityAlongExhaustion_differentiable_beta_gen G Λ J h i n).differentiableAt
-
-/-- **Along-ex: susceptibility ContinuousAt h** (general G). -/
-theorem susceptibilityAlongExhaustion_continuousAt_field_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    ContinuousAt
-      (fun h' => susceptibilityAlongExhaustion G Λ
-          (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
-  (susceptibilityAlongExhaustion_continuous_field_gen G Λ J β i n).continuousAt
-
-/-- **Along-ex: susceptibility DifferentiableAt h** (general G). -/
-theorem susceptibilityAlongExhaustion_differentiableAt_field_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    DifferentiableAt ℝ
-      (fun h' => susceptibilityAlongExhaustion G Λ
-          (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
-  (susceptibilityAlongExhaustion_differentiable_field_gen G Λ J β i n).differentiableAt
-
-/-- **Along-ex: susceptibility ContinuousAt J** (general G). -/
-theorem susceptibilityAlongExhaustion_continuousAt_J_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    ContinuousAt
-      (fun J' => susceptibilityAlongExhaustion G Λ
-          (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
-  (susceptibilityAlongExhaustion_continuous_J_gen G Λ h β i n).continuousAt
-
-/-- **Along-ex: susceptibility DifferentiableAt J** (general G). -/
-theorem susceptibilityAlongExhaustion_differentiableAt_J_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    DifferentiableAt ℝ
-      (fun J' => susceptibilityAlongExhaustion G Λ
-          (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
-  (susceptibilityAlongExhaustion_differentiable_J_gen G Λ h β i n).differentiableAt
 
 /-! ### magnetization parameter-direction convergent (β/h/J → ∞)
 along-ex wraps -/

--- a/IsingModel/AmbientLattice/SpecialCases/SusceptibilityPointwiseRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/SusceptibilityPointwiseRegularity.lean
@@ -1,0 +1,171 @@
+import IsingModel.AmbientLattice.MagnetizationAlongExhaustion
+
+/-!
+# Ambient susceptibility pointwise regularity wrappers
+
+This module contains general-graph `Continuous`, `Differentiable`,
+`ContinuousAt`, and `DifferentiableAt` APIs for per-parameter
+`susceptibilityAlongExhaustion` regularity. It is split out of the legacy
+ambient special-cases module so concrete susceptibility pointwise wrappers can
+depend on a narrower child path.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### Along-exhaustion susceptibility regularity wrappers -/
+
+/-- **Along-ex: susceptibility Continuous in `β`** (general G, general h). -/
+theorem susceptibilityAlongExhaustion_continuous_beta_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (i : V) (n : ℕ) :
+    Continuous (fun β' =>
+      susceptibilityAlongExhaustion G Λ
+        (⟨J, h, β'⟩ : IsingParams ℝ) i n) := by
+  unfold susceptibilityAlongExhaustion
+  by_cases hi : i ∈ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact susceptibilityΛ_continuous_beta G (Λ.volume n) J h _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact continuous_const
+
+/-- **Along-ex: susceptibility Differentiable in `β`** (general G, general h). -/
+theorem susceptibilityAlongExhaustion_differentiable_beta_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (i : V) (n : ℕ) :
+    Differentiable ℝ (fun β' =>
+      susceptibilityAlongExhaustion G Λ
+        (⟨J, h, β'⟩ : IsingParams ℝ) i n) := by
+  unfold susceptibilityAlongExhaustion
+  by_cases hi : i ∈ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact susceptibilityΛ_differentiable_beta G (Λ.volume n) J h _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+/-- **Along-ex: susceptibility Continuous in `h`** (general G). -/
+theorem susceptibilityAlongExhaustion_continuous_field_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i : V) (n : ℕ) :
+    Continuous (fun h' =>
+      susceptibilityAlongExhaustion G Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i n) := by
+  unfold susceptibilityAlongExhaustion
+  by_cases hi : i ∈ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact susceptibilityΛ_continuous_field G (Λ.volume n) J β _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact continuous_const
+
+/-- **Along-ex: susceptibility Differentiable in `h`** (general G). -/
+theorem susceptibilityAlongExhaustion_differentiable_field_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i : V) (n : ℕ) :
+    Differentiable ℝ (fun h' =>
+      susceptibilityAlongExhaustion G Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i n) := by
+  unfold susceptibilityAlongExhaustion
+  by_cases hi : i ∈ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact susceptibilityΛ_differentiable_field G (Λ.volume n) J β _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+/-- **Along-ex: susceptibility Continuous in `J`** (general G). -/
+theorem susceptibilityAlongExhaustion_continuous_J_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (h β : ℝ) (i : V) (n : ℕ) :
+    Continuous (fun J' =>
+      susceptibilityAlongExhaustion G Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i n) := by
+  unfold susceptibilityAlongExhaustion
+  by_cases hi : i ∈ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact susceptibilityΛ_continuous_J G (Λ.volume n) h β _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact continuous_const
+
+/-- **Along-ex: susceptibility Differentiable in `J`** (general G). -/
+theorem susceptibilityAlongExhaustion_differentiable_J_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (h β : ℝ) (i : V) (n : ℕ) :
+    Differentiable ℝ (fun J' =>
+      susceptibilityAlongExhaustion G Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i n) := by
+  unfold susceptibilityAlongExhaustion
+  by_cases hi : i ∈ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact susceptibilityΛ_differentiable_J G (Λ.volume n) h β _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+/-- **Along-ex: susceptibility ContinuousAt β** (general G, general h). -/
+theorem susceptibilityAlongExhaustion_continuousAt_beta_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    ContinuousAt
+      (fun β' => susceptibilityAlongExhaustion G Λ
+          (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
+  (susceptibilityAlongExhaustion_continuous_beta_gen G Λ J h i n).continuousAt
+
+/-- **Along-ex: susceptibility DifferentiableAt β** (general G, general h). -/
+theorem susceptibilityAlongExhaustion_differentiableAt_beta_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    DifferentiableAt ℝ
+      (fun β' => susceptibilityAlongExhaustion G Λ
+          (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
+  (susceptibilityAlongExhaustion_differentiable_beta_gen G Λ J h i n).differentiableAt
+
+/-- **Along-ex: susceptibility ContinuousAt h** (general G). -/
+theorem susceptibilityAlongExhaustion_continuousAt_field_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    ContinuousAt
+      (fun h' => susceptibilityAlongExhaustion G Λ
+          (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
+  (susceptibilityAlongExhaustion_continuous_field_gen G Λ J β i n).continuousAt
+
+/-- **Along-ex: susceptibility DifferentiableAt h** (general G). -/
+theorem susceptibilityAlongExhaustion_differentiableAt_field_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    DifferentiableAt ℝ
+      (fun h' => susceptibilityAlongExhaustion G Λ
+          (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
+  (susceptibilityAlongExhaustion_differentiable_field_gen G Λ J β i n).differentiableAt
+
+/-- **Along-ex: susceptibility ContinuousAt J** (general G). -/
+theorem susceptibilityAlongExhaustion_continuousAt_J_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    ContinuousAt
+      (fun J' => susceptibilityAlongExhaustion G Λ
+          (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
+  (susceptibilityAlongExhaustion_continuous_J_gen G Λ h β i n).continuousAt
+
+/-- **Along-ex: susceptibility DifferentiableAt J** (general G). -/
+theorem susceptibilityAlongExhaustion_differentiableAt_J_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    DifferentiableAt ℝ
+      (fun J' => susceptibilityAlongExhaustion G Λ
+          (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
+  (susceptibilityAlongExhaustion_differentiable_J_gen G Λ h β i n).differentiableAt
+
+end Ambient
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -15,5 +15,8 @@ concrete J-direction `correlationAlongExhaustion` `ContinuousAt` /
 concrete per-parameter `magnetizationAlongExhaustion` pointwise wrappers,
 import
 `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity`
+directly. For concrete per-parameter `susceptibilityAlongExhaustion`
+pointwise wrappers, import
+`IsingModel.Concrete.LatticeGraphCorrelation.SusceptibilityPointwiseRegularity`
 directly.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -15,6 +15,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay
 import IsingModel.Concrete.LatticeGraphCorrelation.Regularity
 import IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity
 import IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity
+import IsingModel.Concrete.LatticeGraphCorrelation.SusceptibilityPointwiseRegularity
 import IsingModel.TranslationInvariance
 import IsingModel.PhaseTransition
 import IsingModel.Inequalities.FKG
@@ -14689,78 +14690,6 @@ theorem magnetizationAlongExhaustion_latticeGraph_differentiable_beta
         Λ (⟨J, h, β'⟩ : IsingParams ℝ) i n) :=
   Ambient.magnetizationAlongExhaustion_differentiable_beta
     (IsingModel.latticeGraph d) Λ J h i n
-
-/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` ContinuousAt β at general h**. -/
-theorem susceptibilityAlongExhaustion_latticeGraph_continuousAt_beta_general_h
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    ContinuousAt (fun β' =>
-      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
-  Ambient.susceptibilityAlongExhaustion_continuousAt_beta_gen
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` DifferentiableAt β at general h**. -/
-theorem susceptibilityAlongExhaustion_latticeGraph_differentiableAt_beta_general_h
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    DifferentiableAt ℝ (fun β' =>
-      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
-  Ambient.susceptibilityAlongExhaustion_differentiableAt_beta_gen
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` ContinuousAt h**. -/
-theorem susceptibilityAlongExhaustion_latticeGraph_continuousAt_field
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    ContinuousAt (fun h' =>
-      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
-  Ambient.susceptibilityAlongExhaustion_continuousAt_field_gen
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` DifferentiableAt h**. -/
-theorem susceptibilityAlongExhaustion_latticeGraph_differentiableAt_field
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    DifferentiableAt ℝ (fun h' =>
-      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
-  Ambient.susceptibilityAlongExhaustion_differentiableAt_field_gen
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` ContinuousAt J**. -/
-theorem susceptibilityAlongExhaustion_latticeGraph_continuousAt_J
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    ContinuousAt (fun J' =>
-      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
-  Ambient.susceptibilityAlongExhaustion_continuousAt_J_gen
-    (IsingModel.latticeGraph d) Λ J h β i n
-
-/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` DifferentiableAt J**. -/
-theorem susceptibilityAlongExhaustion_latticeGraph_differentiableAt_J
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    DifferentiableAt ℝ (fun J' =>
-      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
-  Ambient.susceptibilityAlongExhaustion_differentiableAt_J_gen
-    (IsingModel.latticeGraph d) Λ J h β i n
 
 /-! ### ℤ^d along-ex `partitionFunctionAlongExhaustion` /
 `freeEnergyAlongExhaustion` ContinuousAt / DifferentiableAt wrappers

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularity.lean
@@ -1,0 +1,94 @@
+import IsingModel.Lattice
+import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity
+
+/-!
+# Concrete pointwise regularity wrappers for lattice susceptibility
+
+This module contains concrete `latticeGraph` specializations of ambient
+`ContinuousAt` and `DifferentiableAt` APIs for per-parameter
+`susceptibilityAlongExhaustion` regularity. It is split out of the legacy
+concrete correlation module so future susceptibility pointwise work can build a
+narrower child path.
+-/
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-! ### ℤ^d along-ex pointwise susceptibility wrappers -/
+
+/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` ContinuousAt β at general h**. -/
+theorem susceptibilityAlongExhaustion_latticeGraph_continuousAt_beta_general_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    ContinuousAt (fun β' =>
+      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
+  Ambient.susceptibilityAlongExhaustion_continuousAt_beta_gen
+    (IsingModel.latticeGraph d) Λ J h β i n
+
+/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` DifferentiableAt β at general h**. -/
+theorem susceptibilityAlongExhaustion_latticeGraph_differentiableAt_beta_general_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    DifferentiableAt ℝ (fun β' =>
+      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
+  Ambient.susceptibilityAlongExhaustion_differentiableAt_beta_gen
+    (IsingModel.latticeGraph d) Λ J h β i n
+
+/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` ContinuousAt h**. -/
+theorem susceptibilityAlongExhaustion_latticeGraph_continuousAt_field
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    ContinuousAt (fun h' =>
+      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
+  Ambient.susceptibilityAlongExhaustion_continuousAt_field_gen
+    (IsingModel.latticeGraph d) Λ J h β i n
+
+/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` DifferentiableAt h**. -/
+theorem susceptibilityAlongExhaustion_latticeGraph_differentiableAt_field
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    DifferentiableAt ℝ (fun h' =>
+      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
+  Ambient.susceptibilityAlongExhaustion_differentiableAt_field_gen
+    (IsingModel.latticeGraph d) Λ J h β i n
+
+/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` ContinuousAt J**. -/
+theorem susceptibilityAlongExhaustion_latticeGraph_continuousAt_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    ContinuousAt (fun J' =>
+      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
+  Ambient.susceptibilityAlongExhaustion_continuousAt_J_gen
+    (IsingModel.latticeGraph d) Λ J h β i n
+
+/-- **ℤ^d along-ex: `susceptibilityAlongExhaustion` DifferentiableAt J**. -/
+theorem susceptibilityAlongExhaustion_latticeGraph_differentiableAt_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    DifferentiableAt ℝ (fun J' =>
+      Ambient.susceptibilityAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
+  Ambient.susceptibilityAlongExhaustion_differentiableAt_J_gen
+    (IsingModel.latticeGraph d) Λ J h β i n
+
+end Ambient
+end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,10 +32,13 @@ View* (2nd ed., 1987).
 > concrete J-direction `correlationAlongExhaustion` pointwise wrappers,
 > `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity`
 > for concrete per-parameter `magnetizationAlongExhaustion` pointwise wrappers,
+> `IsingModel.Concrete.LatticeGraphCorrelation.SusceptibilityPointwiseRegularity`
+> for concrete per-parameter `susceptibilityAlongExhaustion` pointwise wrappers,
 > plus
 > `IsingModel.AmbientLattice.SpecialCases.FreeEnergy` /
-> `IsingModel.AmbientLattice.SpecialCases.InfiniteVolume` for faster targeted
-> checks.
+> `IsingModel.AmbientLattice.SpecialCases.InfiniteVolume`, and
+> `IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity`
+> for faster targeted checks.
 
 All theorems are formally proved with **zero `sorry`**.
 Pre-existing axioms (four items) cover Lebowitz-type inequalities


### PR DESCRIPTION
Summary: Split susceptibility pointwise regularity wrappers out of the legacy modules. Added IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity for the general-G susceptibilityAlongExhaustion Continuous/Differentiable and ContinuousAt/DifferentiableAt wrappers, then added IsingModel.Concrete.LatticeGraphCorrelation.SusceptibilityPointwiseRegularity for the six concrete latticeGraph ContinuousAt/DifferentiableAt wrappers. This keeps the public names available through the existing umbrellas while giving future susceptibility pointwise work fast direct child targets. Verification: lake build IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity; lake build IsingModel.Concrete.LatticeGraphCorrelation.SusceptibilityPointwiseRegularity; direct lake env lean import/#check for the moved ambient and concrete public names; git diff --cached --check; added-diff Japanese check; sorry check.