### PR TITLE
refactor(concrete): split ComplexRestrictions restrict family into child

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRestrictions.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRestrictions.lean
@@ -151,53 +151,11 @@ theorem freeEnergyComplex_continuousAt_h_real_coe_latticeGraph
   IsingModel.freeEnergyComplex_continuousAt_h_real_coe
     (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀
 
-/-- **ℤ^d `f_ℂ` restriction to real axis equals `f_ℝ`** (Λ-induced). -/
-theorem freeEnergyComplex_restrict_real_axis_eq_freeEnergy_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ) :
-    (fun h : ℝ => IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (J : ℂ) (h : ℂ) (β : ℂ))
-      = fun h : ℝ => ((IsingModel.freeEnergy
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-          ⟨J, h, β⟩ : ℝ) : ℂ) :=
-  IsingModel.freeEnergyComplex_restrict_real_axis_eq_freeEnergy
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β
+/-! ## Moved: restrict-real-axis wrappers
 
-/-- **ℤ^d `Z_ℂ` restriction to real axis equals `↑Z_ℝ`** (Λ-induced). -/
-theorem partitionFunctionComplex_restrict_real_axis_eq_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ) :
-    (fun h : ℝ => IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (J : ℂ) (h : ℂ) (β : ℂ))
-      = fun h : ℝ => ((IsingModel.partitionFunction
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-          ⟨J, h, β⟩ : ℝ) : ℂ) :=
-  IsingModel.partitionFunctionComplex_restrict_real_axis_eq
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β
-
-/-- **ℤ^d `Z_ℂ` restriction to `IsingParams ℝ`-image = `↑Z_ℝ`**
-(Λ-induced). -/
-theorem partitionFunctionComplex_restrict_joint_real_eq_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) :
-    (fun p : IsingParams ℝ => IsingModel.partitionFunctionComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ))
-      = fun p : IsingParams ℝ => ((IsingModel.partitionFunction
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p : ℝ) : ℂ) :=
-  IsingModel.partitionFunctionComplex_restrict_joint_real_eq
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-
-/-- **ℤ^d `f_ℂ` restriction to `IsingParams ℝ`-image = `↑f_ℝ`**
-(Λ-induced). -/
-theorem freeEnergyComplex_restrict_joint_real_eq_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) :
-    (fun p : IsingParams ℝ => IsingModel.freeEnergyComplex
-        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
-        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ))
-      = fun p : IsingParams ℝ => ((IsingModel.freeEnergy
-          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p : ℝ) : ℂ) :=
-  IsingModel.freeEnergyComplex_restrict_joint_real_eq
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+The four `{freeEnergy,partitionFunction}Complex_restrict_*_latticeGraph`
+real-axis restriction wrappers now live in
+`ComplexRestrictionsRestrict.lean`. -/
 
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRestrictionsRestrict.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexRestrictionsRestrict.lean
@@ -1,0 +1,68 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.ComplexAnalyticity
+import IsingModel.AmbientComplexAnalyticity
+
+/-!
+# Concrete Complex restrict-real-axis wrappers
+
+Narrow child module for four ℤ^d
+`{freeEnergy,partitionFunction}Complex_restrict_*_latticeGraph`
+real-axis restriction wrappers (`restrict_real_axis_eq` /
+`restrict_joint_real_eq`). Each wrapper is a thin pass-through to the
+corresponding ambient `*_restrict_*` lemma at `IsingModel.latticeGraph d`.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d `f_ℂ` restriction to real axis equals `f_ℝ`** (Λ-induced). -/
+theorem freeEnergyComplex_restrict_real_axis_eq_freeEnergy_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ) :
+    (fun h : ℝ => IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (J : ℂ) (h : ℂ) (β : ℂ))
+      = fun h : ℝ => ((IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          ⟨J, h, β⟩ : ℝ) : ℂ) :=
+  IsingModel.freeEnergyComplex_restrict_real_axis_eq_freeEnergy
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β
+
+/-- **ℤ^d `Z_ℂ` restriction to real axis equals `↑Z_ℝ`** (Λ-induced). -/
+theorem partitionFunctionComplex_restrict_real_axis_eq_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β : ℝ) :
+    (fun h : ℝ => IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (J : ℂ) (h : ℂ) (β : ℂ))
+      = fun h : ℝ => ((IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+          ⟨J, h, β⟩ : ℝ) : ℂ) :=
+  IsingModel.partitionFunctionComplex_restrict_real_axis_eq
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β
+
+/-- **ℤ^d `Z_ℂ` restriction to `IsingParams ℝ`-image = `↑Z_ℝ`**
+(Λ-induced). -/
+theorem partitionFunctionComplex_restrict_joint_real_eq_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) :
+    (fun p : IsingParams ℝ => IsingModel.partitionFunctionComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ))
+      = fun p : IsingParams ℝ => ((IsingModel.partitionFunction
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p : ℝ) : ℂ) :=
+  IsingModel.partitionFunctionComplex_restrict_joint_real_eq
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+
+/-- **ℤ^d `f_ℂ` restriction to `IsingParams ℝ`-image = `↑f_ℝ`**
+(Λ-induced). -/
+theorem freeEnergyComplex_restrict_joint_real_eq_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) :
+    (fun p : IsingParams ℝ => IsingModel.freeEnergyComplex
+        (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+        (p.J : ℂ) (p.h : ℂ) (p.β : ℂ))
+      = fun p : IsingParams ℝ => ((IsingModel.freeEnergy
+          (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) p : ℝ) : ℂ) :=
+  IsingModel.freeEnergyComplex_restrict_joint_real_eq
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ)
+
+
+end Ambient
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -8,6 +8,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.ComplexContinuityNorm
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranches
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexSlitPlane
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRestrictions
+import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRestrictionsRestrict
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranchEntire
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexIsingPoly
 import IsingModel.Concrete.LatticeGraphCorrelation.PerStage


### PR DESCRIPTION
Part of #1850.

Split four ℤ^d `{freeEnergy,partitionFunction}Complex_restrict_*_latticeGraph` real-axis restriction wrappers out of `ComplexRestrictions.lean` into a new narrow child `ComplexRestrictionsRestrict.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)