### PR TITLE
Clean up empty legacy re-export shims

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -3,9 +3,10 @@ import IsingModel.AmbientLattice.SpecialCases.Legacy
 /-!
 # Ambient-lattice special cases umbrella
 
-This module is intentionally a thin re-export. The legacy monolithic body lives
-in `IsingModel.AmbientLattice.SpecialCases.Legacy`. Non-analytic free-energy
-special cases live in `IsingModel.AmbientLattice.SpecialCases.FreeEnergy`, and
+This module is intentionally a thin re-export. The compatibility shim
+`IsingModel.AmbientLattice.SpecialCases.Legacy` re-exports the split child
+modules for older import paths. Non-analytic free-energy special cases live in
+`IsingModel.AmbientLattice.SpecialCases.FreeEnergy`, and
 general-graph free-energy per-direction analyticity wrappers live in
 `IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity`. Lightweight
 infinite-volume aliases live in

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -41,25 +41,10 @@ import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticity
 import IsingModel.AmbientLattice.Analyticity
 
 /-!
-# Special-case closed forms, h-symmetry, and critical exponents
+# Ambient special-case legacy re-export
 
-Uniform upper bounds (BoundedEdgeDensity), closed forms for special
-parameter slices (β=0, J=h=0, J=0), h-symmetry / |h|-monotonicity
-along an exhaustion, and the critical exponent bounds η≥0, ζ≥0
-at infinite volume (GJ §17.7 Thm 17.7.1).
-
-## References
-
-* Glimm–Jaffe, *Quantum Physics*, §4.6, §17.7.
+This module is intentionally a compatibility shim. The former monolithic
+special-case theorem bodies have been split into child modules imported above.
+New code should import the narrow child modules or
+`IsingModel.AmbientLattice.SpecialCases`.
 -/
-
-namespace IsingModel
-namespace Ambient
-
-open Finset Real
-open scoped symmDiff
-
-variable {V : Type*} [DecidableEq V]
-
-end Ambient
-end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -3,10 +3,11 @@ import IsingModel.Concrete.LatticeGraphCorrelation.Legacy
 /-!
 # Concrete correlation umbrella for the ℤ^d Ising model
 
-This module is intentionally a thin re-export. The legacy monolithic
-implementation lives in `IsingModel.Concrete.LatticeGraphCorrelation.Legacy`;
-new narrow APIs should be added in dedicated child modules and re-exported
-here only when they belong to the public concrete correlation surface. For
+This module is intentionally a thin re-export. The compatibility shim
+`IsingModel.Concrete.LatticeGraphCorrelation.Legacy` re-exports the split child
+modules for older import paths. New narrow APIs should be added in dedicated
+child modules and re-exported here only when they belong to the public concrete
+correlation surface. For
 concrete finite-volume graph, spin-algebra, bottom-graph, and Hamiltonian
 symmetry wrappers, import
 `IsingModel.Concrete.LatticeGraphCorrelation.FiniteVolumeBasics` directly. For

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -80,38 +80,10 @@ import IsingModel.AmbientFKG
 import IsingModel.AmbientLattice.SpecialCases.Legacy
 
 /-!
-# Concrete translation invariance for the ℤ^d Ising correlation
+# Concrete lattice-graph correlation legacy re-export
 
-Apply the abstract `correlationInfinite_vaddFinset_of_translationInvariant`
-theorem (`TranslationInvariance.lean`, PR #251) to the physical
-`d`-dimensional Ising setup
-`(IsingModel.latticeGraph d, Ambient.cubicExhaustion d)`:
-
-* `isTranslationInvariant_latticeGraph` (PR #244) supplies the
-  `IsTranslationInvariant (Fin d → ℤ) (latticeGraph d)` instance.
-* `cubicExhaustion d` (PR #245) supplies the ambient exhaustion.
-* The `Fintype (inducedGraph (latticeGraph d) Λ).edgeSet` instance
-  (PR #246) supplies the Fintype hypothesis for arbitrary `Λ`.
-
-## Main theorems
-
-* `correlationInfinite_latticeGraph_cubicExhaustion_vaddFinset`:
-  `correlationInfinite (latticeGraph d) (cubicExhaustion d) p
-  (vaddFinset t A) = correlationInfinite ... p A` (ferromagnetic).
-* `magnetizationInfinite_latticeGraph_cubicExhaustion_translation`:
-  single-site specialization.
-
-## References
-
-* Glimm–Jaffe, *Quantum Physics* 2nd ed., §4.6, p. 68.
+This module is intentionally a compatibility shim. The former monolithic
+theorem bodies have been split into child modules imported above. New code
+should import the narrow child modules or
+`IsingModel.Concrete.LatticeGraphCorrelation`.
 -/
-
-open scoped symmDiff
-
-namespace IsingModel
-
-namespace Ambient
-
-end Ambient
-
-end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,10 +21,11 @@ View* (2nd ed., 1987).
 >
 > **Import note:** `IsingModel.Concrete.LatticeGraphCorrelation` and
 > `IsingModel.AmbientLattice.SpecialCases` are thin public re-exports. Their
-> pre-existing monolithic bodies live in
+> legacy compatibility shims are
 > `IsingModel.Concrete.LatticeGraphCorrelation.Legacy` and
-> `IsingModel.AmbientLattice.SpecialCases.Legacy`. New narrow APIs should
-> prefer dedicated child modules such as
+> `IsingModel.AmbientLattice.SpecialCases.Legacy`; those shims re-export the
+> split child modules for older import paths. New narrow APIs should prefer
+> dedicated child modules such as
 > `IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay`,
 > `IsingModel.Concrete.LatticeGraphCorrelation.Peierls` for concrete Peierls
 > along-exhaustion wrappers,


### PR DESCRIPTION
## Summary

- clean up stale module docs in the now-empty concrete and ambient legacy re-export shims
- remove empty namespace/open scaffolding that no longer declares anything
- preserve the existing import lists for compatibility

## Verification

- `lake build IsingModel.Concrete.LatticeGraphCorrelation.Legacy`
- `lake build IsingModel.AmbientLattice.SpecialCases.Legacy`
- `lake build IsingModel.Concrete.LatticeGraphCorrelation`
- `lake build IsingModel.AmbientLattice.SpecialCases`
- `lake build`
- concrete Legacy import smoke tests
- ambient SpecialCases Legacy import smoke tests
- `git diff --check`
