### PR TITLE
Split partition-function general analyticity wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -76,6 +76,9 @@ regularity wrappers live in
 general-graph `partitionFunctionAlongExhaustion` regularity-at-zero-field
 wrappers live in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFunctionRegularity`,
+general-graph `partitionFunctionAlongExhaustion` joint and general-h
+analyticity wrappers live in
+`IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticity`,
 and `susceptibilityAlongExhaustion` pointwise regularity wrappers live in
 `IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity`.
 New narrow APIs should be added in dedicated child modules and re-exported here

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -18,6 +18,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
+import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionRegularity
 import IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyPointwiseRegularity
 import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyAnalyticity
@@ -196,58 +197,6 @@ theorem partitionFunctionAlongExhaustion_monotone_abs_h
     partitionFunctionAlongExhaustion G Λ (⟨J, h₁, β⟩ : IsingParams ℝ) n
       ≤ partitionFunctionAlongExhaustion G Λ (⟨J, h₂, β⟩ : IsingParams ℝ) n :=
   partitionFunctionΛ_monotone_abs_h G (Λ.volume n) J β hJ hβ hh
-
-/-! ### §18.6 partitionFunctionAlongExhaustion joint + general-h
-analyticity along-ex wraps -/
-
-/-- **Along-ex: partitionFunction jointly `Continuous` in
-`(β, J, h)`**. -/
-theorem partitionFunctionAlongExhaustion_continuous_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
-    Continuous (fun p : ℝ × ℝ × ℝ =>
-      partitionFunctionAlongExhaustion G Λ
-        ⟨p.2.1, p.2.2, p.1⟩ n) :=
-  partitionFunctionΛ_continuous_joint G (Λ.volume n)
-
-/-- **Along-ex: partitionFunction jointly `Differentiable ℝ` in
-`(β, J, h)`**. -/
-theorem partitionFunctionAlongExhaustion_differentiable_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
-    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
-      partitionFunctionAlongExhaustion G Λ
-        ⟨p.2.1, p.2.2, p.1⟩ n) :=
-  partitionFunctionΛ_differentiable_joint G (Λ.volume n)
-
-/-- **Along-ex: partitionFunction `AnalyticAt ℝ` in `β` at general
-`h`**. -/
-theorem partitionFunctionAlongExhaustion_analyticAt_beta_general_h
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun β' : ℝ =>
-      partitionFunctionAlongExhaustion G Λ ⟨J, h, β'⟩ n) β :=
-  partitionFunctionΛ_analyticAt_beta_general_h G (Λ.volume n) J h β
-
-/-- **Along-ex: partitionFunction `AnalyticAt ℝ` in `J` at general
-`h`**. -/
-theorem partitionFunctionAlongExhaustion_analyticAt_J_general_h
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β h J : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun J' : ℝ =>
-      partitionFunctionAlongExhaustion G Λ ⟨J', h, β⟩ n) J :=
-  partitionFunctionΛ_analyticAt_J_general_h G (Λ.volume n) β h J
-
-/-- **Along-ex: partitionFunction `AnalyticAt ℝ` in `h`**. -/
-theorem partitionFunctionAlongExhaustion_analyticAt_h
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β h : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun h' : ℝ =>
-      partitionFunctionAlongExhaustion G Λ ⟨J, h', β⟩ n) h :=
-  partitionFunctionΛ_analyticAt_h G (Λ.volume n) J β h
 
 /-! ### §18.6 partitionFunction/freeEnergy Continuous + Differentiable
 along-ex wraps (Λ-layer wraps via PR #1541 / #1533) -/

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionGeneralAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionGeneralAnalyticity.lean
@@ -1,0 +1,71 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Ambient partition-function joint and general-h analyticity wrappers
+
+This module contains general-graph joint `Continuous` / `Differentiable` APIs
+and general-h `AnalyticAt` APIs for per-stage
+`partitionFunctionAlongExhaustion`. It is split out of the legacy ambient
+special-cases module so concrete partition-function wrappers can depend on a
+narrower child path.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### Along-exhaustion partition-function joint and general-h analyticity -/
+
+/-- **Along-ex: partitionFunction jointly `Continuous` in
+`(β, J, h)`**. -/
+theorem partitionFunctionAlongExhaustion_continuous_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
+    Continuous (fun p : ℝ × ℝ × ℝ =>
+      partitionFunctionAlongExhaustion G Λ
+        ⟨p.2.1, p.2.2, p.1⟩ n) :=
+  partitionFunctionΛ_continuous_joint G (Λ.volume n)
+
+/-- **Along-ex: partitionFunction jointly `Differentiable ℝ` in
+`(β, J, h)`**. -/
+theorem partitionFunctionAlongExhaustion_differentiable_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
+    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
+      partitionFunctionAlongExhaustion G Λ
+        ⟨p.2.1, p.2.2, p.1⟩ n) :=
+  partitionFunctionΛ_differentiable_joint G (Λ.volume n)
+
+/-- **Along-ex: partitionFunction `AnalyticAt ℝ` in `β` at general
+`h`**. -/
+theorem partitionFunctionAlongExhaustion_analyticAt_beta_general_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun β' : ℝ =>
+      partitionFunctionAlongExhaustion G Λ ⟨J, h, β'⟩ n) β :=
+  partitionFunctionΛ_analyticAt_beta_general_h G (Λ.volume n) J h β
+
+/-- **Along-ex: partitionFunction `AnalyticAt ℝ` in `J` at general
+`h`**. -/
+theorem partitionFunctionAlongExhaustion_analyticAt_J_general_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β h J : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun J' : ℝ =>
+      partitionFunctionAlongExhaustion G Λ ⟨J', h, β⟩ n) J :=
+  partitionFunctionΛ_analyticAt_J_general_h G (Λ.volume n) β h J
+
+/-- **Along-ex: partitionFunction `AnalyticAt ℝ` in `h`**. -/
+theorem partitionFunctionAlongExhaustion_analyticAt_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β h : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun h' : ℝ =>
+      partitionFunctionAlongExhaustion G Λ ⟨J, h', β⟩ n) h :=
+  partitionFunctionΛ_analyticAt_h G (Λ.volume n) J β h
+
+end Ambient
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -62,6 +62,9 @@ directly. For concrete per-parameter `partitionFunctionAlongExhaustion` /
 `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyPointwiseRegularity`
 directly. For concrete partition-function regularity-at-zero-field wrappers,
 import `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionRegularity`
+directly. For concrete partition-function joint and general-h analyticity
+wrappers, import
+`IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionGeneralAnalyticity`
 directly. For concrete `polymerFreeEnergy` analytic wrappers, import
 `IsingModel.Concrete.LatticeGraphCorrelation.PolymerFreeEnergyAnalyticity`
 directly. For concrete basic `polymerFreeEnergy` at-zero / at-one / sandwich

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -33,6 +33,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.MayerTrivialCases
 import IsingModel.Concrete.LatticeGraphCorrelation.MayerVdBounds
 import IsingModel.Concrete.LatticeGraphCorrelation.MayerVdIff
 import IsingModel.Concrete.LatticeGraphCorrelation.MayerVdRegularity
+import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionGeneralAnalyticity
 import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionRegularity
 import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyPointwiseRegularity
 import IsingModel.Concrete.LatticeGraphCorrelation.PolymerFreeEnergyAnalyticity
@@ -3646,126 +3647,6 @@ theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_shift
           (Ambient.cubicExhaustion d) p :=
   freeEnergyInfinite_shift_eq (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) t p
-
-/-! ### §18.6 partitionFunction joint + general-h analyticity ℤ^d
-wraps -/
-
-/-- **ℤ^d Λ: partitionFunction jointly `Continuous` in `(β, J, h)`**. -/
-theorem partitionFunctionΛ_latticeGraph_continuous_joint
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet] :
-    Continuous (fun p : ℝ × ℝ × ℝ =>
-      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
-        ⟨p.2.1, p.2.2, p.1⟩) :=
-  Ambient.partitionFunctionΛ_continuous_joint
-    (IsingModel.latticeGraph d) Λ
-
-/-- **ℤ^d Λ: partitionFunction jointly `Differentiable ℝ` in
-`(β, J, h)`**. -/
-theorem partitionFunctionΛ_latticeGraph_differentiable_joint
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet] :
-    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
-      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
-        ⟨p.2.1, p.2.2, p.1⟩) :=
-  Ambient.partitionFunctionΛ_differentiable_joint
-    (IsingModel.latticeGraph d) Λ
-
-/-- **ℤ^d Λ: partitionFunction `AnalyticAt ℝ` in `β` at general
-`h`**. -/
-theorem partitionFunctionΛ_latticeGraph_analyticAt_beta_general_h
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
-    (J h β : ℝ) :
-    AnalyticAt ℝ (fun β' : ℝ =>
-      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
-        ⟨J, h, β'⟩) β :=
-  Ambient.partitionFunctionΛ_analyticAt_beta_general_h
-    (IsingModel.latticeGraph d) Λ J h β
-
-/-- **ℤ^d Λ: partitionFunction `AnalyticAt ℝ` in `J` at general
-`h`**. -/
-theorem partitionFunctionΛ_latticeGraph_analyticAt_J_general_h
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
-    (β h J : ℝ) :
-    AnalyticAt ℝ (fun J' : ℝ =>
-      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
-        ⟨J', h, β⟩) J :=
-  Ambient.partitionFunctionΛ_analyticAt_J_general_h
-    (IsingModel.latticeGraph d) Λ β h J
-
-/-- **ℤ^d Λ: partitionFunction `AnalyticAt ℝ` in `h`**. -/
-theorem partitionFunctionΛ_latticeGraph_analyticAt_h
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
-    (J β h : ℝ) :
-    AnalyticAt ℝ (fun h' : ℝ =>
-      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
-        ⟨J, h', β⟩) h :=
-  Ambient.partitionFunctionΛ_analyticAt_h
-    (IsingModel.latticeGraph d) Λ J β h
-
-/-- **ℤ^d along-ex: partitionFunction jointly `Continuous`**. -/
-theorem partitionFunctionAlongExhaustion_latticeGraph_continuous_joint
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (n : ℕ) :
-    Continuous (fun p : ℝ × ℝ × ℝ =>
-      Ambient.partitionFunctionAlongExhaustion
-        (IsingModel.latticeGraph d) Λ ⟨p.2.1, p.2.2, p.1⟩ n) :=
-  Ambient.partitionFunctionAlongExhaustion_continuous_joint
-    (IsingModel.latticeGraph d) Λ n
-
-/-- **ℤ^d along-ex: partitionFunction jointly
-`Differentiable ℝ`**. -/
-theorem
-partitionFunctionAlongExhaustion_latticeGraph_differentiable_joint
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (n : ℕ) :
-    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
-      Ambient.partitionFunctionAlongExhaustion
-        (IsingModel.latticeGraph d) Λ ⟨p.2.1, p.2.2, p.1⟩ n) :=
-  Ambient.partitionFunctionAlongExhaustion_differentiable_joint
-    (IsingModel.latticeGraph d) Λ n
-
-/-- **ℤ^d along-ex: partitionFunction `AnalyticAt ℝ` in `β` at
-general `h`**. -/
-theorem
-partitionFunctionAlongExhaustion_latticeGraph_analyticAt_beta_general_h
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (J h β : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun β' : ℝ =>
-      Ambient.partitionFunctionAlongExhaustion
-        (IsingModel.latticeGraph d) Λ ⟨J, h, β'⟩ n) β :=
-  Ambient.partitionFunctionAlongExhaustion_analyticAt_beta_general_h
-    (IsingModel.latticeGraph d) Λ J h β n
-
-/-- **ℤ^d along-ex: partitionFunction `AnalyticAt ℝ` in `J` at
-general `h`**. -/
-theorem
-partitionFunctionAlongExhaustion_latticeGraph_analyticAt_J_general_h
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (β h J : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun J' : ℝ =>
-      Ambient.partitionFunctionAlongExhaustion
-        (IsingModel.latticeGraph d) Λ ⟨J', h, β⟩ n) J :=
-  Ambient.partitionFunctionAlongExhaustion_analyticAt_J_general_h
-    (IsingModel.latticeGraph d) Λ β h J n
-
-/-- **ℤ^d along-ex: partitionFunction `AnalyticAt ℝ` in `h`**. -/
-theorem partitionFunctionAlongExhaustion_latticeGraph_analyticAt_h
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (J β h : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun h' : ℝ =>
-      Ambient.partitionFunctionAlongExhaustion
-        (IsingModel.latticeGraph d) Λ ⟨J, h', β⟩ n) h :=
-  Ambient.partitionFunctionAlongExhaustion_analyticAt_h
-    (IsingModel.latticeGraph d) Λ J β h n
 
 /-! ### §18.6 partitionFunction/freeEnergy Continuous + Differentiable
 ℤ^d wraps -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionGeneralAnalyticity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionGeneralAnalyticity.lean
@@ -1,0 +1,136 @@
+import IsingModel.Lattice
+import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticity
+
+/-!
+# Concrete partition-function joint and general-h analyticity wrappers
+
+This module contains concrete `latticeGraph` specializations of joint
+`Continuous` / `Differentiable` APIs and general-h `AnalyticAt` APIs for
+partition functions. It is split out of the legacy concrete correlation module
+so downstream users can depend on a narrower child path.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-! ### ℤ^d partition-function joint and general-h analyticity -/
+
+/-- **ℤ^d Λ: partitionFunction jointly `Continuous` in `(β, J, h)`**. -/
+theorem partitionFunctionΛ_latticeGraph_continuous_joint
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet] :
+    Continuous (fun p : ℝ × ℝ × ℝ =>
+      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
+        ⟨p.2.1, p.2.2, p.1⟩) :=
+  Ambient.partitionFunctionΛ_continuous_joint
+    (IsingModel.latticeGraph d) Λ
+
+/-- **ℤ^d Λ: partitionFunction jointly `Differentiable ℝ` in
+`(β, J, h)`**. -/
+theorem partitionFunctionΛ_latticeGraph_differentiable_joint
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet] :
+    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
+      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
+        ⟨p.2.1, p.2.2, p.1⟩) :=
+  Ambient.partitionFunctionΛ_differentiable_joint
+    (IsingModel.latticeGraph d) Λ
+
+/-- **ℤ^d Λ: partitionFunction `AnalyticAt ℝ` in `β` at general
+`h`**. -/
+theorem partitionFunctionΛ_latticeGraph_analyticAt_beta_general_h
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
+    (J h β : ℝ) :
+    AnalyticAt ℝ (fun β' : ℝ =>
+      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
+        ⟨J, h, β'⟩) β :=
+  Ambient.partitionFunctionΛ_analyticAt_beta_general_h
+    (IsingModel.latticeGraph d) Λ J h β
+
+/-- **ℤ^d Λ: partitionFunction `AnalyticAt ℝ` in `J` at general
+`h`**. -/
+theorem partitionFunctionΛ_latticeGraph_analyticAt_J_general_h
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
+    (β h J : ℝ) :
+    AnalyticAt ℝ (fun J' : ℝ =>
+      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
+        ⟨J', h, β⟩) J :=
+  Ambient.partitionFunctionΛ_analyticAt_J_general_h
+    (IsingModel.latticeGraph d) Λ β h J
+
+/-- **ℤ^d Λ: partitionFunction `AnalyticAt ℝ` in `h`**. -/
+theorem partitionFunctionΛ_latticeGraph_analyticAt_h
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
+    (J β h : ℝ) :
+    AnalyticAt ℝ (fun h' : ℝ =>
+      Ambient.partitionFunctionΛ (IsingModel.latticeGraph d) Λ
+        ⟨J, h', β⟩) h :=
+  Ambient.partitionFunctionΛ_analyticAt_h
+    (IsingModel.latticeGraph d) Λ J β h
+
+/-- **ℤ^d along-ex: partitionFunction jointly `Continuous`**. -/
+theorem partitionFunctionAlongExhaustion_latticeGraph_continuous_joint
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (n : ℕ) :
+    Continuous (fun p : ℝ × ℝ × ℝ =>
+      Ambient.partitionFunctionAlongExhaustion
+        (IsingModel.latticeGraph d) Λ ⟨p.2.1, p.2.2, p.1⟩ n) :=
+  Ambient.partitionFunctionAlongExhaustion_continuous_joint
+    (IsingModel.latticeGraph d) Λ n
+
+/-- **ℤ^d along-ex: partitionFunction jointly
+`Differentiable ℝ`**. -/
+theorem
+partitionFunctionAlongExhaustion_latticeGraph_differentiable_joint
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (n : ℕ) :
+    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
+      Ambient.partitionFunctionAlongExhaustion
+        (IsingModel.latticeGraph d) Λ ⟨p.2.1, p.2.2, p.1⟩ n) :=
+  Ambient.partitionFunctionAlongExhaustion_differentiable_joint
+    (IsingModel.latticeGraph d) Λ n
+
+/-- **ℤ^d along-ex: partitionFunction `AnalyticAt ℝ` in `β` at
+general `h`**. -/
+theorem
+partitionFunctionAlongExhaustion_latticeGraph_analyticAt_beta_general_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (J h β : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun β' : ℝ =>
+      Ambient.partitionFunctionAlongExhaustion
+        (IsingModel.latticeGraph d) Λ ⟨J, h, β'⟩ n) β :=
+  Ambient.partitionFunctionAlongExhaustion_analyticAt_beta_general_h
+    (IsingModel.latticeGraph d) Λ J h β n
+
+/-- **ℤ^d along-ex: partitionFunction `AnalyticAt ℝ` in `J` at
+general `h`**. -/
+theorem
+partitionFunctionAlongExhaustion_latticeGraph_analyticAt_J_general_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (β h J : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun J' : ℝ =>
+      Ambient.partitionFunctionAlongExhaustion
+        (IsingModel.latticeGraph d) Λ ⟨J', h, β⟩ n) J :=
+  Ambient.partitionFunctionAlongExhaustion_analyticAt_J_general_h
+    (IsingModel.latticeGraph d) Λ β h J n
+
+/-- **ℤ^d along-ex: partitionFunction `AnalyticAt ℝ` in `h`**. -/
+theorem partitionFunctionAlongExhaustion_latticeGraph_analyticAt_h
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (J β h : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun h' : ℝ =>
+      Ambient.partitionFunctionAlongExhaustion
+        (IsingModel.latticeGraph d) Λ ⟨J, h', β⟩ n) h :=
+  Ambient.partitionFunctionAlongExhaustion_analyticAt_h
+    (IsingModel.latticeGraph d) Λ J β h n
+
+end Ambient
+end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,8 @@ View* (2nd ed., 1987).
 > `freeEnergyAlongExhaustion` pointwise wrappers,
 > `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionRegularity`
 > for concrete partition-function regularity-at-zero-field wrappers,
+> `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionGeneralAnalyticity`
+> for concrete partition-function joint and general-h analyticity wrappers,
 > `IsingModel.Concrete.LatticeGraphCorrelation.FreeEnergyAnalyticity`
 > for concrete free-energy per-direction analyticity wrappers,
 > `IsingModel.Concrete.LatticeGraphCorrelation.PolymerFreeEnergyAnalyticity`
@@ -174,6 +176,9 @@ View* (2nd ed., 1987).
 > `IsingModel.AmbientLattice.SpecialCases.PartitionFunctionRegularity`
 > for ambient `partitionFunctionAlongExhaustion`
 > regularity-at-zero-field wrappers, plus
+> `IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticity`
+> for ambient `partitionFunctionAlongExhaustion` joint and general-h
+> analyticity wrappers, plus
 > `IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity`
 > for ambient `freeEnergyAlongExhaustion` per-direction analyticity
 > wrappers, plus

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4669,6 +4669,11 @@ $\mathbb{Z}^d$ wrappers from this family now live in the matching
 \texttt{AmbientLattice/SpecialCases} and
 \texttt{Concrete/LatticeGraphCorrelation}; the $\Lambda$-layer wrappers
 remain in \texttt{IsingModel/AmbientLattice/Analyticity.lean}.
+The along-exhaustion and concrete $\mathbb{Z}^d$ joint/general-$h$
+\texttt{partitionFunction} wrappers now live in the matching
+\texttt{PartitionFunctionGeneralAnalyticity.lean} child modules; the
+$\Lambda$-layer wrappers remain in
+\texttt{IsingModel/AmbientLattice/Analyticity.lean}.
 The analogous \texttt{freeEnergy} per-direction analyticity wrappers
 now live in matching \texttt{FreeEnergyAnalyticity.lean} child modules;
 their $\Lambda$-layer wrappers remain in


### PR DESCRIPTION
Part of #1850.

## Summary
- split partition-function joint/general-h analyticity wrappers into dedicated ambient and concrete child modules
- keep legacy modules as re-export/import compatibility paths
- update module-location notes in docs and the proof guide

## Verification
- lake build IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticity
- lake build IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionGeneralAnalyticity
- lake build IsingModel.AmbientLattice.SpecialCases.Legacy
- lake build IsingModel.Concrete.LatticeGraphCorrelation.Legacy
- lake build IsingModel.AmbientLattice.SpecialCases
- lake build IsingModel.Concrete.LatticeGraphCorrelation
- lake exe GKSTest
- lake build
- rg -n "[ぁ-んァ-ヶ一-龠々〆〤]" tex/proof-guide.tex
- latexmk -lualatex -f -interaction=nonstopmode proof-guide.tex
- rg -n "sorry" IsingModel
- git diff --check
