### PR TITLE
Split concrete Base monotone-ambient-subgraph wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
@@ -195,51 +195,16 @@ theorem freeEnergyΛ_latticeGraph_apply
           (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
   freeEnergyΛ_apply (IsingModel.latticeGraph d) Λ p
 
-/-- **ℤ^d `magnetizationΛ_monotone_ambient_subgraph`**:
-`G₁ ≤ G₂ ⇒ M_{Λ,G₁}(i) ≤ M_{Λ,G₂}(i)` (ferromagnetic). -/
-theorem magnetizationΛ_latticeGraph_monotone_ambient_subgraph
-    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (h : G₁ ≤ G₂)
-    (Λ : Finset (Fin d → ℤ))
-    [Fintype (Ambient.inducedGraph G₁ Λ).edgeSet]
-    [Fintype (Ambient.inducedGraph G₂ Λ).edgeSet]
-    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : ↑Λ) :
-    magnetizationΛ G₁ Λ p i ≤ magnetizationΛ G₂ Λ p i :=
-  magnetizationΛ_monotone_ambient_subgraph h Λ p hf i
+/-! ## Moved: magnetization* / spontaneousCorrelation monotone_ambient_subgraph wrappers
 
-/-- **ℤ^d `magnetizationAlongExhaustion_monotone_ambient_subgraph`**
-per stage (ferromagnetic). -/
-theorem magnetizationAlongExhaustion_latticeGraph_monotone_ambient_subgraph
-    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (h : G₁ ≤ G₂)
-    (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph G₁ (Λ.volume n)).edgeSet]
-    [∀ n, Fintype (Ambient.inducedGraph G₂ (Λ.volume n)).edgeSet]
-    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : Fin d → ℤ) (n : ℕ) :
-    magnetizationAlongExhaustion G₁ Λ p i n
-      ≤ magnetizationAlongExhaustion G₂ Λ p i n :=
-  magnetizationAlongExhaustion_monotone_ambient_subgraph h Λ p hf i n
+The 4 ℤ^d
+`magnetization{Λ,AlongExhaustion,Infinite}_latticeGraph_monotone_ambient_subgraph`
+and `spontaneousCorrelation_latticeGraph_monotone_ambient_subgraph`
+wrappers now live in
+`IsingModel.Concrete.LatticeGraphCorrelation.BaseMonotoneAmbientSubgraph`.
+The legacy import path is preserved by re-importing the new child.
+-/
 
-/-- **ℤ^d `magnetizationInfinite_monotone_ambient_subgraph`**
-(ferromagnetic). -/
-theorem magnetizationInfinite_latticeGraph_monotone_ambient_subgraph
-    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (h : G₁ ≤ G₂)
-    (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph G₁ (Λ.volume n)).edgeSet]
-    [∀ n, Fintype (Ambient.inducedGraph G₂ (Λ.volume n)).edgeSet]
-    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : Fin d → ℤ) :
-    magnetizationInfinite G₁ Λ p i ≤ magnetizationInfinite G₂ Λ p i :=
-  magnetizationInfinite_monotone_ambient_subgraph h Λ p hf i
-
-/-- **ℤ^d `spontaneousCorrelation_monotone_ambient_subgraph`**
-(ferromagnetic). -/
-theorem spontaneousCorrelation_latticeGraph_monotone_ambient_subgraph
-    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (hG : G₁ ≤ G₂)
-    (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph G₁ (Λ.volume n)).edgeSet]
-    [∀ n, Fintype (Ambient.inducedGraph G₂ (Λ.volume n)).edgeSet]
-    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset (Fin d → ℤ)) :
-    spontaneousCorrelation G₁ Λ J β A
-      ≤ spontaneousCorrelation G₂ Λ J β A :=
-  spontaneousCorrelation_monotone_ambient_subgraph hG Λ hJ hβ A
 
 /-! ## Moved: spontaneousCorrelation / spontaneousMagnetization_monotone_ambient_subgraph wrappers
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/BaseMonotoneAmbientSubgraph.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/BaseMonotoneAmbientSubgraph.lean
@@ -1,0 +1,70 @@
+/- BaseMonotoneAmbientSubgraph.lean
+Narrow child module for the 4 ℤ^d
+`magnetization{Λ,AlongExhaustion,Infinite}_latticeGraph_monotone_ambient_subgraph`
+and `spontaneousCorrelation_latticeGraph_monotone_ambient_subgraph`
+wrappers extracted from `Base.lean` in PR #2033. Each is a thin
+pass-through to the abstract `*_monotone_ambient_subgraph` lemma at
+`latticeGraph d`. The theorem names are unchanged from the former
+`Base` declarations.
+-/
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.Concrete.IntLattice
+import IsingModel.TranslationInvariance
+import IsingModel.PhaseTransition
+import IsingModel.Inequalities.FKG
+import IsingModel.AmbientFKG
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d `magnetizationΛ_monotone_ambient_subgraph`**:
+`G₁ ≤ G₂ ⇒ M_{Λ,G₁}(i) ≤ M_{Λ,G₂}(i)` (ferromagnetic). -/
+theorem magnetizationΛ_latticeGraph_monotone_ambient_subgraph
+    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (h : G₁ ≤ G₂)
+    (Λ : Finset (Fin d → ℤ))
+    [Fintype (Ambient.inducedGraph G₁ Λ).edgeSet]
+    [Fintype (Ambient.inducedGraph G₂ Λ).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : ↑Λ) :
+    magnetizationΛ G₁ Λ p i ≤ magnetizationΛ G₂ Λ p i :=
+  magnetizationΛ_monotone_ambient_subgraph h Λ p hf i
+
+/-- **ℤ^d `magnetizationAlongExhaustion_monotone_ambient_subgraph`**
+per stage (ferromagnetic). -/
+theorem magnetizationAlongExhaustion_latticeGraph_monotone_ambient_subgraph
+    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (h : G₁ ≤ G₂)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (Ambient.inducedGraph G₂ (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : Fin d → ℤ) (n : ℕ) :
+    magnetizationAlongExhaustion G₁ Λ p i n
+      ≤ magnetizationAlongExhaustion G₂ Λ p i n :=
+  magnetizationAlongExhaustion_monotone_ambient_subgraph h Λ p hf i n
+
+/-- **ℤ^d `magnetizationInfinite_monotone_ambient_subgraph`**
+(ferromagnetic). -/
+theorem magnetizationInfinite_latticeGraph_monotone_ambient_subgraph
+    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (h : G₁ ≤ G₂)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (Ambient.inducedGraph G₂ (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) (i : Fin d → ℤ) :
+    magnetizationInfinite G₁ Λ p i ≤ magnetizationInfinite G₂ Λ p i :=
+  magnetizationInfinite_monotone_ambient_subgraph h Λ p hf i
+
+/-- **ℤ^d `spontaneousCorrelation_monotone_ambient_subgraph`**
+(ferromagnetic). -/
+theorem spontaneousCorrelation_latticeGraph_monotone_ambient_subgraph
+    (d : ℕ) {G₁ G₂ : SimpleGraph (Fin d → ℤ)} (hG : G₁ ≤ G₂)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph G₁ (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (Ambient.inducedGraph G₂ (Λ.volume n)).edgeSet]
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (A : Finset (Fin d → ℤ)) :
+    spontaneousCorrelation G₁ Λ J β A
+      ≤ spontaneousCorrelation G₂ Λ J β A :=
+  spontaneousCorrelation_monotone_ambient_subgraph hG Λ hJ hβ A
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -83,6 +83,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.TheoremEtaLe1
 import IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMag
 import IsingModel.Concrete.LatticeGraphCorrelation.UniformMag
 import IsingModel.Concrete.LatticeGraphCorrelation.Base
+import IsingModel.Concrete.LatticeGraphCorrelation.BaseMonotoneAmbientSubgraph
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseSpontaneousCorrelation
 import IsingModel.Concrete.LatticeGraphCorrelation.FiniteVolumeBasics
 import IsingModel.Concrete.LatticeGraphCorrelation.FiniteVolumeCorrelationMonotonicity


### PR DESCRIPTION
## Summary

- Move the 4 ℤ^d `*_latticeGraph_monotone_ambient_subgraph` wrappers (`magnetizationΛ`, `magnetizationAlongExhaustion`, `magnetizationInfinite`, `spontaneousCorrelation` — all `_latticeGraph_monotone_ambient_subgraph`) from `Concrete/LatticeGraphCorrelation/Base.lean` into a new narrow child `BaseMonotoneAmbientSubgraph.lean`.
- Continues the Issue #1850 wrapper-split refactor.

## Test plan

- [ ] `lake build`
- [ ] `lake exe GKSTest`
- [ ] codex exec cross-check before squash-merge