### PR TITLE
Split Complex.lean analyticBranch + entire wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation.lean
@@ -241,7 +241,15 @@ wrappers at `h = 0` (pair nonneg, pair `≤ 1`, singleton / pair trivial-slice
 vanishings at `J = 0` and `β = 0`, pair sandwich, singleton / pair
 ferromagnetic, singleton `= 0 ∧ ≤ 1`, pair+singleton bundle), import
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsCorrelationBasic`
-directly. For concrete leeYangSubdomain ⊆ slitPlane locus inclusions and real-axis
+directly. For concrete analyticBranch + Differentiable ℂ entire wrappers
+(`leeYangDomain_subset_branch_locus`,
+`freeEnergyComplex_exists_analyticBranch*`,
+`analyticBranch_freeEnergyComplex_*`,
+`continuous_freeEnergyComplex_on_locus`,
+`partitionFunctionComplex_entire_*` -- 12 theorems), import
+`IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranchEntire`
+directly.
+For concrete leeYangSubdomain ⊆ slitPlane locus inclusions and real-axis
 restriction identities (16 theorems), import
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexRestrictions` directly.
 For concrete slitPlane-locus continuity / analyticOn / differentiableOn

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Complex.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Complex.lean
@@ -7,6 +7,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.ComplexContinuityNorm
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranches
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexSlitPlane
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRestrictions
+import IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranchEntire
 
 /-!
 # ℤ^d real/complex analyticity wrappers (fixed-Λ)
@@ -115,154 +116,18 @@ real-axis restriction identities now live in
 The legacy import path is preserved by re-importing the new child.
 -/
 
-/-! #### Packaged analyticBranch form + Differentiable ℂ entire +
-joint real continuity -/
+/-! ## Moved: analyticBranch + entire wrappers
 
-/-- **ℤ^d GJ §4.6 Thm 4.6.2 finite-volume (symbolic branch-locus form)**
-(Λ-induced, nonempty `Λ`, ferromagnetic). -/
-theorem leeYangDomain_subset_branch_locus_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Nonempty (↑Λ : Type _)]
-    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) :
-    ∀ h ∈ IsingModel.leeYangDomain,
-      ∃ f : ℂ → ℂ, AnalyticAt ℂ f h ∧
-        Complex.exp ((Fintype.card (↑Λ : Type _) : ℂ) * f h)
-          = IsingModel.partitionFunctionComplex
-              (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-              (J : ℂ) h (β : ℂ) :=
-  IsingModel.leeYangDomain_subset_branch_locus
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
+The 12 concrete `leeYangDomain_subset_branch_locus`,
+`freeEnergyComplex_exists_analyticBranch*`,
+`analyticBranch_freeEnergyComplex_*`,
+`continuous_freeEnergyComplex_on_locus`,
+`continuousAt/differentiableAt_freeEnergyComplex_at_real_joint`, and
+`partitionFunctionComplex_entire_*` wrappers now live in
+`IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranchEntire`.
+The legacy import path is preserved by re-importing the new child.
+-/
 
-/-- **ℤ^d `freeEnergyComplex` has analytic branch over leeYangDomain**
-(Λ-induced, nonempty `Λ`, ferromagnetic): headline form. -/
-theorem freeEnergyComplex_exists_analyticBranch_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Nonempty (↑Λ : Type _)]
-    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) :
-    ∀ h ∈ IsingModel.leeYangDomain, ∃ f : ℂ → ℂ, AnalyticAt ℂ f h ∧
-        Complex.exp ((Fintype.card (↑Λ : Type _) : ℂ) * f h)
-          = IsingModel.partitionFunctionComplex
-              (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-              (J : ℂ) h (β : ℂ) :=
-  IsingModel.freeEnergyComplex_exists_analyticBranch
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
-
-/-- **ℤ^d `freeEnergyComplex` analyticBranch (strong form)**
-(Λ-induced, nonempty `Λ`, ferromagnetic): additionally identifies the
-branch value at the basepoint with the principal-branch
-`freeEnergyComplex`. -/
-theorem freeEnergyComplex_exists_analyticBranch_strong_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Nonempty (↑Λ : Type _)]
-    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) :
-    ∀ h ∈ IsingModel.leeYangDomain, ∃ f : ℂ → ℂ,
-        AnalyticAt ℂ f h
-      ∧ Complex.exp ((Fintype.card (↑Λ : Type _) : ℂ) * f h)
-          = IsingModel.partitionFunctionComplex
-              (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-              (J : ℂ) h (β : ℂ)
-      ∧ f h = IsingModel.freeEnergyComplex
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-          (J : ℂ) h (β : ℂ) :=
-  IsingModel.freeEnergyComplex_exists_analyticBranch_strong
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
-
-/-- **ℤ^d GJ §4.6 Thm 4.6.2 finite-volume (`analyticBranch` packaged form
-over `leeYangDomain`)** (Λ-induced, nonempty `Λ`, ferromagnetic). -/
-theorem analyticBranch_freeEnergyComplex_leeYangDomain_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    [Nonempty (↑Λ : Type _)]
-    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) :
-    ∀ h₀ ∈ IsingModel.leeYangDomain,
-      ∃ f : ℂ → ℂ,
-          AnalyticAt ℂ f h₀
-        ∧ Complex.exp ((Fintype.card (↑Λ : Type _) : ℂ) * f h₀)
-            = IsingModel.partitionFunctionComplex
-                (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-                (J : ℂ) h₀ (β : ℂ)
-        ∧ f h₀ = IsingModel.freeEnergyComplex
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-            (J : ℂ) h₀ (β : ℂ) :=
-  IsingModel.analyticBranch_freeEnergyComplex_leeYangDomain
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
-
-/-- **ℤ^d packaged `AnalyticOnNhd` on Lee-Yang subdomain** (Λ-induced,
-ferromagnetic `β > 0`). -/
-theorem freeEnergyComplex_analyticOnNhd_of_leeYangSubdomain_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    {β : ℝ} (hβ : 0 < β) (J : ℝ) :
-    AnalyticOnNhd ℂ (fun h => IsingModel.freeEnergyComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) (J : ℂ) h (β : ℂ))
-      (IsingModel.leeYangSubdomain β (Fintype.card (↑Λ : Type _))) :=
-  IsingModel.freeEnergyComplex_analyticOnNhd_of_leeYangSubdomain
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ J
-
-/-- **ℤ^d `ContinuousOn` joint slitPlane locus (packaged alias)**
-(Λ-induced). -/
-theorem continuous_freeEnergyComplex_on_locus_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) :
-    ContinuousOn
-      (fun z : ℂ × ℂ × ℂ => IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2)
-      {z : ℂ × ℂ × ℂ | IsingModel.partitionFunctionComplex
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2
-        ∈ Complex.slitPlane} :=
-  IsingModel.continuous_freeEnergyComplex_on_locus
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-
-/-- **ℤ^d joint `ContinuousAt` at real parameters** (Λ-induced). -/
-theorem continuousAt_freeEnergyComplex_at_real_joint_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    ContinuousAt
-      (fun z : ℂ × ℂ × ℂ => IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2)
-      ((p.J : ℂ), (p.h : ℂ), (p.β : ℂ)) :=
-  IsingModel.continuousAt_freeEnergyComplex_at_real_joint
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d joint `DifferentiableAt` at real parameters** (Λ-induced). -/
-theorem differentiableAt_freeEnergyComplex_at_real_joint_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    DifferentiableAt ℂ
-      (fun z : ℂ × ℂ × ℂ => IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2)
-      ((p.J : ℂ), (p.h : ℂ), (p.β : ℂ)) :=
-  IsingModel.differentiableAt_freeEnergyComplex_at_real_joint
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d `Z_ℂ` entire in `h` (Differentiable ℂ)** (Λ-induced). -/
-theorem partitionFunctionComplex_entire_h_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℂ) :
-    Differentiable ℂ (fun h => IsingModel.partitionFunctionComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) :=
-  IsingModel.partitionFunctionComplex_entire_h
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β
-
-/-- **ℤ^d `Z_ℂ` entire in `J` (Differentiable ℂ)** (Λ-induced). -/
-theorem partitionFunctionComplex_entire_J_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β : ℂ) :
-    Differentiable ℂ (fun J => IsingModel.partitionFunctionComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) :=
-  IsingModel.partitionFunctionComplex_entire_J
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β
-
-/-- **ℤ^d `Z_ℂ` entire in `β` (Differentiable ℂ)** (Λ-induced). -/
-theorem partitionFunctionComplex_entire_beta_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h : ℂ) :
-    Differentiable ℂ (fun β => IsingModel.partitionFunctionComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) :=
-  IsingModel.partitionFunctionComplex_entire_beta
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h
-
-/-- **ℤ^d `Z_ℂ` jointly entire on ℂ³ (Differentiable ℂ)**
-(Λ-induced). -/
-theorem partitionFunctionComplex_entire_joint_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) :
-    Differentiable ℂ
-      (fun z : ℂ × ℂ × ℂ => IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2) :=
-  IsingModel.partitionFunctionComplex_entire_joint
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
 
 /-- **ℤ^d `‖Z_ℂ‖ = Z_ℝ` at real parameters (alias)** (Λ-induced). -/
 theorem norm_partitionFunctionComplex_eq_partitionFunction_at_real_latticeGraph

--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexBranchEntire.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexBranchEntire.lean
@@ -1,0 +1,168 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.ComplexAnalyticity
+import IsingModel.AmbientComplexAnalyticity
+
+/-!
+# Concrete Complex analyticBranch + entire wrappers
+
+Narrow child module for concrete `leeYangDomain_subset_branch_locus`,
+`freeEnergyComplex_exists_analyticBranch*`, `analyticBranch_freeEnergyComplex_*`,
+`continuous_freeEnergyComplex_on_locus`,
+`continuousAt/differentiableAt_freeEnergyComplex_at_real_joint`, and
+`partitionFunctionComplex_entire_*` wrappers on `latticeGraph d`. 12
+theorems. The theorem names are unchanged from the former `Complex`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d GJ §4.6 Thm 4.6.2 finite-volume (symbolic branch-locus form)**
+(Λ-induced, nonempty `Λ`, ferromagnetic). -/
+theorem leeYangDomain_subset_branch_locus_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Nonempty (↑Λ : Type _)]
+    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) :
+    ∀ h ∈ IsingModel.leeYangDomain,
+      ∃ f : ℂ → ℂ, AnalyticAt ℂ f h ∧
+        Complex.exp ((Fintype.card (↑Λ : Type _) : ℂ) * f h)
+          = IsingModel.partitionFunctionComplex
+              (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+              (J : ℂ) h (β : ℂ) :=
+  IsingModel.leeYangDomain_subset_branch_locus
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
+
+/-- **ℤ^d `freeEnergyComplex` has analytic branch over leeYangDomain**
+(Λ-induced, nonempty `Λ`, ferromagnetic): headline form. -/
+theorem freeEnergyComplex_exists_analyticBranch_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Nonempty (↑Λ : Type _)]
+    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) :
+    ∀ h ∈ IsingModel.leeYangDomain, ∃ f : ℂ → ℂ, AnalyticAt ℂ f h ∧
+        Complex.exp ((Fintype.card (↑Λ : Type _) : ℂ) * f h)
+          = IsingModel.partitionFunctionComplex
+              (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+              (J : ℂ) h (β : ℂ) :=
+  IsingModel.freeEnergyComplex_exists_analyticBranch
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
+
+/-- **ℤ^d `freeEnergyComplex` analyticBranch (strong form)**
+(Λ-induced, nonempty `Λ`, ferromagnetic): additionally identifies the
+branch value at the basepoint with the principal-branch
+`freeEnergyComplex`. -/
+theorem freeEnergyComplex_exists_analyticBranch_strong_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Nonempty (↑Λ : Type _)]
+    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) :
+    ∀ h ∈ IsingModel.leeYangDomain, ∃ f : ℂ → ℂ,
+        AnalyticAt ℂ f h
+      ∧ Complex.exp ((Fintype.card (↑Λ : Type _) : ℂ) * f h)
+          = IsingModel.partitionFunctionComplex
+              (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+              (J : ℂ) h (β : ℂ)
+      ∧ f h = IsingModel.freeEnergyComplex
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (J : ℂ) h (β : ℂ) :=
+  IsingModel.freeEnergyComplex_exists_analyticBranch_strong
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
+
+/-- **ℤ^d GJ §4.6 Thm 4.6.2 finite-volume (`analyticBranch` packaged form
+over `leeYangDomain`)** (Λ-induced, nonempty `Λ`, ferromagnetic). -/
+theorem analyticBranch_freeEnergyComplex_leeYangDomain_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    [Nonempty (↑Λ : Type _)]
+    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) :
+    ∀ h₀ ∈ IsingModel.leeYangDomain,
+      ∃ f : ℂ → ℂ,
+          AnalyticAt ℂ f h₀
+        ∧ Complex.exp ((Fintype.card (↑Λ : Type _) : ℂ) * f h₀)
+            = IsingModel.partitionFunctionComplex
+                (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+                (J : ℂ) h₀ (β : ℂ)
+        ∧ f h₀ = IsingModel.freeEnergyComplex
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+            (J : ℂ) h₀ (β : ℂ) :=
+  IsingModel.analyticBranch_freeEnergyComplex_leeYangDomain
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
+
+/-- **ℤ^d packaged `AnalyticOnNhd` on Lee-Yang subdomain** (Λ-induced,
+ferromagnetic `β > 0`). -/
+theorem freeEnergyComplex_analyticOnNhd_of_leeYangSubdomain_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    {β : ℝ} (hβ : 0 < β) (J : ℝ) :
+    AnalyticOnNhd ℂ (fun h => IsingModel.freeEnergyComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) (J : ℂ) h (β : ℂ))
+      (IsingModel.leeYangSubdomain β (Fintype.card (↑Λ : Type _))) :=
+  IsingModel.freeEnergyComplex_analyticOnNhd_of_leeYangSubdomain
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ J
+
+/-- **ℤ^d `ContinuousOn` joint slitPlane locus (packaged alias)**
+(Λ-induced). -/
+theorem continuous_freeEnergyComplex_on_locus_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) :
+    ContinuousOn
+      (fun z : ℂ × ℂ × ℂ => IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2)
+      {z : ℂ × ℂ × ℂ | IsingModel.partitionFunctionComplex
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2
+        ∈ Complex.slitPlane} :=
+  IsingModel.continuous_freeEnergyComplex_on_locus
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+
+/-- **ℤ^d joint `ContinuousAt` at real parameters** (Λ-induced). -/
+theorem continuousAt_freeEnergyComplex_at_real_joint_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    ContinuousAt
+      (fun z : ℂ × ℂ × ℂ => IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2)
+      ((p.J : ℂ), (p.h : ℂ), (p.β : ℂ)) :=
+  IsingModel.continuousAt_freeEnergyComplex_at_real_joint
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d joint `DifferentiableAt` at real parameters** (Λ-induced). -/
+theorem differentiableAt_freeEnergyComplex_at_real_joint_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    DifferentiableAt ℂ
+      (fun z : ℂ × ℂ × ℂ => IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2)
+      ((p.J : ℂ), (p.h : ℂ), (p.β : ℂ)) :=
+  IsingModel.differentiableAt_freeEnergyComplex_at_real_joint
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d `Z_ℂ` entire in `h` (Differentiable ℂ)** (Λ-induced). -/
+theorem partitionFunctionComplex_entire_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℂ) :
+    Differentiable ℂ (fun h => IsingModel.partitionFunctionComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) :=
+  IsingModel.partitionFunctionComplex_entire_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β
+
+/-- **ℤ^d `Z_ℂ` entire in `J` (Differentiable ℂ)** (Λ-induced). -/
+theorem partitionFunctionComplex_entire_J_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β : ℂ) :
+    Differentiable ℂ (fun J => IsingModel.partitionFunctionComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) :=
+  IsingModel.partitionFunctionComplex_entire_J
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β
+
+/-- **ℤ^d `Z_ℂ` entire in `β` (Differentiable ℂ)** (Λ-induced). -/
+theorem partitionFunctionComplex_entire_beta_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h : ℂ) :
+    Differentiable ℂ (fun β => IsingModel.partitionFunctionComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) :=
+  IsingModel.partitionFunctionComplex_entire_beta
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h
+
+/-- **ℤ^d `Z_ℂ` jointly entire on ℂ³ (Differentiable ℂ)**
+(Λ-induced). -/
+theorem partitionFunctionComplex_entire_joint_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) :
+    Differentiable ℂ
+      (fun z : ℂ × ℂ × ℂ => IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) z.1 z.2.1 z.2.2) :=
+  IsingModel.partitionFunctionComplex_entire_joint
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -7,6 +7,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.ComplexContinuityNorm
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranches
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexSlitPlane
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRestrictions
+import IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranchEntire
 import IsingModel.Concrete.LatticeGraphCorrelation.PerStage
 import IsingModel.Concrete.LatticeGraphCorrelation.Magnetization
 import IsingModel.Concrete.LatticeGraphCorrelation.TwoPoint


### PR DESCRIPTION
Part of #1850

Move 12 concrete analyticBranch / continuous_freeEnergyComplex_on_locus / Differentiable / partitionFunctionComplex_entire wrappers from Complex.lean into ComplexBranchEntire.lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)