### PR TITLE
Split concrete SiteIndepMag uniformSpontaneousMagnetization wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -81,6 +81,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.CubicPseudoMassProductSum
 import IsingModel.Concrete.LatticeGraphCorrelation.CubicPseudoMass
 import IsingModel.Concrete.LatticeGraphCorrelation.TheoremEtaLe1
 import IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMag
+import IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMagUniformSpontaneous
 import IsingModel.Concrete.LatticeGraphCorrelation.UniformMag
 import IsingModel.Concrete.LatticeGraphCorrelation.Base
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseApply

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMag.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMag.lean
@@ -122,93 +122,17 @@ noncomputable def uniformSpontaneousMagnetization
   spontaneousMagnetization (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) J β 0
 
-/-- **Unfolding of `uniformSpontaneousMagnetization`**:
-`uniformSpontaneousMagnetization d J β = spontaneousMagnetization
-(latticeGraph d) (cubicExhaustion d) J β 0`. -/
-theorem uniformSpontaneousMagnetization_apply (d : ℕ) (J β : ℝ) :
-    uniformSpontaneousMagnetization d J β
-      = spontaneousMagnetization (IsingModel.latticeGraph d)
-          (Ambient.cubicExhaustion d) J β 0 := rfl
+/-! ## Moved: ℤ^d `uniformSpontaneousMagnetization` wrappers
 
-/-- **`uniformSpontaneousMagnetization` equals `spontaneousMagnetization`
-under any Exhaustion** (ferromagnetic): bridges fixed-`cubicExhaustion`
-definition to arbitrary Exhaustions via
-`spontaneousMagnetization_indep_exhaustion`. -/
-theorem uniformSpontaneousMagnetization_eq_spontaneousMagnetization_any_exhaustion
-    (d : ℕ) (Λ' : Ambient.Exhaustion (Fin d → ℤ))
-    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
-    uniformSpontaneousMagnetization d J β
-      = spontaneousMagnetization (IsingModel.latticeGraph d) Λ' J β 0 := by
-  rw [uniformSpontaneousMagnetization_apply]
-  exact spontaneousMagnetization_indep_exhaustion (IsingModel.latticeGraph d)
-    _ Λ' hJ hβ 0
-
-/-- **J-monotonicity of `uniformSpontaneousMagnetization` on ℤ^d**. -/
-theorem uniformSpontaneousMagnetization_monotone_J
-    (d : ℕ) {β : ℝ} (hβ : 0 < β) :
-    MonotoneOn
-      (fun J : ℝ => uniformSpontaneousMagnetization d J β)
-      (Set.Ici 0) :=
-  spontaneousMagnetization_monotone_J (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) hβ 0
-
-/-- **β-monotonicity of `uniformSpontaneousMagnetization` on ℤ^d**. -/
-theorem uniformSpontaneousMagnetization_monotone_beta
-    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) :
-    MonotoneOn
-      (fun β : ℝ => uniformSpontaneousMagnetization d J β)
-      (Set.Ioi 0) :=
-  spontaneousMagnetization_monotone_beta (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) hJ 0
-
-/-- **Bridge**: for `0 ≤ J`, `0 < β`, and any site `i : Fin d → ℤ`,
-`spontaneousMagnetization ... J β i = uniformSpontaneousMagnetization d J β`.
-
-Immediate from `spontaneousMagnetization_latticeGraph_cubicExhaustion_eq`
-(PR #257). -/
-theorem spontaneousMagnetization_latticeGraph_cubicExhaustion_eq_uniform
-    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : Fin d → ℤ) :
-    spontaneousMagnetization (IsingModel.latticeGraph d)
-        (Ambient.cubicExhaustion d) J β i
-      = uniformSpontaneousMagnetization d J β :=
-  spontaneousMagnetization_latticeGraph_cubicExhaustion_eq d hJ hβ i 0
-
-/-- **Nonnegativity of `uniformSpontaneousMagnetization`**. -/
-theorem uniformSpontaneousMagnetization_nonneg
-    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
-    0 ≤ uniformSpontaneousMagnetization d J β :=
-  spontaneousMagnetization_nonneg (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) hJ hβ 0
-
-/-- **Upper bound on `uniformSpontaneousMagnetization`**:
-`uniformSpontaneousMagnetization d J β ≤ 1`. -/
-theorem uniformSpontaneousMagnetization_le_one
-    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
-    uniformSpontaneousMagnetization d J β ≤ 1 :=
-  spontaneousMagnetization_le_one (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) hJ hβ 0
-
-/-- **`-1 ≤ uniformSpontaneousMagnetization`** (ferromagnetic).
-Direct from `uniformSpontaneousMagnetization_nonneg`. -/
-theorem neg_one_le_uniformSpontaneousMagnetization
-    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
-    -1 ≤ uniformSpontaneousMagnetization d J β := by
-  have := uniformSpontaneousMagnetization_nonneg d hJ hβ
-  linarith
-
-/-- **`|uniformSpontaneousMagnetization| ≤ 1`** (ferromagnetic). -/
-theorem abs_uniformSpontaneousMagnetization_le_one
-    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
-    |uniformSpontaneousMagnetization d J β| ≤ 1 :=
-  abs_le.mpr ⟨neg_one_le_uniformSpontaneousMagnetization d hJ hβ,
-    uniformSpontaneousMagnetization_le_one d hJ hβ⟩
-
-/-- **`uniformSpontaneousMagnetization² ≤ 1`** (ferromagnetic). -/
-theorem uniformSpontaneousMagnetization_sq_le_one
-    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
-    uniformSpontaneousMagnetization d J β ^ 2 ≤ 1 :=
-  spontaneousMagnetization_sq_le_one (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) hJ hβ 0
+The 9 ℤ^d `uniformSpontaneousMagnetization*` wrappers
+(`_apply`, `_eq_spontaneousMagnetization_any_exhaustion`,
+`_monotone_J`, `_monotone_beta`,
+`spontaneousMagnetization_latticeGraph_cubicExhaustion_eq_uniform`,
+`_nonneg`, `_le_one`, `neg_one_le_*`,
+`abs_*_le_one`, `_sq_le_one`) now live in
+`IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMagUniformSpontaneous`.
+The legacy import path is preserved by re-importing the new child.
+-/
 
 /-- **ℤ^d `spontaneousCorrelation` apply** (any-Exhaustion):
 `spontaneousCorrelation = ⨅ h ∈ Ioi 0, correlationInfinite ⟨J, h, β⟩ A`. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMag.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMag.lean
@@ -124,7 +124,7 @@ noncomputable def uniformSpontaneousMagnetization
 
 /-! ## Moved: ℤ^d `uniformSpontaneousMagnetization` wrappers
 
-The 9 ℤ^d `uniformSpontaneousMagnetization*` wrappers
+The 10 ℤ^d `uniformSpontaneousMagnetization*` wrappers
 (`_apply`, `_eq_spontaneousMagnetization_any_exhaustion`,
 `_monotone_J`, `_monotone_beta`,
 `spontaneousMagnetization_latticeGraph_cubicExhaustion_eq_uniform`,

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMagUniformSpontaneous.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMagUniformSpontaneous.lean
@@ -11,7 +11,7 @@ import IsingModel.AmbientFKG
 /-!
 # ℤ^d `uniformSpontaneousMagnetization` wrappers
 
-Narrow child module for the 9 ℤ^d `uniformSpontaneousMagnetization*`
+Narrow child module for the 10 ℤ^d `uniformSpontaneousMagnetization*`
 wrappers (`_apply`, `_eq_spontaneousMagnetization_any_exhaustion`,
 `_monotone_J`, `_monotone_beta`,
 `spontaneousMagnetization_latticeGraph_cubicExhaustion_eq_uniform`,

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMagUniformSpontaneous.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMagUniformSpontaneous.lean
@@ -1,0 +1,121 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.Concrete.IntLattice
+import IsingModel.Concrete.LatticeGraphCorrelation.TwoPoint
+import IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMag
+import IsingModel.Concrete.LatticeGraphCorrelation.Translation
+import IsingModel.TranslationInvariance
+import IsingModel.PhaseTransition
+import IsingModel.Inequalities.FKG
+import IsingModel.AmbientFKG
+
+/-!
+# ℤ^d `uniformSpontaneousMagnetization` wrappers
+
+Narrow child module for the 9 ℤ^d `uniformSpontaneousMagnetization*`
+wrappers (`_apply`, `_eq_spontaneousMagnetization_any_exhaustion`,
+`_monotone_J`, `_monotone_beta`,
+`spontaneousMagnetization_latticeGraph_cubicExhaustion_eq_uniform`,
+`_nonneg`, `_le_one`, `neg_one_le_*`, `abs_*_le_one`, `_sq_le_one`)
+extracted from `SiteIndepMag.lean` in PR #2047. Each is a thin
+pass-through to the corresponding `spontaneousMagnetization_*` lemma
+at `(latticeGraph d, cubicExhaustion d)`. The theorem names are
+unchanged from the former `SiteIndepMag` declarations.
+-/
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-- **Unfolding of `uniformSpontaneousMagnetization`**:
+`uniformSpontaneousMagnetization d J β = spontaneousMagnetization
+(latticeGraph d) (cubicExhaustion d) J β 0`. -/
+theorem uniformSpontaneousMagnetization_apply (d : ℕ) (J β : ℝ) :
+    uniformSpontaneousMagnetization d J β
+      = spontaneousMagnetization (IsingModel.latticeGraph d)
+          (Ambient.cubicExhaustion d) J β 0 := rfl
+
+/-- **`uniformSpontaneousMagnetization` equals `spontaneousMagnetization`
+under any Exhaustion** (ferromagnetic): bridges fixed-`cubicExhaustion`
+definition to arbitrary Exhaustions via
+`spontaneousMagnetization_indep_exhaustion`. -/
+theorem uniformSpontaneousMagnetization_eq_spontaneousMagnetization_any_exhaustion
+    (d : ℕ) (Λ' : Ambient.Exhaustion (Fin d → ℤ))
+    {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    uniformSpontaneousMagnetization d J β
+      = spontaneousMagnetization (IsingModel.latticeGraph d) Λ' J β 0 := by
+  rw [uniformSpontaneousMagnetization_apply]
+  exact spontaneousMagnetization_indep_exhaustion (IsingModel.latticeGraph d)
+    _ Λ' hJ hβ 0
+
+/-- **J-monotonicity of `uniformSpontaneousMagnetization` on ℤ^d**. -/
+theorem uniformSpontaneousMagnetization_monotone_J
+    (d : ℕ) {β : ℝ} (hβ : 0 < β) :
+    MonotoneOn
+      (fun J : ℝ => uniformSpontaneousMagnetization d J β)
+      (Set.Ici 0) :=
+  spontaneousMagnetization_monotone_J (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hβ 0
+
+/-- **β-monotonicity of `uniformSpontaneousMagnetization` on ℤ^d**. -/
+theorem uniformSpontaneousMagnetization_monotone_beta
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) :
+    MonotoneOn
+      (fun β : ℝ => uniformSpontaneousMagnetization d J β)
+      (Set.Ioi 0) :=
+  spontaneousMagnetization_monotone_beta (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ 0
+
+/-- **Bridge**: for `0 ≤ J`, `0 < β`, and any site `i : Fin d → ℤ`,
+`spontaneousMagnetization ... J β i = uniformSpontaneousMagnetization d J β`.
+
+Immediate from `spontaneousMagnetization_latticeGraph_cubicExhaustion_eq`
+(PR #257). -/
+theorem spontaneousMagnetization_latticeGraph_cubicExhaustion_eq_uniform
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) (i : Fin d → ℤ) :
+    spontaneousMagnetization (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) J β i
+      = uniformSpontaneousMagnetization d J β :=
+  spontaneousMagnetization_latticeGraph_cubicExhaustion_eq d hJ hβ i 0
+
+/-- **Nonnegativity of `uniformSpontaneousMagnetization`**. -/
+theorem uniformSpontaneousMagnetization_nonneg
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    0 ≤ uniformSpontaneousMagnetization d J β :=
+  spontaneousMagnetization_nonneg (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hβ 0
+
+/-- **Upper bound on `uniformSpontaneousMagnetization`**:
+`uniformSpontaneousMagnetization d J β ≤ 1`. -/
+theorem uniformSpontaneousMagnetization_le_one
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    uniformSpontaneousMagnetization d J β ≤ 1 :=
+  spontaneousMagnetization_le_one (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hβ 0
+
+/-- **`-1 ≤ uniformSpontaneousMagnetization`** (ferromagnetic).
+Direct from `uniformSpontaneousMagnetization_nonneg`. -/
+theorem neg_one_le_uniformSpontaneousMagnetization
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    -1 ≤ uniformSpontaneousMagnetization d J β := by
+  have := uniformSpontaneousMagnetization_nonneg d hJ hβ
+  linarith
+
+/-- **`|uniformSpontaneousMagnetization| ≤ 1`** (ferromagnetic). -/
+theorem abs_uniformSpontaneousMagnetization_le_one
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    |uniformSpontaneousMagnetization d J β| ≤ 1 :=
+  abs_le.mpr ⟨neg_one_le_uniformSpontaneousMagnetization d hJ hβ,
+    uniformSpontaneousMagnetization_le_one d hJ hβ⟩
+
+/-- **`uniformSpontaneousMagnetization² ≤ 1`** (ferromagnetic). -/
+theorem uniformSpontaneousMagnetization_sq_le_one
+    (d : ℕ) {J : ℝ} (hJ : 0 ≤ J) {β : ℝ} (hβ : 0 < β) :
+    uniformSpontaneousMagnetization d J β ^ 2 ≤ 1 :=
+  spontaneousMagnetization_sq_le_one (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) hJ hβ 0
+
+
+end Ambient
+
+end IsingModel


### PR DESCRIPTION
## Summary

- Move the 9 ℤ^d `uniformSpontaneousMagnetization*` wrappers (`_apply`, `_eq_spontaneousMagnetization_any_exhaustion`, `_monotone_J`, `_monotone_beta`, `spontaneousMagnetization_latticeGraph_cubicExhaustion_eq_uniform`, `_nonneg`, `_le_one`, `neg_one_le_*`, `abs_*_le_one`, `_sq_le_one`) from `Concrete/LatticeGraphCorrelation/SiteIndepMag.lean` into a new narrow child `SiteIndepMagUniformSpontaneous.lean`.
- Continues the Issue #1850 wrapper-split refactor.

## Test plan

- [ ] `lake build`
- [ ] `lake exe GKSTest`
- [ ] codex exec cross-check before squash-merge