### PR TITLE
Add mailmap for canonical contributor identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+# Map accidental local author identities to the canonical project account.
+phasetr <phasetr@gmail.com> <yoshitsugu.sekine@offisis.co.jp>


### PR DESCRIPTION
## Summary

- add a repository-level `.mailmap` entry mapping the accidental offisis author email to the canonical `phasetr <phasetr@gmail.com>` identity
- prevent contributor aggregation from splitting the project author identity

## Verification

- `git check-mailmap 'Yoshitsugu Sekine <yoshitsugu.sekine@offisis.co.jp>'`
- `git shortlog -sne --all`
- `git diff --check`

No Lean build was run because this only changes Git author metadata normalization.
