### PR TITLE
Split magnetization regularity wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -46,6 +46,9 @@ Mayer trivial/no-polymer comparison wrappers live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdIff`. General-graph
 Mayer and `vdPolymerFamilies_sum` regularity wrappers live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity`. General-graph
+magnetization regularity wrappers live in
+`IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity`.
+General-graph
 `polymerFreeEnergy` analytic wrappers live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyAnalyticity`.
 General-graph basic `polymerFreeEnergy` at-zero / at-one / sandwich wrappers

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -202,68 +202,6 @@ theorem partitionFunctionAlongExhaustion_monotone_abs_h
       ≤ partitionFunctionAlongExhaustion G Λ (⟨J, h₂, β⟩ : IsingParams ℝ) n :=
   partitionFunctionΛ_monotone_abs_h G (Λ.volume n) J β hJ hβ hh
 
-/-! ### ContinuousAt / DifferentiableAt along-ex wrappers -/
-
-/-- **Along-ex: magnetization ContinuousAt β** (general h). -/
-theorem magnetizationAlongExhaustion_continuousAt_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    ContinuousAt
-      (fun β' => magnetizationAlongExhaustion G Λ
-          (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
-  (magnetizationAlongExhaustion_continuous_beta G Λ J h i n).continuousAt
-
-/-- **Along-ex: magnetization DifferentiableAt β** (general h). -/
-theorem magnetizationAlongExhaustion_differentiableAt_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    DifferentiableAt ℝ
-      (fun β' => magnetizationAlongExhaustion G Λ
-          (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
-  (magnetizationAlongExhaustion_differentiable_beta G Λ J h i n).differentiableAt
-
-/-- **Along-ex: magnetization ContinuousAt h**. -/
-theorem magnetizationAlongExhaustion_continuousAt_field
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    ContinuousAt
-      (fun h' => magnetizationAlongExhaustion G Λ
-          (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
-  (magnetizationAlongExhaustion_continuous_field G Λ J β i n).continuousAt
-
-/-- **Along-ex: magnetization DifferentiableAt h**. -/
-theorem magnetizationAlongExhaustion_differentiableAt_field
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    DifferentiableAt ℝ
-      (fun h' => magnetizationAlongExhaustion G Λ
-          (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
-  (magnetizationAlongExhaustion_differentiable_field G Λ J β i n).differentiableAt
-
-/-- **Along-ex: magnetization ContinuousAt J**. -/
-theorem magnetizationAlongExhaustion_continuousAt_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    ContinuousAt
-      (fun J' => magnetizationAlongExhaustion G Λ
-          (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
-  (magnetizationAlongExhaustion_continuous_J G Λ h β i n).continuousAt
-
-/-- **Along-ex: magnetization DifferentiableAt J**. -/
-theorem magnetizationAlongExhaustion_differentiableAt_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (i : V) (n : ℕ) :
-    DifferentiableAt ℝ
-      (fun J' => magnetizationAlongExhaustion G Λ
-          (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
-  (magnetizationAlongExhaustion_differentiable_J G Λ h β i n).differentiableAt
-
 /-! ### magnetization parameter-direction convergent (β/h/J → ∞)
 along-ex wraps -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -20,6 +20,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
+import IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity
 import IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyRegularity
 import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionRegularity
@@ -200,99 +201,6 @@ theorem partitionFunctionAlongExhaustion_monotone_abs_h
     partitionFunctionAlongExhaustion G Λ (⟨J, h₁, β⟩ : IsingParams ℝ) n
       ≤ partitionFunctionAlongExhaustion G Λ (⟨J, h₂, β⟩ : IsingParams ℝ) n :=
   partitionFunctionΛ_monotone_abs_h G (Λ.volume n) J β hJ hβ hh
-
-/-! ### magnetization regularity along-ex wraps -/
-
-/-- **Along-ex: magnetization Continuous in `h` for `i ∈
-Λ.volume n`**. The site coercion is the obvious lift. -/
-theorem magnetizationAlongExhaustion_continuous_field
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (i : V) (n : ℕ) :
-    Continuous (fun h' =>
-      magnetizationAlongExhaustion G Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i n) := by
-  unfold magnetizationAlongExhaustion correlationAlongExhaustion
-  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact magnetizationΛ_continuous_field G (Λ.volume n) J β _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact continuous_const
-
-/-- **Along-ex: magnetization Differentiable in `h`**. -/
-theorem magnetizationAlongExhaustion_differentiable_field
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (i : V) (n : ℕ) :
-    Differentiable ℝ (fun h' =>
-      magnetizationAlongExhaustion G Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i n) := by
-  unfold magnetizationAlongExhaustion correlationAlongExhaustion
-  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact magnetizationΛ_differentiable_field G (Λ.volume n) J β _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact differentiable_const _
-
-/-- **Along-ex: magnetization Continuous in `J`**. -/
-theorem magnetizationAlongExhaustion_continuous_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (h β : ℝ) (i : V) (n : ℕ) :
-    Continuous (fun J' =>
-      magnetizationAlongExhaustion G Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i n) := by
-  unfold magnetizationAlongExhaustion correlationAlongExhaustion
-  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact magnetizationΛ_continuous_J G (Λ.volume n) h β _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact continuous_const
-
-/-- **Along-ex: magnetization Differentiable in `J`**. -/
-theorem magnetizationAlongExhaustion_differentiable_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (h β : ℝ) (i : V) (n : ℕ) :
-    Differentiable ℝ (fun J' =>
-      magnetizationAlongExhaustion G Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i n) := by
-  unfold magnetizationAlongExhaustion correlationAlongExhaustion
-  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact magnetizationΛ_differentiable_J G (Λ.volume n) h β _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact differentiable_const _
-
-/-- **Along-ex: magnetization Continuous in `β`** (general h). -/
-theorem magnetizationAlongExhaustion_continuous_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h : ℝ) (i : V) (n : ℕ) :
-    Continuous (fun β' =>
-      magnetizationAlongExhaustion G Λ
-        (⟨J, h, β'⟩ : IsingParams ℝ) i n) := by
-  unfold magnetizationAlongExhaustion correlationAlongExhaustion
-  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact magnetizationΛ_continuous_beta G (Λ.volume n) J h _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact continuous_const
-
-/-- **Along-ex: magnetization Differentiable in `β`** (general h). -/
-theorem magnetizationAlongExhaustion_differentiable_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h : ℝ) (i : V) (n : ℕ) :
-    Differentiable ℝ (fun β' =>
-      magnetizationAlongExhaustion G Λ
-        (⟨J, h, β'⟩ : IsingParams ℝ) i n) := by
-  unfold magnetizationAlongExhaustion correlationAlongExhaustion
-  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact magnetizationΛ_differentiable_beta G (Λ.volume n) J h _
-  · simp only [hi, dif_neg, not_false_iff]
-    exact differentiable_const _
 
 /-! ### ContinuousAt / DifferentiableAt along-ex wrappers -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MagnetizationRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MagnetizationRegularity.lean
@@ -110,5 +110,67 @@ theorem magnetizationAlongExhaustion_differentiable_beta
   · simp only [hi, dif_neg, not_false_iff]
     exact differentiable_const _
 
+/-! ### ContinuousAt / DifferentiableAt along-ex wrappers -/
+
+/-- **Along-ex: magnetization ContinuousAt β** (general h). -/
+theorem magnetizationAlongExhaustion_continuousAt_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    ContinuousAt
+      (fun β' => magnetizationAlongExhaustion G Λ
+          (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
+  (magnetizationAlongExhaustion_continuous_beta G Λ J h i n).continuousAt
+
+/-- **Along-ex: magnetization DifferentiableAt β** (general h). -/
+theorem magnetizationAlongExhaustion_differentiableAt_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    DifferentiableAt ℝ
+      (fun β' => magnetizationAlongExhaustion G Λ
+          (⟨J, h, β'⟩ : IsingParams ℝ) i n) β :=
+  (magnetizationAlongExhaustion_differentiable_beta G Λ J h i n).differentiableAt
+
+/-- **Along-ex: magnetization ContinuousAt h**. -/
+theorem magnetizationAlongExhaustion_continuousAt_field
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    ContinuousAt
+      (fun h' => magnetizationAlongExhaustion G Λ
+          (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
+  (magnetizationAlongExhaustion_continuous_field G Λ J β i n).continuousAt
+
+/-- **Along-ex: magnetization DifferentiableAt h**. -/
+theorem magnetizationAlongExhaustion_differentiableAt_field
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    DifferentiableAt ℝ
+      (fun h' => magnetizationAlongExhaustion G Λ
+          (⟨J, h', β⟩ : IsingParams ℝ) i n) h :=
+  (magnetizationAlongExhaustion_differentiable_field G Λ J β i n).differentiableAt
+
+/-- **Along-ex: magnetization ContinuousAt J**. -/
+theorem magnetizationAlongExhaustion_continuousAt_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    ContinuousAt
+      (fun J' => magnetizationAlongExhaustion G Λ
+          (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
+  (magnetizationAlongExhaustion_continuous_J G Λ h β i n).continuousAt
+
+/-- **Along-ex: magnetization DifferentiableAt J**. -/
+theorem magnetizationAlongExhaustion_differentiableAt_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (i : V) (n : ℕ) :
+    DifferentiableAt ℝ
+      (fun J' => magnetizationAlongExhaustion G Λ
+          (⟨J', h, β⟩ : IsingParams ℝ) i n) J :=
+  (magnetizationAlongExhaustion_differentiable_J G Λ h β i n).differentiableAt
+
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MagnetizationRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MagnetizationRegularity.lean
@@ -1,0 +1,114 @@
+import IsingModel.AmbientLattice.Defs
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Magnetization regularity wrappers along an exhaustion
+
+Narrow child module for finite-stage magnetization `Continuous` and
+`Differentiable` wrappers along an exhaustion. The theorem names are the same
+as the former legacy declarations, but callers can now avoid importing the
+monolithic special-cases legacy module.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### magnetization regularity along-ex wraps -/
+
+/-- **Along-ex: magnetization Continuous in `h` for `i ∈
+Λ.volume n`**. The site coercion is the obvious lift. -/
+theorem magnetizationAlongExhaustion_continuous_field
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i : V) (n : ℕ) :
+    Continuous (fun h' =>
+      magnetizationAlongExhaustion G Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i n) := by
+  unfold magnetizationAlongExhaustion correlationAlongExhaustion
+  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact magnetizationΛ_continuous_field G (Λ.volume n) J β _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact continuous_const
+
+/-- **Along-ex: magnetization Differentiable in `h`**. -/
+theorem magnetizationAlongExhaustion_differentiable_field
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (i : V) (n : ℕ) :
+    Differentiable ℝ (fun h' =>
+      magnetizationAlongExhaustion G Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i n) := by
+  unfold magnetizationAlongExhaustion correlationAlongExhaustion
+  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact magnetizationΛ_differentiable_field G (Λ.volume n) J β _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+/-- **Along-ex: magnetization Continuous in `J`**. -/
+theorem magnetizationAlongExhaustion_continuous_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (h β : ℝ) (i : V) (n : ℕ) :
+    Continuous (fun J' =>
+      magnetizationAlongExhaustion G Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i n) := by
+  unfold magnetizationAlongExhaustion correlationAlongExhaustion
+  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact magnetizationΛ_continuous_J G (Λ.volume n) h β _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact continuous_const
+
+/-- **Along-ex: magnetization Differentiable in `J`**. -/
+theorem magnetizationAlongExhaustion_differentiable_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (h β : ℝ) (i : V) (n : ℕ) :
+    Differentiable ℝ (fun J' =>
+      magnetizationAlongExhaustion G Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i n) := by
+  unfold magnetizationAlongExhaustion correlationAlongExhaustion
+  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact magnetizationΛ_differentiable_J G (Λ.volume n) h β _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+/-- **Along-ex: magnetization Continuous in `β`** (general h). -/
+theorem magnetizationAlongExhaustion_continuous_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (i : V) (n : ℕ) :
+    Continuous (fun β' =>
+      magnetizationAlongExhaustion G Λ
+        (⟨J, h, β'⟩ : IsingParams ℝ) i n) := by
+  unfold magnetizationAlongExhaustion correlationAlongExhaustion
+  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact magnetizationΛ_continuous_beta G (Λ.volume n) J h _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact continuous_const
+
+/-- **Along-ex: magnetization Differentiable in `β`** (general h). -/
+theorem magnetizationAlongExhaustion_differentiable_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (i : V) (n : ℕ) :
+    Differentiable ℝ (fun β' =>
+      magnetizationAlongExhaustion G Λ
+        (⟨J, h, β'⟩ : IsingParams ℝ) i n) := by
+  unfold magnetizationAlongExhaustion correlationAlongExhaustion
+  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact magnetizationΛ_differentiable_beta G (Λ.volume n) J h _
+  · simp only [hi, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+end Ambient
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -59,7 +59,9 @@ concrete J-direction `correlationAlongExhaustion` `ContinuousAt` /
 concrete per-parameter `magnetizationAlongExhaustion` pointwise wrappers,
 import
 `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity`
-directly. For concrete per-parameter `partitionFunctionAlongExhaustion` /
+directly. For concrete magnetization regularity wrappers, import
+`IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationRegularity` directly.
+For concrete per-parameter `partitionFunctionAlongExhaustion` /
 `freeEnergyAlongExhaustion` pointwise wrappers, import
 `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyPointwiseRegularity`
 directly. For concrete partition-function regularity-at-zero-field wrappers,

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -3828,33 +3828,6 @@ theorem susceptibilityAlongExhaustion_latticeGraph_convergent_J_param
     (IsingModel.latticeGraph d) Λ h hh β hβ i n
 
 
-/-! ### ℤ^d along-ex `magnetizationAlongExhaustion` β-direction
-Continuous/Differentiable wrappers (general h) -/
-
-/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` Continuous in β** (general h). -/
-theorem magnetizationAlongExhaustion_latticeGraph_continuous_beta
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    Continuous (fun β' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
-        Λ (⟨J, h, β'⟩ : IsingParams ℝ) i n) :=
-  Ambient.magnetizationAlongExhaustion_continuous_beta
-    (IsingModel.latticeGraph d) Λ J h i n
-
-/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` Differentiable in β** (general h). -/
-theorem magnetizationAlongExhaustion_latticeGraph_differentiable_beta
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet]
-    (J h : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    Differentiable ℝ (fun β' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
-        Λ (⟨J, h, β'⟩ : IsingParams ℝ) i n) :=
-  Ambient.magnetizationAlongExhaustion_differentiable_beta
-    (IsingModel.latticeGraph d) Λ J h i n
-
 end Ambient
 
 end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -35,6 +35,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.MayerTrivialCases
 import IsingModel.Concrete.LatticeGraphCorrelation.MayerVdBounds
 import IsingModel.Concrete.LatticeGraphCorrelation.MayerVdIff
 import IsingModel.Concrete.LatticeGraphCorrelation.MayerVdRegularity
+import IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationRegularity
 import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyRegularity
 import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionGeneralAnalyticity
 import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFunctionRegularity
@@ -3650,96 +3651,6 @@ theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_shift
           (Ambient.cubicExhaustion d) p :=
   freeEnergyInfinite_shift_eq (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) t p
-
-/-! ### magnetization regularity ℤ^d wraps -/
-
-/-- **ℤ^d Λ: magnetization Continuous in `h`**. -/
-theorem magnetizationΛ_latticeGraph_continuous_field
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
-    (J β : ℝ) (i : ↑Λ) :
-    Continuous (fun h' =>
-      Ambient.magnetizationΛ (IsingModel.latticeGraph d) Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i) :=
-  Ambient.magnetizationΛ_continuous_field
-    (IsingModel.latticeGraph d) Λ J β i
-
-/-- **ℤ^d Λ: magnetization Differentiable in `h`**. -/
-theorem magnetizationΛ_latticeGraph_differentiable_field
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
-    (J β : ℝ) (i : ↑Λ) :
-    Differentiable ℝ (fun h' =>
-      Ambient.magnetizationΛ (IsingModel.latticeGraph d) Λ
-        (⟨J, h', β⟩ : IsingParams ℝ) i) :=
-  Ambient.magnetizationΛ_differentiable_field
-    (IsingModel.latticeGraph d) Λ J β i
-
-/-- **ℤ^d Λ: magnetization Continuous in `J`**. -/
-theorem magnetizationΛ_latticeGraph_continuous_J
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
-    (h β : ℝ) (i : ↑Λ) :
-    Continuous (fun J' =>
-      Ambient.magnetizationΛ (IsingModel.latticeGraph d) Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i) :=
-  Ambient.magnetizationΛ_continuous_J
-    (IsingModel.latticeGraph d) Λ h β i
-
-/-- **ℤ^d Λ: magnetization Differentiable in `J`**. -/
-theorem magnetizationΛ_latticeGraph_differentiable_J
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
-    (h β : ℝ) (i : ↑Λ) :
-    Differentiable ℝ (fun J' =>
-      Ambient.magnetizationΛ (IsingModel.latticeGraph d) Λ
-        (⟨J', h, β⟩ : IsingParams ℝ) i) :=
-  Ambient.magnetizationΛ_differentiable_J
-    (IsingModel.latticeGraph d) Λ h β i
-
-/-- **ℤ^d along-ex: magnetization Continuous in `h`**. -/
-theorem magnetizationAlongExhaustion_latticeGraph_continuous_field
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (J β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    Continuous (fun h' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
-        Λ (⟨J, h', β⟩ : IsingParams ℝ) i n) :=
-  Ambient.magnetizationAlongExhaustion_continuous_field
-    (IsingModel.latticeGraph d) Λ J β i n
-
-/-- **ℤ^d along-ex: magnetization Differentiable in `h`**. -/
-theorem magnetizationAlongExhaustion_latticeGraph_differentiable_field
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (J β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    Differentiable ℝ (fun h' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
-        Λ (⟨J, h', β⟩ : IsingParams ℝ) i n) :=
-  Ambient.magnetizationAlongExhaustion_differentiable_field
-    (IsingModel.latticeGraph d) Λ J β i n
-
-/-- **ℤ^d along-ex: magnetization Continuous in `J`**. -/
-theorem magnetizationAlongExhaustion_latticeGraph_continuous_J
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    Continuous (fun J' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
-        Λ (⟨J', h, β⟩ : IsingParams ℝ) i n) :=
-  Ambient.magnetizationAlongExhaustion_continuous_J
-    (IsingModel.latticeGraph d) Λ h β i n
-
-/-- **ℤ^d along-ex: magnetization Differentiable in `J`**. -/
-theorem magnetizationAlongExhaustion_latticeGraph_differentiable_J
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
-      (Λ.volume n)).edgeSet] (h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
-    Differentiable ℝ (fun J' =>
-      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
-        Λ (⟨J', h, β⟩ : IsingParams ℝ) i n) :=
-  Ambient.magnetizationAlongExhaustion_differentiable_J
-    (IsingModel.latticeGraph d) Λ h β i n
 
 /-! ### magnetization parameter-direction convergent (β/h/J → ∞)
 ℤ^d wraps. Λ-direct versions already exist as

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationRegularity.lean
@@ -1,0 +1,107 @@
+import IsingModel.Lattice
+import IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity
+
+/-!
+# Concrete magnetization regularity wrappers
+
+Narrow child module for concrete finite-stage magnetization `Continuous` and
+`Differentiable` wrappers on the lattice graph. The theorem names are the same
+as the former legacy declarations, but callers can now avoid importing the
+monolithic concrete legacy module.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-! ### magnetization regularity ℤ^d wraps -/
+
+/-- **ℤ^d Λ: magnetization Continuous in `h`**. -/
+theorem magnetizationΛ_latticeGraph_continuous_field
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
+    (J β : ℝ) (i : ↑Λ) :
+    Continuous (fun h' =>
+      Ambient.magnetizationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i) :=
+  Ambient.magnetizationΛ_continuous_field
+    (IsingModel.latticeGraph d) Λ J β i
+
+/-- **ℤ^d Λ: magnetization Differentiable in `h`**. -/
+theorem magnetizationΛ_latticeGraph_differentiable_field
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
+    (J β : ℝ) (i : ↑Λ) :
+    Differentiable ℝ (fun h' =>
+      Ambient.magnetizationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J, h', β⟩ : IsingParams ℝ) i) :=
+  Ambient.magnetizationΛ_differentiable_field
+    (IsingModel.latticeGraph d) Λ J β i
+
+/-- **ℤ^d Λ: magnetization Continuous in `J`**. -/
+theorem magnetizationΛ_latticeGraph_continuous_J
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
+    (h β : ℝ) (i : ↑Λ) :
+    Continuous (fun J' =>
+      Ambient.magnetizationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i) :=
+  Ambient.magnetizationΛ_continuous_J
+    (IsingModel.latticeGraph d) Λ h β i
+
+/-- **ℤ^d Λ: magnetization Differentiable in `J`**. -/
+theorem magnetizationΛ_latticeGraph_differentiable_J
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Fintype (inducedGraph (IsingModel.latticeGraph d) Λ).edgeSet]
+    (h β : ℝ) (i : ↑Λ) :
+    Differentiable ℝ (fun J' =>
+      Ambient.magnetizationΛ (IsingModel.latticeGraph d) Λ
+        (⟨J', h, β⟩ : IsingParams ℝ) i) :=
+  Ambient.magnetizationΛ_differentiable_J
+    (IsingModel.latticeGraph d) Λ h β i
+
+/-- **ℤ^d along-ex: magnetization Continuous in `h`**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_continuous_field
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (J β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    Continuous (fun h' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
+        Λ (⟨J, h', β⟩ : IsingParams ℝ) i n) :=
+  Ambient.magnetizationAlongExhaustion_continuous_field
+    (IsingModel.latticeGraph d) Λ J β i n
+
+/-- **ℤ^d along-ex: magnetization Differentiable in `h`**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_differentiable_field
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (J β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    Differentiable ℝ (fun h' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
+        Λ (⟨J, h', β⟩ : IsingParams ℝ) i n) :=
+  Ambient.magnetizationAlongExhaustion_differentiable_field
+    (IsingModel.latticeGraph d) Λ J β i n
+
+/-- **ℤ^d along-ex: magnetization Continuous in `J`**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_continuous_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    Continuous (fun J' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
+        Λ (⟨J', h, β⟩ : IsingParams ℝ) i n) :=
+  Ambient.magnetizationAlongExhaustion_continuous_J
+    (IsingModel.latticeGraph d) Λ h β i n
+
+/-- **ℤ^d along-ex: magnetization Differentiable in `J`**. -/
+theorem magnetizationAlongExhaustion_latticeGraph_differentiable_J
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet] (h β : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    Differentiable ℝ (fun J' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
+        Λ (⟨J', h, β⟩ : IsingParams ℝ) i n) :=
+  Ambient.magnetizationAlongExhaustion_differentiable_J
+    (IsingModel.latticeGraph d) Λ h β i n
+
+end Ambient
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationRegularity.lean
@@ -103,5 +103,32 @@ theorem magnetizationAlongExhaustion_latticeGraph_differentiable_J
   Ambient.magnetizationAlongExhaustion_differentiable_J
     (IsingModel.latticeGraph d) Λ h β i n
 
+/-! ### ℤ^d along-ex `magnetizationAlongExhaustion` β-direction
+Continuous/Differentiable wrappers (general h) -/
+
+/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` Continuous in β** (general h). -/
+theorem magnetizationAlongExhaustion_latticeGraph_continuous_beta
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    Continuous (fun β' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
+        Λ (⟨J, h, β'⟩ : IsingParams ℝ) i n) :=
+  Ambient.magnetizationAlongExhaustion_continuous_beta
+    (IsingModel.latticeGraph d) Λ J h i n
+
+/-- **ℤ^d along-ex: `magnetizationAlongExhaustion` Differentiable in β** (general h). -/
+theorem magnetizationAlongExhaustion_latticeGraph_differentiable_beta
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (inducedGraph (IsingModel.latticeGraph d)
+      (Λ.volume n)).edgeSet]
+    (J h : ℝ) (i : Fin d → ℤ) (n : ℕ) :
+    Differentiable ℝ (fun β' =>
+      Ambient.magnetizationAlongExhaustion (IsingModel.latticeGraph d)
+        Λ (⟨J, h, β'⟩ : IsingParams ℝ) i n) :=
+  Ambient.magnetizationAlongExhaustion_differentiable_beta
+    (IsingModel.latticeGraph d) Λ J h i n
+
 end Ambient
 end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ View* (2nd ed., 1987).
 > concrete J-direction `correlationAlongExhaustion` pointwise wrappers,
 > `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationPointwiseRegularity`
 > for concrete per-parameter `magnetizationAlongExhaustion` pointwise wrappers,
+> `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationRegularity` for
+> concrete magnetization regularity wrappers,
 > `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyPointwiseRegularity`
 > for concrete per-parameter `partitionFunctionAlongExhaustion` /
 > `freeEnergyAlongExhaustion` pointwise wrappers,
@@ -152,6 +154,8 @@ View* (2nd ed., 1987).
 > `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity` for ambient
 > along-exhaustion `mayerPartialSum` / `mayerExpansionTerm` /
 > `vdPolymerFamilies_sum` regularity wrappers,
+> `IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity` for ambient
+> along-exhaustion magnetization regularity wrappers,
 > `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyAnalyticity` for
 > ambient along-exhaustion `polymerFreeEnergy` analytic wrappers,
 > `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyBasic` for ambient

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4688,6 +4688,10 @@ The along-exhaustion and concrete $\mathbb{Z}^d$ Mayer filter-connected and
 epsilon-power wrappers now live in matching
 \texttt{MayerFilterConnected.lean} child modules; the $\Lambda$-layer wrappers
 remain in \texttt{IsingModel/AmbientLattice/Analyticity.lean}.
+The along-exhaustion and concrete $\mathbb{Z}^d$ magnetization regularity
+wrappers now live in matching \texttt{MagnetizationRegularity.lean} child
+modules; the $\Lambda$-layer wrappers remain in
+\texttt{IsingModel/AmbientLattice/Defs.lean}.
 The analogous \texttt{freeEnergy} per-direction analyticity wrappers
 now live in matching \texttt{FreeEnergyAnalyticity.lean} child modules;
 their $\Lambda$-layer wrappers remain in


### PR DESCRIPTION
Part of #1850.

## Summary

- split finite-stage magnetization regularity wrappers into ambient and concrete `MagnetizationRegularity` child modules
- keep Legacy and umbrella re-export paths intact through imports
- update module-location notes in `docs/index.md` and `tex/proof-guide.tex`

## Verification

- `lake build IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity`
- `lake build IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationRegularity`
- `lake build IsingModel.AmbientLattice.SpecialCases.Legacy`
- `lake build IsingModel.Concrete.LatticeGraphCorrelation.Legacy`
- `lake build IsingModel.AmbientLattice.SpecialCases`
- `lake build IsingModel.Concrete.LatticeGraphCorrelation`
- `lake exe GKSTest`
- `lake build`
- `rg -n "sorry" IsingModel`
- `rg -n "[ぁ-んァ-ヶ一-龠々〆〤]" tex/proof-guide.tex`
- `git diff --check`
- `latexmk -lualatex -f -interaction=nonstopmode proof-guide.tex`
