### PR TITLE
Split concrete Base correlationAlongExhaustion wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
@@ -229,75 +229,17 @@ The legacy import path is preserved by re-importing the new child.
 -/
 
 
-/-- **ℤ^d `correlationAlongExhaustion` at `J = 0`** per stage (on-stage):
-`A ⊆ Λ.volume n ⇒ = tanh(β·h)^|A|`. -/
-theorem correlationAlongExhaustion_latticeGraph_J_zero_of_subset
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    (h β : ℝ) {A : Finset (Fin d → ℤ)} {n : ℕ} (hAn : A ⊆ Λ.volume n) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
-        (⟨0, h, β⟩ : IsingParams ℝ) A n
-      = Real.tanh (β * h) ^ A.card :=
-  correlationAlongExhaustion_J_zero_of_subset (IsingModel.latticeGraph d) Λ h β hAn
+/-! ## Moved: correlationΛ + correlationAlongExhaustion empty/subset/J_zero wrappers
 
-/-- **ℤ^d `correlationAlongExhaustion` at `J = 0` is eventually constant
-at `tanh(β·h)^|A|`**. -/
-theorem correlationAlongExhaustion_latticeGraph_J_zero_eventually_eq
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    (h β : ℝ) (A : Finset (Fin d → ℤ)) :
-    ∀ᶠ n in Filter.atTop,
-      correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
-          (⟨0, h, β⟩ : IsingParams ℝ) A n
-        = Real.tanh (β * h) ^ A.card :=
-  correlationAlongExhaustion_J_zero_eventually_eq
-    (IsingModel.latticeGraph d) Λ h β A
+The 7 ℤ^d wrappers
+`correlationAlongExhaustion_latticeGraph_{J_zero_of_subset,J_zero_eventually_eq}`,
+`correlationΛ_latticeGraph_empty`, and
+`correlationAlongExhaustion_latticeGraph_{empty,of_subset,of_not_subset,cubicExhaustion_monotone}`
+now live in
+`IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongEx`.
+The legacy import path is preserved by re-importing the new child.
+-/
 
-
-/-- **ℤ^d correlationΛ_empty = 1** per finite volume. -/
-@[simp]
-theorem correlationΛ_latticeGraph_empty
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    correlationΛ (IsingModel.latticeGraph d) Λ p ∅ = 1 :=
-  correlationΛ_empty (IsingModel.latticeGraph d) Λ p
-
-/-- **ℤ^d correlationAlongExhaustion_empty = 1** per stage. -/
-@[simp]
-theorem correlationAlongExhaustion_latticeGraph_empty
-    (d : ℕ) (p : IsingParams ℝ) (n : ℕ) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d)
-      (Ambient.cubicExhaustion d) p ∅ n = 1 :=
-  correlationAlongExhaustion_empty (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p n
-
-/-- **ℤ^d correlationAlongExhaustion of_subset unfolding**. -/
-theorem correlationAlongExhaustion_latticeGraph_of_subset
-    (d : ℕ) (p : IsingParams ℝ)
-    {A : Finset (Fin d → ℤ)} {n : ℕ}
-    (hA : A ⊆ (Ambient.cubicExhaustion d).volume n) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d)
-        (Ambient.cubicExhaustion d) p A n
-      = correlationΛ (IsingModel.latticeGraph d)
-        ((Ambient.cubicExhaustion d).volume n) p (liftFinset A hA) :=
-  correlationAlongExhaustion_of_subset (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p hA
-
-/-- **ℤ^d correlationAlongExhaustion of_not_subset unfolding**. -/
-theorem correlationAlongExhaustion_latticeGraph_of_not_subset
-    (d : ℕ) (p : IsingParams ℝ)
-    {A : Finset (Fin d → ℤ)} {n : ℕ}
-    (hA : ¬ A ⊆ (Ambient.cubicExhaustion d).volume n) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d)
-        (Ambient.cubicExhaustion d) p A n = 0 :=
-  correlationAlongExhaustion_of_not_subset (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p hA
-
-/-- **ℤ^d correlationAlongExhaustion stage-index Monotone**. -/
-theorem correlationAlongExhaustion_latticeGraph_cubicExhaustion_monotone
-    (d : ℕ) (p : IsingParams ℝ) (hf : Ferromagnetic p)
-    (A : Finset (Fin d → ℤ)) :
-    Monotone (correlationAlongExhaustion (IsingModel.latticeGraph d)
-      (Ambient.cubicExhaustion d) p A) :=
-  correlationAlongExhaustion_monotone (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p hf A
 
 /-- **ℤ^d correlationΛ_gks_second** (GKS-II at finite volume). -/
 theorem correlationΛ_latticeGraph_gks_second

--- a/IsingModel/Concrete/LatticeGraphCorrelation/BaseCorrelationAlongEx.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/BaseCorrelationAlongEx.lean
@@ -1,0 +1,96 @@
+/- BaseCorrelationAlongEx.lean
+Narrow child module for the 7 ℤ^d
+`correlation{Λ,AlongExhaustion}_latticeGraph_*` wrappers extracted
+from `Base.lean` in PR #2035. Theorems:
+`correlationAlongExhaustion_latticeGraph_{J_zero_of_subset,J_zero_eventually_eq}`,
+`correlationΛ_latticeGraph_empty`,
+`correlationAlongExhaustion_latticeGraph_{empty,of_subset,of_not_subset,cubicExhaustion_monotone}`.
+Each is a thin pass-through to the corresponding abstract lemma at
+`latticeGraph d`. The theorem names are unchanged from the former
+`Base` declarations.
+-/
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.Concrete.IntLattice
+import IsingModel.TranslationInvariance
+import IsingModel.PhaseTransition
+import IsingModel.Inequalities.FKG
+import IsingModel.AmbientFKG
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d `correlationAlongExhaustion` at `J = 0`** per stage (on-stage):
+`A ⊆ Λ.volume n ⇒ = tanh(β·h)^|A|`. -/
+theorem correlationAlongExhaustion_latticeGraph_J_zero_of_subset
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (h β : ℝ) {A : Finset (Fin d → ℤ)} {n : ℕ} (hAn : A ⊆ Λ.volume n) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
+        (⟨0, h, β⟩ : IsingParams ℝ) A n
+      = Real.tanh (β * h) ^ A.card :=
+  correlationAlongExhaustion_J_zero_of_subset (IsingModel.latticeGraph d) Λ h β hAn
+
+/-- **ℤ^d `correlationAlongExhaustion` at `J = 0` is eventually constant
+at `tanh(β·h)^|A|`**. -/
+theorem correlationAlongExhaustion_latticeGraph_J_zero_eventually_eq
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (h β : ℝ) (A : Finset (Fin d → ℤ)) :
+    ∀ᶠ n in Filter.atTop,
+      correlationAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (⟨0, h, β⟩ : IsingParams ℝ) A n
+        = Real.tanh (β * h) ^ A.card :=
+  correlationAlongExhaustion_J_zero_eventually_eq
+    (IsingModel.latticeGraph d) Λ h β A
+
+
+/-- **ℤ^d correlationΛ_empty = 1** per finite volume. -/
+@[simp]
+theorem correlationΛ_latticeGraph_empty
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    correlationΛ (IsingModel.latticeGraph d) Λ p ∅ = 1 :=
+  correlationΛ_empty (IsingModel.latticeGraph d) Λ p
+
+/-- **ℤ^d correlationAlongExhaustion_empty = 1** per stage. -/
+@[simp]
+theorem correlationAlongExhaustion_latticeGraph_empty
+    (d : ℕ) (p : IsingParams ℝ) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) p ∅ n = 1 :=
+  correlationAlongExhaustion_empty (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p n
+
+/-- **ℤ^d correlationAlongExhaustion of_subset unfolding**. -/
+theorem correlationAlongExhaustion_latticeGraph_of_subset
+    (d : ℕ) (p : IsingParams ℝ)
+    {A : Finset (Fin d → ℤ)} {n : ℕ}
+    (hA : A ⊆ (Ambient.cubicExhaustion d).volume n) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) p A n
+      = correlationΛ (IsingModel.latticeGraph d)
+        ((Ambient.cubicExhaustion d).volume n) p (liftFinset A hA) :=
+  correlationAlongExhaustion_of_subset (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p hA
+
+/-- **ℤ^d correlationAlongExhaustion of_not_subset unfolding**. -/
+theorem correlationAlongExhaustion_latticeGraph_of_not_subset
+    (d : ℕ) (p : IsingParams ℝ)
+    {A : Finset (Fin d → ℤ)} {n : ℕ}
+    (hA : ¬ A ⊆ (Ambient.cubicExhaustion d).volume n) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) p A n = 0 :=
+  correlationAlongExhaustion_of_not_subset (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p hA
+
+/-- **ℤ^d correlationAlongExhaustion stage-index Monotone**. -/
+theorem correlationAlongExhaustion_latticeGraph_cubicExhaustion_monotone
+    (d : ℕ) (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset (Fin d → ℤ)) :
+    Monotone (correlationAlongExhaustion (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) p A) :=
+  correlationAlongExhaustion_monotone (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p hf A
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -84,6 +84,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMag
 import IsingModel.Concrete.LatticeGraphCorrelation.UniformMag
 import IsingModel.Concrete.LatticeGraphCorrelation.Base
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseBoundsTanh
+import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongEx
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseMonotoneAmbientSubgraph
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseSpontaneousCorrelation
 import IsingModel.Concrete.LatticeGraphCorrelation.FiniteVolumeBasics


### PR DESCRIPTION
## Summary

- Move the 7 ℤ^d `correlation{Λ,AlongExhaustion}_latticeGraph_*` wrappers (`_J_zero_of_subset`, `_J_zero_eventually_eq`, `correlationΛ_latticeGraph_empty`, `correlationAlongExhaustion_latticeGraph_empty`, `_of_subset`, `_of_not_subset`, `_cubicExhaustion_monotone`) from `Concrete/LatticeGraphCorrelation/Base.lean` into a new narrow child `BaseCorrelationAlongEx.lean`.
- Continues the Issue #1850 wrapper-split refactor.

## Test plan

- [ ] `lake build`
- [ ] `lake exe GKSTest`
- [ ] codex exec cross-check before squash-merge