### PR TITLE
refactor: split ℤ^d correlationAlongExhaustion of_subset/of_not_subset/monotone wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/BaseCorrelationAlongEx.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/BaseCorrelationAlongEx.lean
@@ -60,36 +60,14 @@ theorem correlationAlongExhaustion_latticeGraph_empty
   correlationAlongExhaustion_empty (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) p n
 
-/-- **ℤ^d correlationAlongExhaustion of_subset unfolding**. -/
-theorem correlationAlongExhaustion_latticeGraph_of_subset
-    (d : ℕ) (p : IsingParams ℝ)
-    {A : Finset (Fin d → ℤ)} {n : ℕ}
-    (hA : A ⊆ (Ambient.cubicExhaustion d).volume n) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d)
-        (Ambient.cubicExhaustion d) p A n
-      = correlationΛ (IsingModel.latticeGraph d)
-        ((Ambient.cubicExhaustion d).volume n) p (liftFinset A hA) :=
-  correlationAlongExhaustion_of_subset (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p hA
+/-! ## Moved: subset / monotone wrappers
 
-/-- **ℤ^d correlationAlongExhaustion of_not_subset unfolding**. -/
-theorem correlationAlongExhaustion_latticeGraph_of_not_subset
-    (d : ℕ) (p : IsingParams ℝ)
-    {A : Finset (Fin d → ℤ)} {n : ℕ}
-    (hA : ¬ A ⊆ (Ambient.cubicExhaustion d).volume n) :
-    correlationAlongExhaustion (IsingModel.latticeGraph d)
-        (Ambient.cubicExhaustion d) p A n = 0 :=
-  correlationAlongExhaustion_of_not_subset (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p hA
+The three wrappers
+`correlationAlongExhaustion_latticeGraph_of_subset`,
+`correlationAlongExhaustion_latticeGraph_of_not_subset`,
+`correlationAlongExhaustion_latticeGraph_cubicExhaustion_monotone` now
+live in `BaseCorrelationAlongExSubsetMono.lean`. -/
 
-/-- **ℤ^d correlationAlongExhaustion stage-index Monotone**. -/
-theorem correlationAlongExhaustion_latticeGraph_cubicExhaustion_monotone
-    (d : ℕ) (p : IsingParams ℝ) (hf : Ferromagnetic p)
-    (A : Finset (Fin d → ℤ)) :
-    Monotone (correlationAlongExhaustion (IsingModel.latticeGraph d)
-      (Ambient.cubicExhaustion d) p A) :=
-  correlationAlongExhaustion_monotone (IsingModel.latticeGraph d)
-    (Ambient.cubicExhaustion d) p hf A
 
 end Ambient
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/BaseCorrelationAlongExSubsetMono.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/BaseCorrelationAlongExSubsetMono.lean
@@ -1,0 +1,63 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.Concrete.IntLattice
+import IsingModel.TranslationInvariance
+import IsingModel.PhaseTransition
+import IsingModel.Inequalities.FKG
+import IsingModel.AmbientFKG
+
+/-!
+# ℤ^d `correlationAlongExhaustion` subset / monotone wrappers
+
+Narrow child module for three ℤ^d
+`correlationAlongExhaustion_latticeGraph_*` wrappers extracted from
+`BaseCorrelationAlongEx.lean`:
+
+* `correlationAlongExhaustion_latticeGraph_of_subset`,
+* `correlationAlongExhaustion_latticeGraph_of_not_subset`,
+* `correlationAlongExhaustion_latticeGraph_cubicExhaustion_monotone`.
+
+Each result is a thin pass-through of the corresponding abstract
+`correlationAlongExhaustion_*` lemma at
+`G := IsingModel.latticeGraph d`. The theorem names are unchanged
+from the former `BaseCorrelationAlongEx` declarations.
+-/
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d correlationAlongExhaustion of_subset unfolding**. -/
+theorem correlationAlongExhaustion_latticeGraph_of_subset
+    (d : ℕ) (p : IsingParams ℝ)
+    {A : Finset (Fin d → ℤ)} {n : ℕ}
+    (hA : A ⊆ (Ambient.cubicExhaustion d).volume n) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) p A n
+      = correlationΛ (IsingModel.latticeGraph d)
+        ((Ambient.cubicExhaustion d).volume n) p (liftFinset A hA) :=
+  correlationAlongExhaustion_of_subset (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p hA
+
+/-- **ℤ^d correlationAlongExhaustion of_not_subset unfolding**. -/
+theorem correlationAlongExhaustion_latticeGraph_of_not_subset
+    (d : ℕ) (p : IsingParams ℝ)
+    {A : Finset (Fin d → ℤ)} {n : ℕ}
+    (hA : ¬ A ⊆ (Ambient.cubicExhaustion d).volume n) :
+    correlationAlongExhaustion (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) p A n = 0 :=
+  correlationAlongExhaustion_of_not_subset (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p hA
+
+/-- **ℤ^d correlationAlongExhaustion stage-index Monotone**. -/
+theorem correlationAlongExhaustion_latticeGraph_cubicExhaustion_monotone
+    (d : ℕ) (p : IsingParams ℝ) (hf : Ferromagnetic p)
+    (A : Finset (Fin d → ℤ)) :
+    Monotone (correlationAlongExhaustion (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) p A) :=
+  correlationAlongExhaustion_monotone (IsingModel.latticeGraph d)
+    (Ambient.cubicExhaustion d) p hf A
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -271,6 +271,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.Base
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseApply
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseBoundsTanh
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongEx
+import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongExSubsetMono
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongExBounds
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationBounds
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseVanish


### PR DESCRIPTION
Split three `correlationAlongExhaustion_latticeGraph_*` wrappers from `BaseCorrelationAlongEx.lean` into a focused child `BaseCorrelationAlongExSubsetMono.lean`:

- `correlationAlongExhaustion_latticeGraph_of_subset`
- `correlationAlongExhaustion_latticeGraph_of_not_subset`
- `correlationAlongExhaustion_latticeGraph_cubicExhaustion_monotone`

The parent retains 4 wrappers (2 J_zero + 2 empty). Pure wrapper relocation.

Part of refactoring loop.
