### PR TITLE
Split ComplexAnalyticityBasic single-variable freeEnergyComplex wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexAnalyticityBasic.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexAnalyticityBasic.lean
@@ -84,41 +84,13 @@ theorem partitionFunctionComplex_analyticAt_beta_latticeGraph
   IsingModel.partitionFunctionComplex_analyticAt_beta
     (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀
 
-/-- **ℤ^d `freeEnergyComplex` analytic in `h`** (Λ-induced), on
-`{Z ∈ slitPlane}`. -/
-theorem freeEnergyComplex_analyticAt_h_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℂ)
-    (hZ : IsingModel.partitionFunctionComplex
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h₀ β
-          ∈ Complex.slitPlane) :
-    AnalyticAt ℂ (fun h => IsingModel.freeEnergyComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) h₀ :=
-  IsingModel.freeEnergyComplex_analyticAt_h
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀ hZ
+/-! ## Moved: single-variable freeEnergyComplex wrappers
 
-/-- **ℤ^d `freeEnergyComplex` analytic in `J`** (Λ-induced), on
-`{Z ∈ slitPlane}`. -/
-theorem freeEnergyComplex_analyticAt_J_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β J₀ : ℂ)
-    (hZ : IsingModel.partitionFunctionComplex
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J₀ h β
-          ∈ Complex.slitPlane) :
-    AnalyticAt ℂ (fun J => IsingModel.freeEnergyComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) J₀ :=
-  IsingModel.freeEnergyComplex_analyticAt_J
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β J₀ hZ
+The three single-variable
+`freeEnergyComplex_analyticAt_{h,J,beta}_latticeGraph` wrappers now live in
+`ComplexAnalyticityBasicFreeEnergySingle.lean`. -/
 
-/-- **ℤ^d `freeEnergyComplex` analytic in `β`** (Λ-induced), on
-`{Z ∈ slitPlane}`. -/
-theorem freeEnergyComplex_analyticAt_beta_latticeGraph
-    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β₀ : ℂ)
-    (hZ : IsingModel.partitionFunctionComplex
-            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀
-          ∈ Complex.slitPlane) :
-    AnalyticAt ℂ (fun β => IsingModel.freeEnergyComplex
-      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) β₀ :=
-  IsingModel.freeEnergyComplex_analyticAt_beta
-    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀ hZ
+
 
 /-- **ℤ^d `partitionFunctionComplex` jointly entire in `(J, h, β)`**
 (Λ-induced). -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/ComplexAnalyticityBasicFreeEnergySingle.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/ComplexAnalyticityBasicFreeEnergySingle.lean
@@ -1,0 +1,55 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.ComplexAnalyticity
+import IsingModel.AmbientComplexAnalyticity
+
+/-!
+# ℤ^d single-variable `freeEnergyComplex` analyticity wrappers
+
+Narrow child module for three ℤ^d Λ-induced single-variable
+`freeEnergyComplex_analyticAt_{h,J,beta}_latticeGraph` wrappers extracted
+from `ComplexAnalyticityBasic.lean`. Each wrapper is a thin pass-through to
+the corresponding ambient `freeEnergyComplex_analyticAt_*` lemma, conditional
+on `Z ∈ slitPlane` at the base point.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d `freeEnergyComplex` analytic in `h`** (Λ-induced), on
+`{Z ∈ slitPlane}`. -/
+theorem freeEnergyComplex_analyticAt_h_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J β h₀ : ℂ)
+    (hZ : IsingModel.partitionFunctionComplex
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h₀ β
+          ∈ Complex.slitPlane) :
+    AnalyticAt ℂ (fun h => IsingModel.freeEnergyComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) h₀ :=
+  IsingModel.freeEnergyComplex_analyticAt_h
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J β h₀ hZ
+
+/-- **ℤ^d `freeEnergyComplex` analytic in `J`** (Λ-induced), on
+`{Z ∈ slitPlane}`. -/
+theorem freeEnergyComplex_analyticAt_J_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (h β J₀ : ℂ)
+    (hZ : IsingModel.partitionFunctionComplex
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J₀ h β
+          ∈ Complex.slitPlane) :
+    AnalyticAt ℂ (fun J => IsingModel.freeEnergyComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) J₀ :=
+  IsingModel.freeEnergyComplex_analyticAt_J
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) h β J₀ hZ
+
+/-- **ℤ^d `freeEnergyComplex` analytic in `β`** (Λ-induced), on
+`{Z ∈ slitPlane}`. -/
+theorem freeEnergyComplex_analyticAt_beta_latticeGraph
+    (d : ℕ) (Λ : Finset (Fin d → ℤ)) (J h β₀ : ℂ)
+    (hZ : IsingModel.partitionFunctionComplex
+            (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀
+          ∈ Complex.slitPlane) :
+    AnalyticAt ℂ (fun β => IsingModel.freeEnergyComplex
+      (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β) β₀ :=
+  IsingModel.freeEnergyComplex_analyticAt_beta
+    (Ambient.inducedGraph (IsingModel.latticeGraph d) Λ) J h β₀ hZ
+
+end Ambient
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -2,6 +2,7 @@ import IsingModel.Concrete.LatticeGraphBED
 import IsingModel.Concrete.IntLattice
 import IsingModel.Concrete.LatticeGraphCorrelation.Complex
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexAnalyticityBasic
+import IsingModel.Concrete.LatticeGraphCorrelation.ComplexAnalyticityBasicFreeEnergySingle
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRealCompat
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexRealCompatAtReal
 import IsingModel.Concrete.LatticeGraphCorrelation.ComplexContinuityNorm


### PR DESCRIPTION
Refactor split (Issue #1850): extract the 3 ℤ^d `freeEnergyComplex_analyticAt_{h,J,beta}_latticeGraph` (single-variable) wrappers out of `ComplexAnalyticityBasic.lean` into a narrow child module `ComplexAnalyticityBasicFreeEnergySingle.lean`.

* parent: `ComplexAnalyticityBasic.lean` (drops 3 theorems, keeps Moved doc block)
* child: `ComplexAnalyticityBasicFreeEnergySingle.lean` (3 theorems)
* `Legacy.lean`: re-export the new child

Part of #1850.