### PR TITLE
refactor: split ambient mayerExpansionTerm analyticity wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -23,6 +23,7 @@ import IsingModel.AmbientLattice.SpecialCases.InfiniteVolume
 import IsingModel.AmbientLattice.SpecialCases.JointAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.JointRegularity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticity
+import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentities
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCases
 import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCases

--- a/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm
 
 /-!
 # Mayer analyticity wrappers along an exhaustion
@@ -36,28 +37,12 @@ theorem mayerPartialSumAlongExhaustion_analyticOnNhd
           (inducedGraph G (Λ.volume n)) N s) Set.univ :=
   mayerPartialSum_Λ_analyticOnNhd G (Λ.volume n) N
 
-/-! ### `mayerExpansionTerm` analyticity along an exhaustion -/
+/-! ## Moved: mayerExpansionTermAlongExhaustion analyticity wrappers
 
-/-- **Along-ex: `mayerExpansionTerm` is `AnalyticAt ℝ`**. -/
-theorem mayerExpansionTermAlongExhaustion_analyticAt
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (n : ℕ) (t : ℝ) :
-    AnalyticAt ℝ (fun s : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k s) t :=
-  mayerExpansionTerm_Λ_analyticAt G (Λ.volume n) k t
+The two `mayerExpansionTermAlongExhaustion_analytic{At,OnNhd}` wrappers
+now live in `MayerAnalyticityExpansionTerm.lean`. They are re-imported
+here so downstream consumers continue to see the symbols. -/
 
-/-- **Along-ex: `mayerExpansionTerm` is
-`AnalyticOnNhd ℝ _ Set.univ`**. -/
-theorem mayerExpansionTermAlongExhaustion_analyticOnNhd
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (n : ℕ) :
-    AnalyticOnNhd ℝ (fun s : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k s) Set.univ :=
-  mayerExpansionTerm_Λ_analyticOnNhd G (Λ.volume n) k
 
 /-! ### `mayerPartialSum` tanh β/J analyticity along an exhaustion -/
 
@@ -107,29 +92,11 @@ theorem mayerPartialSumAlongExhaustion_tanh_analyticOnNhd_J
           (Real.tanh (β * J'))) Set.univ :=
   mayerPartialSum_Λ_tanh_analyticOnNhd_J G (Λ.volume n) N β
 
-/-! ### `mayerExpansionTerm` tanh β/J analyticity along an exhaustion -/
+/-! ## Moved: mayerExpansionTermAlongExhaustion tanh analyticity wrappers
 
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) AnalyticAt in β**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_analyticAt_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (J β : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun β' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β' * J))) β :=
-  mayerExpansionTerm_Λ_tanh_analyticAt_beta G (Λ.volume n) k J β
+The two `mayerExpansionTermAlongExhaustion_tanh_analyticAt_{beta,J}`
+wrappers now live in `MayerAnalyticityExpansionTerm.lean`. -/
 
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) AnalyticAt in J**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_analyticAt_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (β J : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun J' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β * J'))) J :=
-  mayerExpansionTerm_Λ_tanh_analyticAt_J G (Λ.volume n) k β J
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityExpansionTerm.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityExpansionTerm.lean
@@ -1,0 +1,75 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Ambient mayerExpansionTermAlongExhaustion analyticity wrappers
+
+Narrow child module for 4 ambient `mayerExpansionTermAlongExhaustion_*`
+analyticity wrappers extracted from `MayerAnalyticity.lean`:
+
+* `mayerExpansionTermAlongExhaustion_analyticAt`,
+* `mayerExpansionTermAlongExhaustion_analyticOnNhd`,
+* `mayerExpansionTermAlongExhaustion_tanh_analyticAt_beta`,
+* `mayerExpansionTermAlongExhaustion_tanh_analyticAt_J`.
+
+Each result is a thin pass-through of the corresponding Λ-level
+`mayerExpansionTerm_Λ_*` analyticity lemma. The theorem names are
+unchanged from the former `MayerAnalyticity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+
+/-! ### `mayerExpansionTerm` analyticity along an exhaustion -/
+
+/-- **Along-ex: `mayerExpansionTerm` is `AnalyticAt ℝ`**. -/
+theorem mayerExpansionTermAlongExhaustion_analyticAt
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (n : ℕ) (t : ℝ) :
+    AnalyticAt ℝ (fun s : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k s) t :=
+  mayerExpansionTerm_Λ_analyticAt G (Λ.volume n) k t
+
+/-- **Along-ex: `mayerExpansionTerm` is
+`AnalyticOnNhd ℝ _ Set.univ`**. -/
+theorem mayerExpansionTermAlongExhaustion_analyticOnNhd
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (n : ℕ) :
+    AnalyticOnNhd ℝ (fun s : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k s) Set.univ :=
+  mayerExpansionTerm_Λ_analyticOnNhd G (Λ.volume n) k
+
+/-! ### `mayerExpansionTerm` tanh β/J analyticity along an exhaustion -/
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) AnalyticAt in β**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_analyticAt_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (J β : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun β' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β' * J))) β :=
+  mayerExpansionTerm_Λ_tanh_analyticAt_beta G (Λ.volume n) k J β
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) AnalyticAt in J**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_analyticAt_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (β J : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun J' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β * J'))) J :=
+  mayerExpansionTerm_Λ_tanh_analyticAt_J G (Λ.volume n) k β J
+
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor at the AmbientLattice/SpecialCases level: extract 4
\`mayerExpansionTermAlongExhaustion_*\` analyticity wrappers from
\`MayerAnalyticity.lean\` into new child
\`MayerAnalyticityExpansionTerm.lean\`.

Moved declarations:
* \`mayerExpansionTermAlongExhaustion_analyticAt\`
* \`mayerExpansionTermAlongExhaustion_analyticOnNhd\`
* \`mayerExpansionTermAlongExhaustion_tanh_analyticAt_beta\`
* \`mayerExpansionTermAlongExhaustion_tanh_analyticAt_J\`

Parent retains 6 \`mayerPartialSumAlongExhaustion_*\` analyticity
wrappers and re-imports the new child for transitive visibility.
\`AmbientLattice/SpecialCases/Legacy.lean\` is updated.

Pure refactor — no mathematical change.