### PR TITLE
refactor: split ambient joint analyticity partitionFunction+freeEnergy wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/JointAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointAnalyticity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.MagnetizationAlongExhaustion
+import IsingModel.AmbientLattice.SpecialCases.JointAnalyticityPartitionFreeEnergy
 
 /-!
 # Joint analyticity wrappers along an exhaustion
@@ -86,41 +87,13 @@ theorem susceptibilityAlongExhaustion_analyticOnNhd_joint_gen
       susceptibilityAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ i n) Set.univ :=
   fun ⟨β, J, h⟩ _ => susceptibilityAlongExhaustion_analyticAt_joint_gen G Λ i n β J h
 
-/-- **Along-ex: partitionFunction jointly AnalyticAt**. -/
-theorem partitionFunctionAlongExhaustion_analyticAt_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ) (β J h : ℝ) :
-    AnalyticAt ℝ (fun p : ℝ × ℝ × ℝ =>
-      partitionFunctionAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ n) (β, J, h) :=
-  partitionFunctionΛ_analyticAt_joint G (Λ.volume n) β J h
+/-! ## Moved: partitionFunction + freeEnergy joint analyticity wrappers
 
-/-- **Along-ex: partitionFunction jointly AnalyticOnNhd over Set.univ**. -/
-theorem partitionFunctionAlongExhaustion_analyticOnNhd_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ) :
-    AnalyticOnNhd ℝ (fun p : ℝ × ℝ × ℝ =>
-      partitionFunctionAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ n) Set.univ :=
-  partitionFunctionΛ_analyticOnNhd_joint G (Λ.volume n)
+The four `{partitionFunction,freeEnergy}AlongExhaustion_analytic{At,OnNhd}_joint`
+wrappers now live in `JointAnalyticityPartitionFreeEnergy.lean`. They
+are re-imported here so downstream consumers continue to see the symbols. -/
 
-/-- **Along-ex: freeEnergy jointly AnalyticAt**. -/
-theorem freeEnergyAlongExhaustion_analyticAt_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ) (β J h : ℝ) :
-    AnalyticAt ℝ (fun p : ℝ × ℝ × ℝ =>
-      freeEnergyAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ n) (β, J, h) :=
-  freeEnergyΛ_analyticAt_joint G (Λ.volume n) β J h
 
-/-- **Along-ex: freeEnergy jointly AnalyticOnNhd over Set.univ**. -/
-theorem freeEnergyAlongExhaustion_analyticOnNhd_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ) :
-    AnalyticOnNhd ℝ (fun p : ℝ × ℝ × ℝ =>
-      freeEnergyAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ n) Set.univ :=
-  freeEnergyΛ_analyticOnNhd_joint G (Λ.volume n)
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/JointAnalyticityPartitionFreeEnergy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointAnalyticityPartitionFreeEnergy.lean
@@ -1,0 +1,64 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.MagnetizationAlongExhaustion
+
+/-!
+# Ambient joint analyticity partitionFunction + freeEnergy wrappers
+
+Narrow child module for 4 ambient
+`{partitionFunction,freeEnergy}AlongExhaustion_analytic{At,OnNhd}_joint`
+wrappers extracted from `JointAnalyticity.lean`:
+
+* `partitionFunctionAlongExhaustion_analyticAt_joint`,
+* `partitionFunctionAlongExhaustion_analyticOnNhd_joint`,
+* `freeEnergyAlongExhaustion_analyticAt_joint`,
+* `freeEnergyAlongExhaustion_analyticOnNhd_joint`.
+
+Each result is a thin pass-through of the corresponding Λ-level
+`{partitionFunction,freeEnergy}Λ_analytic*_joint` lemma. The theorem
+names are unchanged from the former `JointAnalyticity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+
+/-- **Along-ex: partitionFunction jointly AnalyticAt**. -/
+theorem partitionFunctionAlongExhaustion_analyticAt_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ) (β J h : ℝ) :
+    AnalyticAt ℝ (fun p : ℝ × ℝ × ℝ =>
+      partitionFunctionAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ n) (β, J, h) :=
+  partitionFunctionΛ_analyticAt_joint G (Λ.volume n) β J h
+
+/-- **Along-ex: partitionFunction jointly AnalyticOnNhd over Set.univ**. -/
+theorem partitionFunctionAlongExhaustion_analyticOnNhd_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ) :
+    AnalyticOnNhd ℝ (fun p : ℝ × ℝ × ℝ =>
+      partitionFunctionAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ n) Set.univ :=
+  partitionFunctionΛ_analyticOnNhd_joint G (Λ.volume n)
+
+/-- **Along-ex: freeEnergy jointly AnalyticAt**. -/
+theorem freeEnergyAlongExhaustion_analyticAt_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ) (β J h : ℝ) :
+    AnalyticAt ℝ (fun p : ℝ × ℝ × ℝ =>
+      freeEnergyAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ n) (β, J, h) :=
+  freeEnergyΛ_analyticAt_joint G (Λ.volume n) β J h
+
+/-- **Along-ex: freeEnergy jointly AnalyticOnNhd over Set.univ**. -/
+theorem freeEnergyAlongExhaustion_analyticOnNhd_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ) :
+    AnalyticOnNhd ℝ (fun p : ℝ × ℝ × ℝ =>
+      freeEnergyAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ n) Set.univ :=
+  freeEnergyΛ_analyticOnNhd_joint G (Λ.volume n)
+
+end Ambient
+end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -21,6 +21,7 @@ import IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelationBa
 import IsingModel.AmbientLattice.SpecialCases.HighTemperatureCapstones
 import IsingModel.AmbientLattice.SpecialCases.InfiniteVolume
 import IsingModel.AmbientLattice.SpecialCases.JointAnalyticity
+import IsingModel.AmbientLattice.SpecialCases.JointAnalyticityPartitionFreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.JointRegularity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm


### PR DESCRIPTION
Wrapper-split refactor at the AmbientLattice/SpecialCases level: extract 4
thin pass-through `*AlongExhaustion_analytic{At,OnNhd}_joint` wrappers
from \`JointAnalyticity.lean\` into new child
\`JointAnalyticityPartitionFreeEnergy.lean\`.

Moved declarations:
* \`partitionFunctionAlongExhaustion_analyticAt_joint\`
* \`partitionFunctionAlongExhaustion_analyticOnNhd_joint\`
* \`freeEnergyAlongExhaustion_analyticAt_joint\`
* \`freeEnergyAlongExhaustion_analyticOnNhd_joint\`

Parent retains 6 wrappers
(correlation × 2, magnetization × 2, susceptibility × 2) with
tactic-mode proofs, and re-imports the new child for transitive
visibility.
\`AmbientLattice/SpecialCases/Legacy.lean\` is updated.

Pure refactor — no mathematical change.