### PR TITLE
Split concrete Base apply unfoldings

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
@@ -56,27 +56,15 @@ theorem correlationΛ_latticeGraph_nonneg
     0 ≤ correlationΛ (IsingModel.latticeGraph d) Λ p A :=
   correlationΛ_nonneg (IsingModel.latticeGraph d) Λ p hf A
 
-/-- **ℤ^d freeEnergyAlongExhaustion_apply unfolding**. -/
-@[simp]
-theorem freeEnergyAlongExhaustion_latticeGraph_apply
-    (d : ℕ) (p : IsingParams ℝ) (n : ℕ) :
-    freeEnergyAlongExhaustion (IsingModel.latticeGraph d)
-        (Ambient.cubicExhaustion d) p n
-      = freeEnergyΛ (IsingModel.latticeGraph d)
-        ((Ambient.cubicExhaustion d).volume n) p :=
-  freeEnergyAlongExhaustion_apply (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p n
+/-! ## Moved: AlongExhaustion apply unfoldings
 
-/-- **ℤ^d partitionFunctionAlongExhaustion_apply unfolding**. -/
-@[simp]
-theorem partitionFunctionAlongExhaustion_latticeGraph_apply
-    (d : ℕ) (p : IsingParams ℝ) (n : ℕ) :
-    partitionFunctionAlongExhaustion (IsingModel.latticeGraph d)
-        (Ambient.cubicExhaustion d) p n
-      = partitionFunctionΛ (IsingModel.latticeGraph d)
-        ((Ambient.cubicExhaustion d).volume n) p :=
-  partitionFunctionAlongExhaustion_apply (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p n
+The 2 `@[simp]` ℤ^d `freeEnergyAlongExhaustion_latticeGraph_apply` and
+`partitionFunctionAlongExhaustion_latticeGraph_apply` wrappers now live
+alongside the Λ-layer apply unfoldings in
+`IsingModel.Concrete.LatticeGraphCorrelation.BaseApply`.
+The legacy import path is preserved by re-importing the new child.
+-/
+
 
 /-- **ℤ^d freeEnergyAlongExhaustion = log Z / |Λ|** (log-bridge). -/
 theorem freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_eq_log_div_card
@@ -148,30 +136,15 @@ The legacy import path is preserved by re-importing the new child.
 -/
 
 
-/-- **ℤ^d `partitionFunctionΛ_apply`** unfolding. -/
-theorem partitionFunctionΛ_latticeGraph_apply
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    partitionFunctionΛ (IsingModel.latticeGraph d) Λ p
-      = IsingModel.partitionFunction
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
-  partitionFunctionΛ_apply (IsingModel.latticeGraph d) Λ p
+/-! ## Moved: Λ-layer apply unfoldings
 
-/-- **ℤ^d `correlationΛ_apply`** unfolding. -/
-theorem correlationΛ_latticeGraph_apply
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)
-    (A : Finset (↑Λ : Type _)) :
-    correlationΛ (IsingModel.latticeGraph d) Λ p A
-      = IsingModel.correlation
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p A :=
-  correlationΛ_apply (IsingModel.latticeGraph d) Λ p A
+The 3 ℤ^d `partitionFunctionΛ_latticeGraph_apply`,
+`correlationΛ_latticeGraph_apply`, and `freeEnergyΛ_latticeGraph_apply`
+wrappers now live in
+`IsingModel.Concrete.LatticeGraphCorrelation.BaseApply`.
+The legacy import path is preserved by re-importing the new child.
+-/
 
-/-- **ℤ^d `freeEnergyΛ_apply`** unfolding. -/
-theorem freeEnergyΛ_latticeGraph_apply
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    freeEnergyΛ (IsingModel.latticeGraph d) Λ p
-      = IsingModel.freeEnergy
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
-  freeEnergyΛ_apply (IsingModel.latticeGraph d) Λ p
 
 /-! ## Moved: magnetization* / spontaneousCorrelation monotone_ambient_subgraph wrappers
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/BaseApply.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/BaseApply.lean
@@ -1,0 +1,72 @@
+/- BaseApply.lean
+Narrow child module for the 5 ℤ^d `_apply` unfolding wrappers
+extracted from `Base.lean` in PR #2037. Theorems:
+`freeEnergyAlongExhaustion_latticeGraph_apply` (`@[simp]`),
+`partitionFunctionAlongExhaustion_latticeGraph_apply` (`@[simp]`),
+`partitionFunctionΛ_latticeGraph_apply`,
+`correlationΛ_latticeGraph_apply`,
+`freeEnergyΛ_latticeGraph_apply`. Each is a thin pass-through to the
+corresponding abstract `*_apply` lemma at `latticeGraph d`. The
+theorem names are unchanged from the former `Base` declarations.
+-/
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.Concrete.IntLattice
+import IsingModel.TranslationInvariance
+import IsingModel.PhaseTransition
+import IsingModel.Inequalities.FKG
+import IsingModel.AmbientFKG
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d freeEnergyAlongExhaustion_apply unfolding**. -/
+@[simp]
+theorem freeEnergyAlongExhaustion_latticeGraph_apply
+    (d : ℕ) (p : IsingParams ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) p n
+      = freeEnergyΛ (IsingModel.latticeGraph d)
+        ((Ambient.cubicExhaustion d).volume n) p :=
+  freeEnergyAlongExhaustion_apply (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p n
+
+/-- **ℤ^d partitionFunctionAlongExhaustion_apply unfolding**. -/
+@[simp]
+theorem partitionFunctionAlongExhaustion_latticeGraph_apply
+    (d : ℕ) (p : IsingParams ℝ) (n : ℕ) :
+    partitionFunctionAlongExhaustion (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) p n
+      = partitionFunctionΛ (IsingModel.latticeGraph d)
+        ((Ambient.cubicExhaustion d).volume n) p :=
+  partitionFunctionAlongExhaustion_apply (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p n
+
+/-- **ℤ^d `partitionFunctionΛ_apply`** unfolding. -/
+theorem partitionFunctionΛ_latticeGraph_apply
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    partitionFunctionΛ (IsingModel.latticeGraph d) Λ p
+      = IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  partitionFunctionΛ_apply (IsingModel.latticeGraph d) Λ p
+
+/-- **ℤ^d `correlationΛ_apply`** unfolding. -/
+theorem correlationΛ_latticeGraph_apply
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ)
+    (A : Finset (↑Λ : Type _)) :
+    correlationΛ (IsingModel.latticeGraph d) Λ p A
+      = IsingModel.correlation
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p A :=
+  correlationΛ_apply (IsingModel.latticeGraph d) Λ p A
+
+/-- **ℤ^d `freeEnergyΛ_apply`** unfolding. -/
+theorem freeEnergyΛ_latticeGraph_apply
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    freeEnergyΛ (IsingModel.latticeGraph d) Λ p
+      = IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  freeEnergyΛ_apply (IsingModel.latticeGraph d) Λ p
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -83,6 +83,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.TheoremEtaLe1
 import IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMag
 import IsingModel.Concrete.LatticeGraphCorrelation.UniformMag
 import IsingModel.Concrete.LatticeGraphCorrelation.Base
+import IsingModel.Concrete.LatticeGraphCorrelation.BaseApply
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseBoundsTanh
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongEx
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseVanish


### PR DESCRIPTION
## Summary

- Move the 5 ℤ^d `_apply` unfolding wrappers from `Concrete/LatticeGraphCorrelation/Base.lean` into a new narrow child `BaseApply.lean`. Theorems: `freeEnergyAlongExhaustion_latticeGraph_apply`, `partitionFunctionAlongExhaustion_latticeGraph_apply`, `partitionFunctionΛ_latticeGraph_apply`, `correlationΛ_latticeGraph_apply`, `freeEnergyΛ_latticeGraph_apply` (the first two are `@[simp]`).
- Continues the Issue #1850 wrapper-split refactor.

## Test plan

- [ ] `lake build`
- [ ] `lake exe GKSTest`
- [ ] codex exec cross-check before squash-merge