### PR TITLE
Split concrete PerStage complex per-stage analyticity wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -10,6 +10,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRestrictions
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranchEntire
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexIsingPoly
 import IsingModel.Concrete.LatticeGraphCorrelation.PerStage
+import IsingModel.Concrete.LatticeGraphCorrelation.PerStageComplex
 import IsingModel.Concrete.LatticeGraphCorrelation.PerStageSubgraph
 import IsingModel.Concrete.LatticeGraphCorrelation.PerStageZetaEta
 import IsingModel.Concrete.LatticeGraphCorrelation.Magnetization

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PerStage.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PerStage.lean
@@ -105,185 +105,24 @@ theorem freeEnergyComplexAlongExhaustion_at_real_latticeGraph
   Ambient.freeEnergyComplexAlongExhaustion_at_real_eq_ofReal
     (IsingModel.latticeGraph d) Λ p n
 
-/-! #### Per-stage analyticity / continuity / norm-bound for the complex
-along-exhaustion sequence (ℤ^d wrappers)
+/-! ## Moved: ℤ^d per-stage complex analyticity wrappers
 
-ℤ^d forwarders for the per-stage properties in
-`IsingModel/AmbientComplexAnalyticity.lean`. Foundation for the Montel /
-Vitali extraction. -/
+The 12 ℤ^d per-stage complex analyticity / continuity / norm-bound
+wrappers
+(`partitionFunctionComplexAlongExhaustion_analyticAt_{h,J,beta,joint}_stage_latticeGraph`,
+`_continuous_h_stage_latticeGraph`,
+`freeEnergyComplexAlongExhaustion_analyticAt_h_stage_latticeGraph`,
+`_analyticOnNhd_leeYangSubdomain_stage_latticeGraph`,
+`_differentiableOn_leeYangSubdomain_stage_latticeGraph`,
+`_continuousOn_leeYangSubdomain_stage_latticeGraph`,
+`norm_partitionFunctionComplexAlongExhaustion_le_of_re_bound_stage_latticeGraph`,
+`partitionFunctionComplexAlongExhaustion_ne_zero_on_leeYangDomain_stage_latticeGraph`,
+`freeEnergyComplexAlongExhaustion_tendsto_at_real_of_disjointTowerHypotheses_latticeGraph`)
+now live in
+`IsingModel.Concrete.LatticeGraphCorrelation.PerStageComplex`.
+The legacy import path is preserved by re-importing the new child.
+-/
 
-/-- **ℤ^d per-stage entire in `h`** for `partitionFunctionComplexAlongExhaustion`. -/
-theorem partitionFunctionComplexAlongExhaustion_analyticAt_h_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (J β : ℂ) (n : ℕ) (h₀ : ℂ) :
-    AnalyticAt ℂ
-      (fun h => Ambient.partitionFunctionComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ J h β n) h₀ :=
-  Ambient.partitionFunctionComplexAlongExhaustion_analyticAt_h_stage
-    (IsingModel.latticeGraph d) Λ J β n h₀
-
-/-- **ℤ^d per-stage entire in `J`** for `partitionFunctionComplexAlongExhaustion`. -/
-theorem partitionFunctionComplexAlongExhaustion_analyticAt_J_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (h β : ℂ) (n : ℕ) (J₀ : ℂ) :
-    AnalyticAt ℂ
-      (fun J => Ambient.partitionFunctionComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ J h β n) J₀ :=
-  Ambient.partitionFunctionComplexAlongExhaustion_analyticAt_J_stage
-    (IsingModel.latticeGraph d) Λ h β n J₀
-
-/-- **ℤ^d per-stage entire in `β`** for `partitionFunctionComplexAlongExhaustion`. -/
-theorem partitionFunctionComplexAlongExhaustion_analyticAt_beta_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (J h : ℂ) (n : ℕ) (β₀ : ℂ) :
-    AnalyticAt ℂ
-      (fun β => Ambient.partitionFunctionComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ J h β n) β₀ :=
-  Ambient.partitionFunctionComplexAlongExhaustion_analyticAt_beta_stage
-    (IsingModel.latticeGraph d) Λ J h n β₀
-
-/-- **ℤ^d per-stage joint entire** for `partitionFunctionComplexAlongExhaustion`. -/
-theorem partitionFunctionComplexAlongExhaustion_analyticAt_joint_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (n : ℕ) (z₀ : ℂ × ℂ × ℂ) :
-    AnalyticAt ℂ (fun z : ℂ × ℂ × ℂ =>
-      Ambient.partitionFunctionComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ z.1 z.2.1 z.2.2 n) z₀ :=
-  Ambient.partitionFunctionComplexAlongExhaustion_analyticAt_joint_stage
-    (IsingModel.latticeGraph d) Λ n z₀
-
-/-- **ℤ^d per-stage `Continuous` in `h`** for
-`partitionFunctionComplexAlongExhaustion`. -/
-theorem partitionFunctionComplexAlongExhaustion_continuous_h_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (J β : ℂ) (n : ℕ) :
-    Continuous
-      (fun h => Ambient.partitionFunctionComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ J h β n) :=
-  Ambient.partitionFunctionComplexAlongExhaustion_continuous_h_stage
-    (IsingModel.latticeGraph d) Λ J β n
-
-/-- **ℤ^d per-stage `AnalyticAt h₀` for `freeEnergyComplexAlongExhaustion`
-under `Z_{stage} ∈ slitPlane`**. -/
-theorem freeEnergyComplexAlongExhaustion_analyticAt_h_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (J β : ℂ) (n : ℕ) (h₀ : ℂ)
-    (hZ : Ambient.partitionFunctionComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ J h₀ β n ∈ Complex.slitPlane) :
-    AnalyticAt ℂ
-      (fun h => Ambient.freeEnergyComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ J h β n) h₀ :=
-  Ambient.freeEnergyComplexAlongExhaustion_analyticAt_h_stage
-    (IsingModel.latticeGraph d) Λ J β n h₀ hZ
-
-/-- **ℤ^d per-stage `AnalyticOnNhd` on Lee-Yang subdomain** for
-`freeEnergyComplexAlongExhaustion` (ferromagnetic). -/
-theorem freeEnergyComplexAlongExhaustion_analyticOnNhd_leeYangSubdomain_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    {β : ℝ} (hβ : 0 < β) (J : ℝ) (n : ℕ) :
-    AnalyticOnNhd ℂ
-      (fun h => Ambient.freeEnergyComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n)
-      (IsingModel.leeYangSubdomain β
-        (Fintype.card (↑(Λ.volume n) : Type _))) :=
-  Ambient.freeEnergyComplexAlongExhaustion_analyticOnNhd_leeYangSubdomain_stage
-    (IsingModel.latticeGraph d) Λ hβ J n
-
-/-- **ℤ^d per-stage `DifferentiableOn` on Lee-Yang subdomain** for
-`freeEnergyComplexAlongExhaustion`. -/
-theorem freeEnergyComplexAlongExhaustion_differentiableOn_leeYangSubdomain_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    {β : ℝ} (hβ : 0 < β) (J : ℝ) (n : ℕ) :
-    DifferentiableOn ℂ
-      (fun h => Ambient.freeEnergyComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n)
-      (IsingModel.leeYangSubdomain β
-        (Fintype.card (↑(Λ.volume n) : Type _))) :=
-  Ambient.freeEnergyComplexAlongExhaustion_differentiableOn_leeYangSubdomain_stage
-    (IsingModel.latticeGraph d) Λ hβ J n
-
-/-- **ℤ^d per-stage `ContinuousOn` on Lee-Yang subdomain** for
-`freeEnergyComplexAlongExhaustion`. -/
-theorem freeEnergyComplexAlongExhaustion_continuousOn_leeYangSubdomain_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    {β : ℝ} (hβ : 0 < β) (J : ℝ) (n : ℕ) :
-    ContinuousOn
-      (fun h => Ambient.freeEnergyComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n)
-      (IsingModel.leeYangSubdomain β
-        (Fintype.card (↑(Λ.volume n) : Type _))) :=
-  Ambient.freeEnergyComplexAlongExhaustion_continuousOn_leeYangSubdomain_stage
-    (IsingModel.latticeGraph d) Λ hβ J n
-
-/-- **ℤ^d per-stage locally-uniform norm bound** for
-`partitionFunctionComplexAlongExhaustion`: `‖Z_ℂ_{Λ_n}‖ ≤ 2^|Λ_n| · exp(...)`
-under `|Re h| ≤ R`. Montel input for the Vitali extraction. -/
-theorem norm_partitionFunctionComplexAlongExhaustion_le_of_re_bound_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (β J : ℝ) (n : ℕ) {R : ℝ} {h : ℂ} (hh : |h.re| ≤ R) :
-    ‖Ambient.partitionFunctionComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n‖
-      ≤ Fintype.card (IsingModel.Config (↑(Λ.volume n) : Type _)) *
-          Real.exp (|β| *
-            (|J| * (Ambient.inducedGraph
-                (IsingModel.latticeGraph d) (Λ.volume n)).edgeFinset.card
-              + R * Fintype.card (↑(Λ.volume n) : Type _))) :=
-  Ambient.norm_partitionFunctionComplexAlongExhaustion_le_of_re_bound_stage
-    (IsingModel.latticeGraph d) Λ β J n hh
-
-/-- **ℤ^d per-stage `Z_ℂ ≠ 0 on leeYangDomain`** for
-`partitionFunctionComplexAlongExhaustion` (ferromagnetic). -/
-theorem partitionFunctionComplexAlongExhaustion_ne_zero_on_leeYangDomain_stage_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) (n : ℕ) {h : ℂ}
-    (hh : h ∈ IsingModel.leeYangDomain) :
-    Ambient.partitionFunctionComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n ≠ 0 :=
-  Ambient.partitionFunctionComplexAlongExhaustion_ne_zero_on_leeYangDomain_stage
-    (IsingModel.latticeGraph d) Λ hβ hJ n hh
-
-/-- **ℤ^d real-axis convergence of `freeEnergyComplexAlongExhaustion`**
-(under `DisjointTowerHypotheses` + `BoundedEdgeDensity`): at real
-parameters, the complex along-exhaustion sequence converges (in `ℂ`) to
-`↑(freeEnergyInfinite G Λ p)`. Pass-through of the abstract lemma. -/
-theorem freeEnergyComplexAlongExhaustion_tendsto_at_real_of_disjointTowerHypotheses_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (p : IsingParams ℝ)
-    (hBED : Ambient.BoundedEdgeDensity (IsingModel.latticeGraph d) Λ)
-    (hd : Ambient.DisjointTowerHypotheses (IsingModel.latticeGraph d) Λ p) :
-    Filter.Tendsto
-      (fun n => Ambient.freeEnergyComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ) n)
-      Filter.atTop
-      (nhds ((Ambient.freeEnergyInfinite
-        (IsingModel.latticeGraph d) Λ p : ℝ) : ℂ)) :=
-  Ambient.freeEnergyComplexAlongExhaustion_tendsto_at_real_of_disjointTowerHypotheses
-    (IsingModel.latticeGraph d) Λ p hBED hd
 
 /-! #### Per-stage Gibbs expectation along an exhaustion + FKG (ℤ^d) -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PerStageComplex.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PerStageComplex.lean
@@ -1,0 +1,217 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.PhaseTransition
+import IsingModel.Inequalities.FKG
+import IsingModel.ComplexAnalyticity
+import IsingModel.PeierlsInfinite
+import IsingModel.AmbientComplexAnalyticity
+import IsingModel.AmbientFKG
+import IsingModel.AmbientLattice.SpecialCases.InfiniteVolume
+
+/-!
+# Concrete ℤ^d per-stage complex analyticity wrappers
+
+Narrow child module for 12 ℤ^d per-stage complex analyticity /
+continuity / norm-bound wrappers
+(`partitionFunctionComplexAlongExhaustion_analyticAt_{h,J,beta,joint}_stage_latticeGraph`,
+`_continuous_h_stage_latticeGraph`,
+`freeEnergyComplexAlongExhaustion_analyticAt_h_stage_latticeGraph`,
+`_analyticOnNhd_leeYangSubdomain_stage_latticeGraph`,
+`_differentiableOn_leeYangSubdomain_stage_latticeGraph`,
+`_continuousOn_leeYangSubdomain_stage_latticeGraph`,
+`norm_partitionFunctionComplexAlongExhaustion_le_of_re_bound_stage_latticeGraph`,
+`partitionFunctionComplexAlongExhaustion_ne_zero_on_leeYangDomain_stage_latticeGraph`,
+`freeEnergyComplexAlongExhaustion_tendsto_at_real_of_disjointTowerHypotheses_latticeGraph`)
+extracted from `PerStage.lean` in PR #2051. Foundation for the Montel /
+Vitali extraction. Each is a thin pass-through to the corresponding
+ambient `partitionFunctionComplexAlongExhaustion_*` /
+`freeEnergyComplexAlongExhaustion_*` lemma at
+`IsingModel.latticeGraph d`. The theorem names are unchanged from the
+former `PerStage` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-! #### Per-stage analyticity / continuity / norm-bound for the complex
+along-exhaustion sequence (ℤ^d wrappers)
+
+ℤ^d forwarders for the per-stage properties in
+`IsingModel/AmbientComplexAnalyticity.lean`. Foundation for the Montel /
+Vitali extraction. -/
+
+/-- **ℤ^d per-stage entire in `h`** for `partitionFunctionComplexAlongExhaustion`. -/
+theorem partitionFunctionComplexAlongExhaustion_analyticAt_h_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (J β : ℂ) (n : ℕ) (h₀ : ℂ) :
+    AnalyticAt ℂ
+      (fun h => Ambient.partitionFunctionComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ J h β n) h₀ :=
+  Ambient.partitionFunctionComplexAlongExhaustion_analyticAt_h_stage
+    (IsingModel.latticeGraph d) Λ J β n h₀
+
+/-- **ℤ^d per-stage entire in `J`** for `partitionFunctionComplexAlongExhaustion`. -/
+theorem partitionFunctionComplexAlongExhaustion_analyticAt_J_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (h β : ℂ) (n : ℕ) (J₀ : ℂ) :
+    AnalyticAt ℂ
+      (fun J => Ambient.partitionFunctionComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ J h β n) J₀ :=
+  Ambient.partitionFunctionComplexAlongExhaustion_analyticAt_J_stage
+    (IsingModel.latticeGraph d) Λ h β n J₀
+
+/-- **ℤ^d per-stage entire in `β`** for `partitionFunctionComplexAlongExhaustion`. -/
+theorem partitionFunctionComplexAlongExhaustion_analyticAt_beta_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (J h : ℂ) (n : ℕ) (β₀ : ℂ) :
+    AnalyticAt ℂ
+      (fun β => Ambient.partitionFunctionComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ J h β n) β₀ :=
+  Ambient.partitionFunctionComplexAlongExhaustion_analyticAt_beta_stage
+    (IsingModel.latticeGraph d) Λ J h n β₀
+
+/-- **ℤ^d per-stage joint entire** for `partitionFunctionComplexAlongExhaustion`. -/
+theorem partitionFunctionComplexAlongExhaustion_analyticAt_joint_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (n : ℕ) (z₀ : ℂ × ℂ × ℂ) :
+    AnalyticAt ℂ (fun z : ℂ × ℂ × ℂ =>
+      Ambient.partitionFunctionComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ z.1 z.2.1 z.2.2 n) z₀ :=
+  Ambient.partitionFunctionComplexAlongExhaustion_analyticAt_joint_stage
+    (IsingModel.latticeGraph d) Λ n z₀
+
+/-- **ℤ^d per-stage `Continuous` in `h`** for
+`partitionFunctionComplexAlongExhaustion`. -/
+theorem partitionFunctionComplexAlongExhaustion_continuous_h_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (J β : ℂ) (n : ℕ) :
+    Continuous
+      (fun h => Ambient.partitionFunctionComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ J h β n) :=
+  Ambient.partitionFunctionComplexAlongExhaustion_continuous_h_stage
+    (IsingModel.latticeGraph d) Λ J β n
+
+/-- **ℤ^d per-stage `AnalyticAt h₀` for `freeEnergyComplexAlongExhaustion`
+under `Z_{stage} ∈ slitPlane`**. -/
+theorem freeEnergyComplexAlongExhaustion_analyticAt_h_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (J β : ℂ) (n : ℕ) (h₀ : ℂ)
+    (hZ : Ambient.partitionFunctionComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ J h₀ β n ∈ Complex.slitPlane) :
+    AnalyticAt ℂ
+      (fun h => Ambient.freeEnergyComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ J h β n) h₀ :=
+  Ambient.freeEnergyComplexAlongExhaustion_analyticAt_h_stage
+    (IsingModel.latticeGraph d) Λ J β n h₀ hZ
+
+/-- **ℤ^d per-stage `AnalyticOnNhd` on Lee-Yang subdomain** for
+`freeEnergyComplexAlongExhaustion` (ferromagnetic). -/
+theorem freeEnergyComplexAlongExhaustion_analyticOnNhd_leeYangSubdomain_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    {β : ℝ} (hβ : 0 < β) (J : ℝ) (n : ℕ) :
+    AnalyticOnNhd ℂ
+      (fun h => Ambient.freeEnergyComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n)
+      (IsingModel.leeYangSubdomain β
+        (Fintype.card (↑(Λ.volume n) : Type _))) :=
+  Ambient.freeEnergyComplexAlongExhaustion_analyticOnNhd_leeYangSubdomain_stage
+    (IsingModel.latticeGraph d) Λ hβ J n
+
+/-- **ℤ^d per-stage `DifferentiableOn` on Lee-Yang subdomain** for
+`freeEnergyComplexAlongExhaustion`. -/
+theorem freeEnergyComplexAlongExhaustion_differentiableOn_leeYangSubdomain_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    {β : ℝ} (hβ : 0 < β) (J : ℝ) (n : ℕ) :
+    DifferentiableOn ℂ
+      (fun h => Ambient.freeEnergyComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n)
+      (IsingModel.leeYangSubdomain β
+        (Fintype.card (↑(Λ.volume n) : Type _))) :=
+  Ambient.freeEnergyComplexAlongExhaustion_differentiableOn_leeYangSubdomain_stage
+    (IsingModel.latticeGraph d) Λ hβ J n
+
+/-- **ℤ^d per-stage `ContinuousOn` on Lee-Yang subdomain** for
+`freeEnergyComplexAlongExhaustion`. -/
+theorem freeEnergyComplexAlongExhaustion_continuousOn_leeYangSubdomain_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    {β : ℝ} (hβ : 0 < β) (J : ℝ) (n : ℕ) :
+    ContinuousOn
+      (fun h => Ambient.freeEnergyComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n)
+      (IsingModel.leeYangSubdomain β
+        (Fintype.card (↑(Λ.volume n) : Type _))) :=
+  Ambient.freeEnergyComplexAlongExhaustion_continuousOn_leeYangSubdomain_stage
+    (IsingModel.latticeGraph d) Λ hβ J n
+
+/-- **ℤ^d per-stage locally-uniform norm bound** for
+`partitionFunctionComplexAlongExhaustion`: `‖Z_ℂ_{Λ_n}‖ ≤ 2^|Λ_n| · exp(...)`
+under `|Re h| ≤ R`. Montel input for the Vitali extraction. -/
+theorem norm_partitionFunctionComplexAlongExhaustion_le_of_re_bound_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (β J : ℝ) (n : ℕ) {R : ℝ} {h : ℂ} (hh : |h.re| ≤ R) :
+    ‖Ambient.partitionFunctionComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n‖
+      ≤ Fintype.card (IsingModel.Config (↑(Λ.volume n) : Type _)) *
+          Real.exp (|β| *
+            (|J| * (Ambient.inducedGraph
+                (IsingModel.latticeGraph d) (Λ.volume n)).edgeFinset.card
+              + R * Fintype.card (↑(Λ.volume n) : Type _))) :=
+  Ambient.norm_partitionFunctionComplexAlongExhaustion_le_of_re_bound_stage
+    (IsingModel.latticeGraph d) Λ β J n hh
+
+/-- **ℤ^d per-stage `Z_ℂ ≠ 0 on leeYangDomain`** for
+`partitionFunctionComplexAlongExhaustion` (ferromagnetic). -/
+theorem partitionFunctionComplexAlongExhaustion_ne_zero_on_leeYangDomain_stage_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβ : 0 < β) (hJ : 0 < J) (n : ℕ) {h : ℂ}
+    (hh : h ∈ IsingModel.leeYangDomain) :
+    Ambient.partitionFunctionComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ (J : ℂ) h (β : ℂ) n ≠ 0 :=
+  Ambient.partitionFunctionComplexAlongExhaustion_ne_zero_on_leeYangDomain_stage
+    (IsingModel.latticeGraph d) Λ hβ hJ n hh
+
+/-- **ℤ^d real-axis convergence of `freeEnergyComplexAlongExhaustion`**
+(under `DisjointTowerHypotheses` + `BoundedEdgeDensity`): at real
+parameters, the complex along-exhaustion sequence converges (in `ℂ`) to
+`↑(freeEnergyInfinite G Λ p)`. Pass-through of the abstract lemma. -/
+theorem freeEnergyComplexAlongExhaustion_tendsto_at_real_of_disjointTowerHypotheses_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ)
+    (hBED : Ambient.BoundedEdgeDensity (IsingModel.latticeGraph d) Λ)
+    (hd : Ambient.DisjointTowerHypotheses (IsingModel.latticeGraph d) Λ p) :
+    Filter.Tendsto
+      (fun n => Ambient.freeEnergyComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ) n)
+      Filter.atTop
+      (nhds ((Ambient.freeEnergyInfinite
+        (IsingModel.latticeGraph d) Λ p : ℝ) : ℂ)) :=
+  Ambient.freeEnergyComplexAlongExhaustion_tendsto_at_real_of_disjointTowerHypotheses
+    (IsingModel.latticeGraph d) Λ p hBED hd
+
+end Ambient
+
+end IsingModel


### PR DESCRIPTION
## Summary

- Move the 12 ℤ^d per-stage complex analyticity / continuity / norm-bound wrappers (`partitionFunctionComplexAlongExhaustion_analyticAt_{h,J,beta,joint}_stage_latticeGraph`, `_continuous_h_stage_latticeGraph`, `freeEnergyComplexAlongExhaustion_analyticAt_h_stage_latticeGraph`, `_analyticOnNhd_leeYangSubdomain_stage_latticeGraph`, `_differentiableOn_leeYangSubdomain_stage_latticeGraph`, `_continuousOn_leeYangSubdomain_stage_latticeGraph`, `norm_partitionFunctionComplexAlongExhaustion_le_of_re_bound_stage_latticeGraph`, `partitionFunctionComplexAlongExhaustion_ne_zero_on_leeYangDomain_stage_latticeGraph`, `freeEnergyComplexAlongExhaustion_tendsto_at_real_of_disjointTowerHypotheses_latticeGraph`) from `Concrete/LatticeGraphCorrelation/PerStage.lean` into a new narrow child `PerStageComplex.lean`.
- Continues the Issue #1850 wrapper-split refactor.

## Test plan

- [ ] `lake build`
- [ ] `lake exe GKSTest`
- [ ] codex exec cross-check before squash-merge