### PR TITLE
Split concrete Complex.lean per-direction analyticity wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -241,7 +241,12 @@ wrappers at `h = 0` (pair nonneg, pair `≤ 1`, singleton / pair trivial-slice
 vanishings at `J = 0` and `β = 0`, pair sandwich, singleton / pair
 ferromagnetic, singleton `= 0 ∧ ≤ 1`, pair+singleton bundle), import
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsCorrelationBasic`
-directly. For concrete §18.3-§18.4 `freeEnergyInfinite` high-temperature wrappers
+directly. For concrete per-direction real / complex analyticity wrappers
+(`partitionFunction*` / `freeEnergy*` `analyticAt`/`analyticOn` in
+`h`, `J`, `β`, plus joint analyticity -- 12 theorems), import
+`IsingModel.Concrete.LatticeGraphCorrelation.ComplexAnalyticityBasic`
+directly.
+For concrete §18.3-§18.4 `freeEnergyInfinite` high-temperature wrappers
 on `latticeGraph d` (10 theorems: `upper_bound_exp_uniform`,
 `upper_bound_exp`, `sandwich_exp`, `complete_summary_exp`,
 `deviation_bound_exp`, `continuity_at_J_zero`,

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Complex.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Complex.lean
@@ -1,6 +1,7 @@
 import IsingModel.Concrete.LatticeGraphBED
 import IsingModel.ComplexAnalyticity
 import IsingModel.AmbientComplexAnalyticity
+import IsingModel.Concrete.LatticeGraphCorrelation.ComplexAnalyticityBasic
 
 /-!
 # ℤ^d real/complex analyticity wrappers (fixed-Λ)
@@ -30,133 +31,15 @@ namespace IsingModel
 
 namespace Ambient
 
-/-- **ℤ^d `partitionFunction` analytic in `h`** at Λ-induced subgraph. -/
-theorem partitionFunctionH_analyticAt_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℝ) :
-    AnalyticAt ℝ
-      (fun h => partitionFunctionΛ (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩) h₀ :=
-  IsingModel.partitionFunctionH_analyticAt
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀
+/-! ## Moved: per-direction analyticity wrappers (real and complex)
 
-/-- **ℤ^d `freeEnergyH` analytic on `(0, ∞)`** at Λ-induced subgraph. -/
-theorem freeEnergyH_analyticOn_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ) :
-    AnalyticOn ℝ
-      (IsingModel.freeEnergyH
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β)
-      (Set.Ioi 0) :=
-  IsingModel.freeEnergyH_analyticOn
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β
+The 12 concrete per-direction `analyticAt` / `analyticOn` wrappers
+for `partitionFunction*` / `freeEnergy*` in `h`, `J`, `β` (plus joint
+analyticity) now live in
+`IsingModel.Concrete.LatticeGraphCorrelation.ComplexAnalyticityBasic`.
+The legacy import path is preserved by re-importing the new child.
+-/
 
-/-- **ℤ^d `partitionFunction` analytic in `J`** at Λ-induced subgraph. -/
-theorem partitionFunctionJ_analyticAt_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β J₀ : ℝ) :
-    AnalyticAt ℝ
-      (fun J => partitionFunctionΛ (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩) J₀ :=
-  IsingModel.partitionFunctionJ_analyticAt
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β J₀
-
-/-- **ℤ^d `freeEnergyJ` analytic on `(0, ∞)`** at Λ-induced subgraph. -/
-theorem freeEnergyJ_analyticOn_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β : ℝ) :
-    AnalyticOn ℝ
-      (IsingModel.freeEnergyJ
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β)
-      (Set.Ioi 0) :=
-  IsingModel.freeEnergyJ_analyticOn
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β
-
-/-! #### Complex analyticity (GJ §4.6 Thm 4.6.2)
-
-Direct ℤ^d forwarders for the complex-analyticity package in
-`IsingModel/ComplexAnalyticity.lean`: per-variable / joint entire
-analyticity of `partitionFunctionComplex`, its `slitPlane`-conditioned
-`freeEnergyComplex` counterpart, and the real-complex compatibility
-identities. -/
-
-/-- **ℤ^d `partitionFunctionComplex` entire in `h`** (Λ-induced). -/
-theorem partitionFunctionComplex_analyticAt_h_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℂ) :
-    AnalyticAt ℂ (fun h => IsingModel.partitionFunctionComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) h₀ :=
-  IsingModel.partitionFunctionComplex_analyticAt_h
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀
-
-/-- **ℤ^d `partitionFunctionComplex` entire in `J`** (Λ-induced). -/
-theorem partitionFunctionComplex_analyticAt_J_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β J₀ : ℂ) :
-    AnalyticAt ℂ (fun J => IsingModel.partitionFunctionComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) J₀ :=
-  IsingModel.partitionFunctionComplex_analyticAt_J
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β J₀
-
-/-- **ℤ^d `partitionFunctionComplex` entire in `β`** (Λ-induced). -/
-theorem partitionFunctionComplex_analyticAt_beta_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β₀ : ℂ) :
-    AnalyticAt ℂ (fun β => IsingModel.partitionFunctionComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) β₀ :=
-  IsingModel.partitionFunctionComplex_analyticAt_beta
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀
-
-/-- **ℤ^d `freeEnergyComplex` analytic in `h`** (Λ-induced), on
-`{Z ∈ slitPlane}`. -/
-theorem freeEnergyComplex_analyticAt_h_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℂ)
-    (hZ : IsingModel.partitionFunctionComplex
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h₀ β
-          ∈ Complex.slitPlane) :
-    AnalyticAt ℂ (fun h => IsingModel.freeEnergyComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) h₀ :=
-  IsingModel.freeEnergyComplex_analyticAt_h
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀ hZ
-
-/-- **ℤ^d `freeEnergyComplex` analytic in `J`** (Λ-induced), on
-`{Z ∈ slitPlane}`. -/
-theorem freeEnergyComplex_analyticAt_J_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β J₀ : ℂ)
-    (hZ : IsingModel.partitionFunctionComplex
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J₀ h β
-          ∈ Complex.slitPlane) :
-    AnalyticAt ℂ (fun J => IsingModel.freeEnergyComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) J₀ :=
-  IsingModel.freeEnergyComplex_analyticAt_J
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β J₀ hZ
-
-/-- **ℤ^d `freeEnergyComplex` analytic in `β`** (Λ-induced), on
-`{Z ∈ slitPlane}`. -/
-theorem freeEnergyComplex_analyticAt_beta_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β₀ : ℂ)
-    (hZ : IsingModel.partitionFunctionComplex
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀
-          ∈ Complex.slitPlane) :
-    AnalyticAt ℂ (fun β => IsingModel.freeEnergyComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) β₀ :=
-  IsingModel.freeEnergyComplex_analyticAt_beta
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀ hZ
-
-/-- **ℤ^d `partitionFunctionComplex` jointly entire in `(J, h, β)`**
-(Λ-induced). -/
-theorem partitionFunctionComplex_analyticAt_joint_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (z₀ : ℂ × ℂ × ℂ) :
-    AnalyticAt ℂ (fun z : ℂ × ℂ × ℂ =>
-      IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2) z₀ :=
-  IsingModel.partitionFunctionComplex_analyticAt_joint
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z₀
-
-/-- **ℤ^d `freeEnergyComplex` jointly analytic** (Λ-induced), on
-`{Z ∈ slitPlane}`. -/
-theorem freeEnergyComplex_analyticAt_joint_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (z₀ : ℂ × ℂ × ℂ)
-    (hZ : IsingModel.partitionFunctionComplex
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-            z₀.1 z₀.2.1 z₀.2.2
-          ∈ Complex.slitPlane) :
-    AnalyticAt ℂ (fun z : ℂ × ℂ × ℂ =>
-      IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2) z₀ :=
-  IsingModel.freeEnergyComplex_analyticAt_joint
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z₀ hZ
 
 /-- **ℤ^d `partitionFunction` / `partitionFunctionComplex` real-complex
 compatibility** (Λ-induced):

--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexAnalyticityBasic.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexAnalyticityBasic.lean
@@ -1,0 +1,149 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.ComplexAnalyticity
+import IsingModel.AmbientComplexAnalyticity
+
+/-!
+# Concrete per-direction analyticity wrappers (real and complex)
+
+Narrow child module for the per-direction real and complex analyticity
+wrappers on `latticeGraph d`. 12 theorems for `partitionFunction*` /
+`freeEnergy*` `analyticAt`/`analyticOn` in `h`, `J`, `β`, plus joint
+analyticity wrappers. The theorem names are unchanged from the former
+`Complex` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+
+/-- **ℤ^d `partitionFunction` analytic in `h`** at Λ-induced subgraph. -/
+theorem partitionFunctionH_analyticAt_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℝ) :
+    AnalyticAt ℝ
+      (fun h => partitionFunctionΛ (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩) h₀ :=
+  IsingModel.partitionFunctionH_analyticAt
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀
+
+/-- **ℤ^d `freeEnergyH` analytic on `(0, ∞)`** at Λ-induced subgraph. -/
+theorem freeEnergyH_analyticOn_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ) :
+    AnalyticOn ℝ
+      (IsingModel.freeEnergyH
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β)
+      (Set.Ioi 0) :=
+  IsingModel.freeEnergyH_analyticOn
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β
+
+/-- **ℤ^d `partitionFunction` analytic in `J`** at Λ-induced subgraph. -/
+theorem partitionFunctionJ_analyticAt_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β J₀ : ℝ) :
+    AnalyticAt ℝ
+      (fun J => partitionFunctionΛ (IsingModel.latticeGraph d) Λ ⟨J, h, β⟩) J₀ :=
+  IsingModel.partitionFunctionJ_analyticAt
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β J₀
+
+/-- **ℤ^d `freeEnergyJ` analytic on `(0, ∞)`** at Λ-induced subgraph. -/
+theorem freeEnergyJ_analyticOn_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β : ℝ) :
+    AnalyticOn ℝ
+      (IsingModel.freeEnergyJ
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β)
+      (Set.Ioi 0) :=
+  IsingModel.freeEnergyJ_analyticOn
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β
+
+/-! #### Complex analyticity (GJ §4.6 Thm 4.6.2)
+
+Direct ℤ^d forwarders for the complex-analyticity package in
+`IsingModel/ComplexAnalyticity.lean`: per-variable / joint entire
+analyticity of `partitionFunctionComplex`, its `slitPlane`-conditioned
+`freeEnergyComplex` counterpart, and the real-complex compatibility
+identities. -/
+
+/-- **ℤ^d `partitionFunctionComplex` entire in `h`** (Λ-induced). -/
+theorem partitionFunctionComplex_analyticAt_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℂ) :
+    AnalyticAt ℂ (fun h => IsingModel.partitionFunctionComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) h₀ :=
+  IsingModel.partitionFunctionComplex_analyticAt_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀
+
+/-- **ℤ^d `partitionFunctionComplex` entire in `J`** (Λ-induced). -/
+theorem partitionFunctionComplex_analyticAt_J_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β J₀ : ℂ) :
+    AnalyticAt ℂ (fun J => IsingModel.partitionFunctionComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) J₀ :=
+  IsingModel.partitionFunctionComplex_analyticAt_J
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β J₀
+
+/-- **ℤ^d `partitionFunctionComplex` entire in `β`** (Λ-induced). -/
+theorem partitionFunctionComplex_analyticAt_beta_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β₀ : ℂ) :
+    AnalyticAt ℂ (fun β => IsingModel.partitionFunctionComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) β₀ :=
+  IsingModel.partitionFunctionComplex_analyticAt_beta
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀
+
+/-- **ℤ^d `freeEnergyComplex` analytic in `h`** (Λ-induced), on
+`{Z ∈ slitPlane}`. -/
+theorem freeEnergyComplex_analyticAt_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℂ)
+    (hZ : IsingModel.partitionFunctionComplex
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h₀ β
+          ∈ Complex.slitPlane) :
+    AnalyticAt ℂ (fun h => IsingModel.freeEnergyComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) h₀ :=
+  IsingModel.freeEnergyComplex_analyticAt_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀ hZ
+
+/-- **ℤ^d `freeEnergyComplex` analytic in `J`** (Λ-induced), on
+`{Z ∈ slitPlane}`. -/
+theorem freeEnergyComplex_analyticAt_J_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β J₀ : ℂ)
+    (hZ : IsingModel.partitionFunctionComplex
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J₀ h β
+          ∈ Complex.slitPlane) :
+    AnalyticAt ℂ (fun J => IsingModel.freeEnergyComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) J₀ :=
+  IsingModel.freeEnergyComplex_analyticAt_J
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β J₀ hZ
+
+/-- **ℤ^d `freeEnergyComplex` analytic in `β`** (Λ-induced), on
+`{Z ∈ slitPlane}`. -/
+theorem freeEnergyComplex_analyticAt_beta_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β₀ : ℂ)
+    (hZ : IsingModel.partitionFunctionComplex
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀
+          ∈ Complex.slitPlane) :
+    AnalyticAt ℂ (fun β => IsingModel.freeEnergyComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) β₀ :=
+  IsingModel.freeEnergyComplex_analyticAt_beta
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀ hZ
+
+/-- **ℤ^d `partitionFunctionComplex` jointly entire in `(J, h, β)`**
+(Λ-induced). -/
+theorem partitionFunctionComplex_analyticAt_joint_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (z₀ : ℂ × ℂ × ℂ) :
+    AnalyticAt ℂ (fun z : ℂ × ℂ × ℂ =>
+      IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2) z₀ :=
+  IsingModel.partitionFunctionComplex_analyticAt_joint
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z₀
+
+/-- **ℤ^d `freeEnergyComplex` jointly analytic** (Λ-induced), on
+`{Z ∈ slitPlane}`. -/
+theorem freeEnergyComplex_analyticAt_joint_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (z₀ : ℂ × ℂ × ℂ)
+    (hZ : IsingModel.partitionFunctionComplex
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+            z₀.1 z₀.2.1 z₀.2.2
+          ∈ Complex.slitPlane) :
+    AnalyticAt ℂ (fun z : ℂ × ℂ × ℂ =>
+      IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2) z₀ :=
+  IsingModel.freeEnergyComplex_analyticAt_joint
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z₀ hZ
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -1,6 +1,7 @@
 import IsingModel.Concrete.LatticeGraphBED
 import IsingModel.Concrete.IntLattice
 import IsingModel.Concrete.LatticeGraphCorrelation.Complex
+import IsingModel.Concrete.LatticeGraphCorrelation.ComplexAnalyticityBasic
 import IsingModel.Concrete.LatticeGraphCorrelation.PerStage
 import IsingModel.Concrete.LatticeGraphCorrelation.Magnetization
 import IsingModel.Concrete.LatticeGraphCorrelation.TwoPoint


### PR DESCRIPTION
Part of #1850

Move 12 concrete per-direction analyticity wrappers (real partitionFunctionH/J + freeEnergyH/J + complex partitionFunctionComplex_analyticAt_h/J/beta + freeEnergyComplex_analyticAt_h/J/beta + joint variants) from Concrete/LatticeGraphCorrelation/Complex.lean (1490 lines) into a new child ComplexAnalyticityBasic.lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)