### PR TITLE
Split concrete Base correlationAlongExhaustion bound wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
@@ -77,44 +77,16 @@ theorem freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_eq_log_div_card
   freeEnergyAlongExhaustion_eq_log_div_card (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p n
 
-/-- **ℤ^d `correlationAlongExhaustion` is ≤ 1** per stage (unconditional).
-Concrete specialization of `correlationAlongExhaustion_le_one`. -/
-theorem correlationAlongExhaustion_latticeGraph_le_one
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n ≤ 1 :=
-  correlationAlongExhaustion_le_one (IsingModel.latticeGraph d) Λ p A n
+/-! ## Moved: correlationAlongExhaustion per-stage bound wrappers
 
-/-- **ℤ^d cross-exhaustion sandwich** (ferromagnetic): for any two ℤ^d
-exhaustions `Λ, Λ'`, per stage `correlationAlongExhaustion Λ'` is ≤
-the `correlationInfinite` computed via `Λ`. -/
-theorem correlationAlongExhaustion_latticeGraph_le_correlationInfinite_of_other
-    (d : ℕ) (Λ Λ' : Ambient.Exhaustion (Fin d → ℤ))
-    (p : IsingParams ℝ) (hf : Ferromagnetic p)
-    (A : Finset (Fin d → ℤ)) (n : ℕ) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ' p A n
-      ≤ correlationInfinite (IsingModel.latticeGraph d) Λ p A :=
-  correlationAlongExhaustion_le_correlationInfinite_of_other
-    (IsingModel.latticeGraph d) Λ Λ' p hf A n
+The 4 ℤ^d wrappers
+`correlationAlongExhaustion_latticeGraph_le_one`,
+`_le_correlationInfinite_of_other`, `_le_correlationInfinite`,
+and `_nonneg` now live in
+`IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongExBounds`.
+The legacy import path is preserved by re-importing the new child.
+-/
 
-/-- **ℤ^d `correlationAlongExhaustion ≤ correlationInfinite`** per stage
-(ferromagnetic): stage-wise upper bound by the limsup value. -/
-theorem correlationAlongExhaustion_latticeGraph_le_correlationInfinite
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n
-      ≤ correlationInfinite (IsingModel.latticeGraph d) Λ p A :=
-  correlationAlongExhaustion_le_correlationInfinite
-    (IsingModel.latticeGraph d) Λ p A n
-
-/-- **ℤ^d `correlationAlongExhaustion` is ≥ 0** per stage (ferromagnetic).
-Concrete specialization of `correlationAlongExhaustion_nonneg`. -/
-theorem correlationAlongExhaustion_latticeGraph_nonneg
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    (p : IsingParams ℝ) (hf : Ferromagnetic p)
-    (A : Finset (Fin d → ℤ)) (n : ℕ) :
-    0 ≤ correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n :=
-  correlationAlongExhaustion_nonneg (IsingModel.latticeGraph d) Λ p hf A n
 
 /-- **ℤ^d `correlationInfinite` on the empty site set = 1** (any Exhaustion). -/
 @[simp]

--- a/IsingModel/Concrete/LatticeGraphCorrelation/BaseCorrelationAlongExBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/BaseCorrelationAlongExBounds.lean
@@ -1,0 +1,65 @@
+/- BaseCorrelationAlongExBounds.lean
+Narrow child module for the 4 ℤ^d per-stage `correlationAlongExhaustion_latticeGraph_*`
+bound wrappers extracted from `Base.lean` in PR #2038. Theorems:
+`correlationAlongExhaustion_latticeGraph_le_one`,
+`_le_correlationInfinite_of_other`,
+`_le_correlationInfinite`,
+`_nonneg`. Each is a thin pass-through to the corresponding
+abstract `correlationAlongExhaustion_*` lemma at `latticeGraph d`.
+The theorem names are unchanged from the former `Base`
+declarations.
+-/
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.Concrete.IntLattice
+import IsingModel.TranslationInvariance
+import IsingModel.PhaseTransition
+import IsingModel.Inequalities.FKG
+import IsingModel.AmbientFKG
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d `correlationAlongExhaustion` is ≤ 1** per stage (unconditional).
+Concrete specialization of `correlationAlongExhaustion_le_one`. -/
+theorem correlationAlongExhaustion_latticeGraph_le_one
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n ≤ 1 :=
+  correlationAlongExhaustion_le_one (IsingModel.latticeGraph d) Λ p A n
+
+/-- **ℤ^d cross-exhaustion sandwich** (ferromagnetic): for any two ℤ^d
+exhaustions `Λ, Λ'`, per stage `correlationAlongExhaustion Λ'` is ≤
+the `correlationInfinite` computed via `Λ`. -/
+theorem correlationAlongExhaustion_latticeGraph_le_correlationInfinite_of_other
+    (d : ℕ) (Λ Λ' : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset (Fin d → ℤ)) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ' p A n
+      ≤ correlationInfinite (IsingModel.latticeGraph d) Λ p A :=
+  correlationAlongExhaustion_le_correlationInfinite_of_other
+    (IsingModel.latticeGraph d) Λ Λ' p hf A n
+
+/-- **ℤ^d `correlationAlongExhaustion ≤ correlationInfinite`** per stage
+(ferromagnetic): stage-wise upper bound by the limsup value. -/
+theorem correlationAlongExhaustion_latticeGraph_le_correlationInfinite
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (A : Finset (Fin d → ℤ)) (n : ℕ) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n
+      ≤ correlationInfinite (IsingModel.latticeGraph d) Λ p A :=
+  correlationAlongExhaustion_le_correlationInfinite
+    (IsingModel.latticeGraph d) Λ p A n
+
+/-- **ℤ^d `correlationAlongExhaustion` is ≥ 0** per stage (ferromagnetic).
+Concrete specialization of `correlationAlongExhaustion_nonneg`. -/
+theorem correlationAlongExhaustion_latticeGraph_nonneg
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset (Fin d → ℤ)) (n : ℕ) :
+    0 ≤ correlationAlongExhaustion (IsingModel.latticeGraph d) Λ p A n :=
+  correlationAlongExhaustion_nonneg (IsingModel.latticeGraph d) Λ p hf A n
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -86,6 +86,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.Base
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseApply
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseBoundsTanh
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongEx
+import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongExBounds
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseVanish
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseMonotoneAmbientSubgraph
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseSpontaneousCorrelation


### PR DESCRIPTION
## Summary

- Move the 4 ℤ^d `correlationAlongExhaustion_latticeGraph_*` per-stage bound wrappers (`le_one`, `le_correlationInfinite_of_other`, `le_correlationInfinite`, `nonneg`) from `Concrete/LatticeGraphCorrelation/Base.lean` into a new narrow child `BaseCorrelationAlongExBounds.lean`.
- Continues the Issue #1850 wrapper-split refactor.

## Test plan

- [ ] `lake build`
- [ ] `lake exe GKSTest`
- [ ] codex exec cross-check before squash-merge