### PR TITLE
refactor: split ℤ^d ge_tanh wrappers from BaseBoundsTanh

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/BaseBoundsTanh.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/BaseBoundsTanh.lean
@@ -58,44 +58,15 @@ theorem correlationΛ_latticeGraph_J_zero
       = Real.tanh (β * h) ^ A.card :=
   correlationΛ_J_zero (IsingModel.latticeGraph d) Λ h β A
 
-/-- **ℤ^d `correlationΛ ≥ tanh(β·h)^|A|`** (ferromagnetic). -/
-theorem correlationΛ_latticeGraph_ge_tanh_pow_card
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
-    (A : Finset (↑Λ : Type _)) :
-    Real.tanh (β * h) ^ A.card
-      ≤ correlationΛ (IsingModel.latticeGraph d) Λ
-          (⟨J, h, β⟩ : IsingParams ℝ) A :=
-  correlationΛ_ge_tanh_pow_card (IsingModel.latticeGraph d) Λ hJ hh hβ A
+/-! ## Moved: ge_tanh wrappers
 
-/-- **ℤ^d `correlationInfinite ≥ tanh(β·h)^|A|`** (ferromagnetic). -/
-theorem correlationInfinite_latticeGraph_ge_tanh_pow_card
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
-    (A : Finset (Fin d → ℤ)) :
-    Real.tanh (β * h) ^ A.card
-      ≤ correlationInfinite (IsingModel.latticeGraph d) Λ
-          (⟨J, h, β⟩ : IsingParams ℝ) A :=
-  correlationInfinite_ge_tanh_pow_card (IsingModel.latticeGraph d) Λ hJ hh hβ A
+The four wrappers
+`correlationΛ_latticeGraph_ge_tanh_pow_card`,
+`correlationInfinite_latticeGraph_ge_tanh_pow_card`,
+`magnetizationΛ_latticeGraph_ge_tanh`,
+`magnetizationInfinite_latticeGraph_ge_tanh` now live in
+`BaseBoundsTanhGe.lean`. -/
 
-
-/-- **ℤ^d `magnetizationΛ ≥ tanh(β·h)`** (ferromagnetic). -/
-theorem magnetizationΛ_latticeGraph_ge_tanh
-    (d : ℕ) (Λ : Finset (Fin d → ℤ))
-    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (i : ↑Λ) :
-    Real.tanh (β * h)
-      ≤ magnetizationΛ (IsingModel.latticeGraph d) Λ
-          (⟨J, h, β⟩ : IsingParams ℝ) i :=
-  magnetizationΛ_ge_tanh (IsingModel.latticeGraph d) Λ hJ hh hβ i
-
-/-- **ℤ^d `magnetizationInfinite ≥ tanh(β·h)`** (ferromagnetic, any Exhaustion). -/
-theorem magnetizationInfinite_latticeGraph_ge_tanh
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (i : Fin d → ℤ) :
-    Real.tanh (β * h)
-      ≤ magnetizationInfinite (IsingModel.latticeGraph d) Λ
-          (⟨J, h, β⟩ : IsingParams ℝ) i :=
-  magnetizationInfinite_ge_tanh (IsingModel.latticeGraph d) Λ hJ hh hβ i
 
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/BaseBoundsTanhGe.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/BaseBoundsTanhGe.lean
@@ -1,0 +1,72 @@
+import IsingModel.Concrete.LatticeGraphBED
+import IsingModel.Concrete.IntLattice
+import IsingModel.TranslationInvariance
+import IsingModel.PhaseTransition
+import IsingModel.Inequalities.FKG
+import IsingModel.AmbientFKG
+
+/-!
+# ℤ^d `*_ge_tanh*` ferromagnetic wrappers
+
+Narrow child module for four ferromagnetic `*_ge_tanh*_latticeGraph`
+wrappers extracted from `BaseBoundsTanh.lean`:
+
+* `correlationΛ_latticeGraph_ge_tanh_pow_card`,
+* `correlationInfinite_latticeGraph_ge_tanh_pow_card`,
+* `magnetizationΛ_latticeGraph_ge_tanh`,
+* `magnetizationInfinite_latticeGraph_ge_tanh`.
+
+Each result is a thin pass-through of the corresponding abstract
+`correlation*_ge_tanh_pow_card` / `magnetization*_ge_tanh` lemma at
+`IsingModel.latticeGraph d`. The theorem names are unchanged from
+the former `BaseBoundsTanh` declarations.
+-/
+
+open scoped symmDiff
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d `correlationΛ ≥ tanh(β·h)^|A|`** (ferromagnetic). -/
+theorem correlationΛ_latticeGraph_ge_tanh_pow_card
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
+    (A : Finset (↑Λ : Type _)) :
+    Real.tanh (β * h) ^ A.card
+      ≤ correlationΛ (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β⟩ : IsingParams ℝ) A :=
+  correlationΛ_ge_tanh_pow_card (IsingModel.latticeGraph d) Λ hJ hh hβ A
+
+/-- **ℤ^d `correlationInfinite ≥ tanh(β·h)^|A|`** (ferromagnetic). -/
+theorem correlationInfinite_latticeGraph_ge_tanh_pow_card
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β)
+    (A : Finset (Fin d → ℤ)) :
+    Real.tanh (β * h) ^ A.card
+      ≤ correlationInfinite (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β⟩ : IsingParams ℝ) A :=
+  correlationInfinite_ge_tanh_pow_card (IsingModel.latticeGraph d) Λ hJ hh hβ A
+
+
+/-- **ℤ^d `magnetizationΛ ≥ tanh(β·h)`** (ferromagnetic). -/
+theorem magnetizationΛ_latticeGraph_ge_tanh
+    (d : ℕ) (Λ : Finset (Fin d → ℤ))
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (i : ↑Λ) :
+    Real.tanh (β * h)
+      ≤ magnetizationΛ (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β⟩ : IsingParams ℝ) i :=
+  magnetizationΛ_ge_tanh (IsingModel.latticeGraph d) Λ hJ hh hβ i
+
+/-- **ℤ^d `magnetizationInfinite ≥ tanh(β·h)`** (ferromagnetic, any Exhaustion). -/
+theorem magnetizationInfinite_latticeGraph_ge_tanh
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    {J h β : ℝ} (hJ : 0 ≤ J) (hh : 0 ≤ h) (hβ : 0 < β) (i : Fin d → ℤ) :
+    Real.tanh (β * h)
+      ≤ magnetizationInfinite (IsingModel.latticeGraph d) Λ
+          (⟨J, h, β⟩ : IsingParams ℝ) i :=
+  magnetizationInfinite_ge_tanh (IsingModel.latticeGraph d) Λ hJ hh hβ i
+
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Legacy.lean
@@ -270,6 +270,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.UniformMag
 import IsingModel.Concrete.LatticeGraphCorrelation.Base
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseApply
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseBoundsTanh
+import IsingModel.Concrete.LatticeGraphCorrelation.BaseBoundsTanhGe
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongEx
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongExSubsetMono
 import IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongExBounds


### PR DESCRIPTION
Split four ferromagnetic `*_ge_tanh*` wrappers from `BaseBoundsTanh.lean` into a focused child `BaseBoundsTanhGe.lean`:

- `correlationΛ_latticeGraph_ge_tanh_pow_card`
- `correlationInfinite_latticeGraph_ge_tanh_pow_card`
- `magnetizationΛ_latticeGraph_ge_tanh`
- `magnetizationInfinite_latticeGraph_ge_tanh`

The parent retains 4 wrappers: 3 `magnetization*_sq_le_one` and 1 `correlationΛ_J_zero`. Pure wrapper relocation.

Part of refactoring loop.
