### PR TITLE
refactor(concrete): split ComplexRealCompat _at_real family into child

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRealCompat.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRealCompat.lean
@@ -194,121 +194,17 @@ theorem logDeriv_partitionFunctionComplex_analyticOnNhd_leeYangDomain_latticeGra
   IsingModel.logDeriv_partitionFunctionComplex_analyticOnNhd_leeYangDomain
     (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) hβ hJ
 
-/-! #### Real-axis evaluation of the complex partition function / free energy
+/-! ## Moved: real-axis evaluation of the complex Z / f
 
-Direct ℤ^d forwarders for the real-axis evaluation identities of the
-complex partition function and free energy. These restate the
-real-complex bridge in the form most useful for Vitali convergence
-(pointwise values on the real axis via Fekete). -/
+The ten `*_at_real_latticeGraph` wrappers (`partitionFunctionComplex_at_real_pos`,
+`freeEnergyComplex_at_real`, `freeEnergyComplex_ofReal_eq_freeEnergy`,
+`{partitionFunctionComplex,freeEnergyComplex}_{re_pos,im_zero}_at_real`,
+`log_partitionFunctionComplex_im_zero_at_real`,
+`freeEnergyComplex_re_eq_freeEnergy_at_real`,
+`norm_partitionFunctionComplex_at_real`, and
+`partitionFunctionComplex_is_pos_real_at_real`) now live in
+`ComplexRealCompatAtReal.lean`. -/
 
-/-- **ℤ^d `partitionFunctionComplex` at real `h₀`** (Λ-induced):
-`Z_ℂ(J, ↑h₀, β) = ↑(Z G ⟨J, h₀, β⟩)`. -/
-theorem partitionFunctionComplex_at_real_pos_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℝ) :
-    IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (J : ℂ) (h₀ : ℂ) (β : ℂ)
-      = ((IsingModel.partitionFunction
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-            ⟨J, h₀, β⟩ : ℝ) : ℂ) :=
-  IsingModel.partitionFunctionComplex_at_real_pos
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀
-
-/-- **ℤ^d `freeEnergyComplex` at real parameters** (Λ-induced):
-`f_ℂ(J, h, β) = ↑(f G ⟨J, h, β⟩)`. -/
-theorem freeEnergyComplex_at_real_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ) :
-    IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (J : ℂ) (h : ℂ) (β : ℂ)
-      = ((IsingModel.freeEnergy
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-            ⟨J, h, β⟩ : ℝ) : ℂ) :=
-  IsingModel.freeEnergyComplex_at_real
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β
-
-/-- **ℤ^d `freeEnergyComplex ↔ freeEnergy` Vitali form** (Λ-induced):
-`f_ℂ G ↑p.J ↑p.h ↑p.β = ↑(f G p)`. Thin restatement of
-`freeEnergy_ofReal_eq_freeEnergyComplex` in the orientation most useful
-for Vitali convergence (RHS is the cast of the real-parameter value). -/
-theorem freeEnergyComplex_ofReal_eq_freeEnergy_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)
-      = ((IsingModel.freeEnergy
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p : ℝ) : ℂ) :=
-  IsingModel.freeEnergyComplex_ofReal_eq_freeEnergy
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d `Re Z_ℂ > 0` at real parameters** (Λ-induced):
-immediate from positivity of the real `Z`. -/
-theorem partitionFunctionComplex_re_pos_at_real_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    0 < (IsingModel.partitionFunctionComplex
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-          (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)).re :=
-  IsingModel.partitionFunctionComplex_re_pos_at_real
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d `Im Z_ℂ = 0` at real parameters** (Λ-induced). -/
-theorem partitionFunctionComplex_im_zero_at_real_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    (IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)).im = 0 :=
-  IsingModel.partitionFunctionComplex_im_zero_at_real
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d `Im (log Z_ℂ) = 0` at real parameters** (Λ-induced). -/
-theorem log_partitionFunctionComplex_im_zero_at_real_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    (Complex.log (IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ))).im = 0 :=
-  IsingModel.log_partitionFunctionComplex_im_zero_at_real
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d `Im f_ℂ = 0` at real parameters** (Λ-induced). -/
-theorem freeEnergyComplex_im_zero_at_real_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    (IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)).im = 0 :=
-  IsingModel.freeEnergyComplex_im_zero_at_real
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d `Re f_ℂ = f` at real parameters** (Λ-induced). -/
-theorem freeEnergyComplex_re_eq_freeEnergy_at_real_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    (IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)).re
-      = IsingModel.freeEnergy
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
-  IsingModel.freeEnergyComplex_re_eq_freeEnergy_at_real
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d `‖Z_ℂ‖ = Z` at real parameters** (Λ-induced). -/
-theorem norm_partitionFunctionComplex_at_real_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    ‖IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)‖
-      = IsingModel.partitionFunction
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
-  IsingModel.norm_partitionFunctionComplex_at_real
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
-
-/-- **ℤ^d `Z_ℂ` is a positive real at real parameters** (Λ-induced):
-explicit witness for `Z_ℂ = ↑x` with `0 < x`. -/
-theorem partitionFunctionComplex_is_pos_real_at_real_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
-    ∃ x : ℝ, 0 < x ∧ IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ) = (x : ℂ) :=
-  IsingModel.partitionFunctionComplex_is_pos_real_at_real
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
 
 end Ambient
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRealCompat.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRealCompat.lean
@@ -6,20 +6,20 @@ import IsingModel.AmbientComplexAnalyticity
 # Concrete real-complex compatibility / Lee-Yang domain wrappers
 
 Narrow child module for concrete real-complex compatibility,
-Lee-Yang-domain non-vanishing, and related restriction wrappers on
-`latticeGraph d`. 22 theorems including
+Lee-Yang-domain non-vanishing, and analyticity restriction wrappers on
+`latticeGraph d`. Twelve theorems remain here including
 `partitionFunction_ofReal_eq_partitionFunctionComplex_latticeGraph`,
 `partitionFunctionComplex_mem_slitPlane_of_real_latticeGraph`,
 `freeEnergy_ofReal_eq_freeEnergyComplex_latticeGraph`,
 `partitionFunctionComplex_eq_normalization_mul_isingEdgePoly_latticeGraph`,
 `partitionFunctionComplex_ne_zero_on_leeYangDomain_latticeGraph`,
-`partitionFunctionComplex_re_pos_of_leeYangSubdomain_latticeGraph`,
-`freeEnergyComplex_analyticAt_h_of_leeYangSubdomain_latticeGraph`,
-`partitionFunctionComplex_at_real_pos_latticeGraph`,
-`freeEnergyComplex_at_real_latticeGraph`,
-`norm_partitionFunctionComplex_at_real_latticeGraph`, and related
-real-axis restriction lemmas. The theorem names are unchanged from the
-former `Complex` declarations.
+`partitionFunctionComplex_re_pos_of_leeYangSubdomain_latticeGraph`, and
+`freeEnergyComplex_analyticAt_h_of_leeYangSubdomain_latticeGraph`. The
+ten `*_at_real_latticeGraph` real-axis evaluation wrappers
+(`partitionFunctionComplex_at_real_pos`, `freeEnergyComplex_at_real`,
+`norm_partitionFunctionComplex_at_real`, etc.) were carved out into
+`ComplexRealCompatAtReal.lean` in PR #2121. Theorem names are
+unchanged from the former `Complex` declarations.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRealCompatAtReal.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRealCompatAtReal.lean
@@ -1,0 +1,135 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.ComplexAnalyticity
+import IsingModel.AmbientComplexAnalyticity
+
+/-!
+# Concrete real-axis evaluation of complex partition function / free energy
+
+Narrow child module for ten ℤ^d `*_at_real_latticeGraph` real-axis
+evaluation wrappers of the complex partition function and free energy.
+Each wrapper is a thin pass-through to the corresponding ambient
+`IsingModel.*_at_real` lemma at the induced graph.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-! #### Real-axis evaluation of the complex partition function / free energy
+
+Direct ℤ^d forwarders for the real-axis evaluation identities of the
+complex partition function and free energy. These restate the
+real-complex bridge in the form most useful for Vitali convergence
+(pointwise values on the real axis via Fekete). -/
+
+/-- **ℤ^d `partitionFunctionComplex` at real `h₀`** (Λ-induced):
+`Z_ℂ(J, ↑h₀, β) = ↑(Z G ⟨J, h₀, β⟩)`. -/
+theorem partitionFunctionComplex_at_real_pos_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℝ) :
+    IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (J : ℂ) (h₀ : ℂ) (β : ℂ)
+      = ((IsingModel.partitionFunction
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+            ⟨J, h₀, β⟩ : ℝ) : ℂ) :=
+  IsingModel.partitionFunctionComplex_at_real_pos
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀
+
+/-- **ℤ^d `freeEnergyComplex` at real parameters** (Λ-induced):
+`f_ℂ(J, h, β) = ↑(f G ⟨J, h, β⟩)`. -/
+theorem freeEnergyComplex_at_real_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β : ℝ) :
+    IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (J : ℂ) (h : ℂ) (β : ℂ)
+      = ((IsingModel.freeEnergy
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+            ⟨J, h, β⟩ : ℝ) : ℂ) :=
+  IsingModel.freeEnergyComplex_at_real
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β
+
+/-- **ℤ^d `freeEnergyComplex ↔ freeEnergy` Vitali form** (Λ-induced):
+`f_ℂ G ↑p.J ↑p.h ↑p.β = ↑(f G p)`. Thin restatement of
+`freeEnergy_ofReal_eq_freeEnergyComplex` in the orientation most useful
+for Vitali convergence (RHS is the cast of the real-parameter value). -/
+theorem freeEnergyComplex_ofReal_eq_freeEnergy_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)
+      = ((IsingModel.freeEnergy
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p : ℝ) : ℂ) :=
+  IsingModel.freeEnergyComplex_ofReal_eq_freeEnergy
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d `Re Z_ℂ > 0` at real parameters** (Λ-induced):
+immediate from positivity of the real `Z`. -/
+theorem partitionFunctionComplex_re_pos_at_real_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    0 < (IsingModel.partitionFunctionComplex
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)).re :=
+  IsingModel.partitionFunctionComplex_re_pos_at_real
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d `Im Z_ℂ = 0` at real parameters** (Λ-induced). -/
+theorem partitionFunctionComplex_im_zero_at_real_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    (IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)).im = 0 :=
+  IsingModel.partitionFunctionComplex_im_zero_at_real
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d `Im (log Z_ℂ) = 0` at real parameters** (Λ-induced). -/
+theorem log_partitionFunctionComplex_im_zero_at_real_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    (Complex.log (IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ))).im = 0 :=
+  IsingModel.log_partitionFunctionComplex_im_zero_at_real
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d `Im f_ℂ = 0` at real parameters** (Λ-induced). -/
+theorem freeEnergyComplex_im_zero_at_real_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    (IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)).im = 0 :=
+  IsingModel.freeEnergyComplex_im_zero_at_real
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d `Re f_ℂ = f` at real parameters** (Λ-induced). -/
+theorem freeEnergyComplex_re_eq_freeEnergy_at_real_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    (IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)).re
+      = IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  IsingModel.freeEnergyComplex_re_eq_freeEnergy_at_real
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d `‖Z_ℂ‖ = Z` at real parameters** (Λ-induced). -/
+theorem norm_partitionFunctionComplex_at_real_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    ‖IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ)‖
+      = IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p :=
+  IsingModel.norm_partitionFunctionComplex_at_real
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+/-- **ℤ^d `Z_ℂ` is a positive real at real parameters** (Λ-induced):
+explicit witness for `Z_ℂ = ↑x` with `0 < x`. -/
+theorem partitionFunctionComplex_is_pos_real_at_real_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (p : IsingParams ℝ) :
+    ∃ x : ℝ, 0 < x ∧ IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ) = (x : ℂ) :=
+  IsingModel.partitionFunctionComplex_is_pos_real_at_real
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -3,6 +3,7 @@ import IsingModel.Concrete.IntLattice
 import IsingModel.Concrete.LatticeGraphCorrelation.Complex
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexAnalyticityBasic
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRealCompat
+import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRealCompatAtReal
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexContinuityNorm
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranches
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexSlitPlane


### PR DESCRIPTION
Part of #1850.

Split nine ℤ^d `*_at_real_latticeGraph` complex-to-real bridge wrappers out of `ComplexRealCompat.lean` into a new narrow child `ComplexRealCompatAtReal.lean`.

## Moved theorems (9)
- partitionFunctionComplex_at_real_pos_latticeGraph
- freeEnergyComplex_at_real_latticeGraph
- freeEnergyComplex_ofReal_eq_freeEnergy_latticeGraph
- partitionFunctionComplex_re_pos_at_real_latticeGraph
- partitionFunctionComplex_im_zero_at_real_latticeGraph
- log_partitionFunctionComplex_im_zero_at_real_latticeGraph
- freeEnergyComplex_im_zero_at_real_latticeGraph
- freeEnergyComplex_re_eq_freeEnergy_at_real_latticeGraph
- norm_partitionFunctionComplex_at_real_latticeGraph
- partitionFunctionComplex_is_pos_real_at_real_latticeGraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)