### PR TITLE
refactor: split ambient log_vdPolymerFamilies analyticity wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -66,6 +66,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyTanhSharpening
 import IsingModel.AmbientLattice.SpecialCases.SusceptibilityConvergence
 import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity
 import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticity
+import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLog
 import IsingModel.AmbientLattice.Analyticity
 
 /-!

--- a/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLog
 
 /-!
 # Polymer-family analyticity wrappers along an exhaustion
@@ -52,55 +53,15 @@ theorem vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J
           ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) J :=
   vdPolymerFamilies_sum_Λ_tanh_analyticAt_J G (Λ.volume n) β J
 
-/-! ### `log_vdPolymerFamilies_sum` analyticity along an exhaustion -/
+/-! ## Moved: log_vdPolymerFamilies_sumAlongExhaustion analyticity wrappers
 
-/-- **Along-ex: log_vdPolymerFamilies_sum AnalyticAt for `t ≥ 0`**. -/
-theorem log_vdPolymerFamilies_sumAlongExhaustion_analyticAt
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
-    AnalyticAt ℝ (fun s : ℝ =>
-        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, s ^ P.card)) t :=
-  log_vdPolymerFamilies_sum_Λ_analyticAt G (Λ.volume n) ht
+The four `log_vdPolymerFamilies_sumAlongExhaustion_*` analyticity
+wrappers (`analyticAt`, `analyticOnNhd_Ici_zero`,
+`tanh_analyticAt_beta`, `tanh_analyticAt_J`) now live in
+`VdPolymerFamiliesAnalyticityLog.lean`. They are re-imported here so
+downstream consumers continue to see the symbols. -/
 
-/-- **Along-ex: log_vdPolymerFamilies_sum AnalyticOnNhd over `[0, ∞)`**. -/
-theorem log_vdPolymerFamilies_sumAlongExhaustion_analyticOnNhd_Ici_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
-    AnalyticOnNhd ℝ (fun s : ℝ =>
-        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, s ^ P.card)) (Set.Ici 0) :=
-  log_vdPolymerFamilies_sum_Λ_analyticOnNhd_Ici_zero
-    G (Λ.volume n)
 
-/-- **Along-ex: log_vdPolymerFamilies_sum ∘ tanh AnalyticAt in β under
-`0 ≤ β·J`**. -/
-theorem log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (hβJ : 0 ≤ β * J) (n : ℕ) :
-    AnalyticAt ℝ (fun β' : ℝ =>
-        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card)) β :=
-  log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_beta
-    G (Λ.volume n) J β hβJ
-
-/-- **Along-ex: log_vdPolymerFamilies_sum ∘ tanh AnalyticAt in J under
-`0 ≤ β·J`**. -/
-theorem log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β J : ℝ) (hβJ : 0 ≤ β * J) (n : ℕ) :
-    AnalyticAt ℝ (fun J' : ℝ =>
-        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card)) J :=
-  log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_J
-    G (Λ.volume n) β J hβJ
 
 /-! ### Epsilon analyticity along an exhaustion -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityLog.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityLog.lean
@@ -1,0 +1,78 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Ambient log_vdPolymerFamilies_sumAlongExhaustion analyticity wrappers
+
+Narrow child module for 4 ambient
+`log_vdPolymerFamilies_sumAlongExhaustion_*` analyticity wrappers
+extracted from `VdPolymerFamiliesAnalyticity.lean`:
+
+* `log_vdPolymerFamilies_sumAlongExhaustion_analyticAt`,
+* `log_vdPolymerFamilies_sumAlongExhaustion_analyticOnNhd_Ici_zero`,
+* `log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta`,
+* `log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J`.
+
+Each result is a thin pass-through of the corresponding Λ-level
+`log_vdPolymerFamilies_sum_Λ_*` lemma. The theorem names are unchanged
+from the former `VdPolymerFamiliesAnalyticity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+
+/-! ### `log_vdPolymerFamilies_sum` analyticity along an exhaustion -/
+
+/-- **Along-ex: log_vdPolymerFamilies_sum AnalyticAt for `t ≥ 0`**. -/
+theorem log_vdPolymerFamilies_sumAlongExhaustion_analyticAt
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    AnalyticAt ℝ (fun s : ℝ =>
+        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, s ^ P.card)) t :=
+  log_vdPolymerFamilies_sum_Λ_analyticAt G (Λ.volume n) ht
+
+/-- **Along-ex: log_vdPolymerFamilies_sum AnalyticOnNhd over `[0, ∞)`**. -/
+theorem log_vdPolymerFamilies_sumAlongExhaustion_analyticOnNhd_Ici_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
+    AnalyticOnNhd ℝ (fun s : ℝ =>
+        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, s ^ P.card)) (Set.Ici 0) :=
+  log_vdPolymerFamilies_sum_Λ_analyticOnNhd_Ici_zero
+    G (Λ.volume n)
+
+/-- **Along-ex: log_vdPolymerFamilies_sum ∘ tanh AnalyticAt in β under
+`0 ≤ β·J`**. -/
+theorem log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hβJ : 0 ≤ β * J) (n : ℕ) :
+    AnalyticAt ℝ (fun β' : ℝ =>
+        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card)) β :=
+  log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_beta
+    G (Λ.volume n) J β hβJ
+
+/-- **Along-ex: log_vdPolymerFamilies_sum ∘ tanh AnalyticAt in J under
+`0 ≤ β·J`**. -/
+theorem log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β J : ℝ) (hβJ : 0 ≤ β * J) (n : ℕ) :
+    AnalyticAt ℝ (fun J' : ℝ =>
+        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card)) J :=
+  log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_J
+    G (Λ.volume n) β J hβJ
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor: extract 4 ambient
\`log_vdPolymerFamilies_sumAlongExhaustion_*\` analyticity wrappers
from \`AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticity.lean\`
into new child \`VdPolymerFamiliesAnalyticityLog.lean\`.

Moved declarations:
* \`log_vdPolymerFamilies_sumAlongExhaustion_analyticAt\`
* \`log_vdPolymerFamilies_sumAlongExhaustion_analyticOnNhd_Ici_zero\`
* \`log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta\`
* \`log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J\`

Parent retains 4 wrappers (3 \`vdPolymerFamilies_sumAlongExhaustion_*\`
+ 1 \`vdPolymerFamilies_sumAlongExhaustion_minus_one_analyticAt\`)
and re-imports the new child.
\`AmbientLattice/SpecialCases/Legacy.lean\` is updated.

Pure refactor — no mathematical change.