### PR TITLE
refactor: split ambient polymerFreeEnergyAlongEx eq mayerPartialSum wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -29,6 +29,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentities
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCases
+import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPolymerFreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCases
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonInfrastructure
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivity

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCases.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPolymerFreeEnergy
 
 /-!
 # Mayer edge-case wrappers along an exhaustion
@@ -67,57 +68,14 @@ theorem mayer_identity_at_J_zero_AlongExhaustion
         (Real.tanh (β * (0 : ℝ))) :=
   mayer_identity_at_J_zero_Λ G (Λ.volume n) β N
 
-/-! ### §18.5 polymerFreeEnergy_eq_mayerPartialSum_at edge-case along-ex wraps -/
+/-! ## Moved: polymerFreeEnergyAlongExhaustion eq mayerPartialSum wrappers
 
-/-- **Along-ex: polymerFreeEnergy = mayerPartialSum at t = 0**. -/
-theorem polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (n : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) 0 =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N 0 :=
-  polymerFreeEnergy_Λ_eq_mayerPartialSum_at_zero G (Λ.volume n) N
+The four `polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_*`
+wrappers (`zero`, `betaJ_zero`, `beta_zero`, `J_zero`) now live in
+`MayerEdgeCasesPolymerFreeEnergy.lean`. They are re-imported here so
+downstream consumers continue to see the symbols. -/
 
-/-- **Along-ex: polymerFreeEnergy = mayerPartialSum at β·J = 0**. -/
-theorem polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_betaJ_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβJ : β * J = 0) (N : ℕ) (n : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh (β * J)) :=
-  polymerFreeEnergy_Λ_eq_mayerPartialSum_at_betaJ_zero
-    G (Λ.volume n) hβJ N
 
-/-- **Along-ex: polymerFreeEnergy = mayerPartialSum at β = 0**. -/
-theorem polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_beta_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J : ℝ) (N : ℕ) (n : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh ((0 : ℝ) * J)) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh ((0 : ℝ) * J)) :=
-  polymerFreeEnergy_Λ_eq_mayerPartialSum_at_beta_zero
-    G (Λ.volume n) J N
-
-/-- **Along-ex: polymerFreeEnergy = mayerPartialSum at J = 0**. -/
-theorem polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_J_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (N : ℕ) (n : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh (β * (0 : ℝ))) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh (β * (0 : ℝ))) :=
-  polymerFreeEnergy_Λ_eq_mayerPartialSum_at_J_zero
-    G (Λ.volume n) β N
 
 /-! ### §18.5 mayer_identity polymer_free_energy variants along-ex wraps -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCasesPolymerFreeEnergy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCasesPolymerFreeEnergy.lean
@@ -1,0 +1,80 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Ambient polymerFreeEnergyAlongExhaustion = mayerPartialSum edge-case wrappers
+
+Narrow child module for 4 ambient
+`polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_*` wrappers
+extracted from `MayerEdgeCases.lean`:
+
+* `polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_zero`,
+* `polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_betaJ_zero`,
+* `polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_beta_zero`,
+* `polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_J_zero`.
+
+Each result is a thin pass-through of the corresponding Λ-level
+`polymerFreeEnergy_Λ_eq_mayerPartialSum_at_*` lemma. The theorem
+names are unchanged from the former `MayerEdgeCases` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+
+/-! ### §18.5 polymerFreeEnergy_eq_mayerPartialSum_at edge-case along-ex wraps -/
+
+/-- **Along-ex: polymerFreeEnergy = mayerPartialSum at t = 0**. -/
+theorem polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (n : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) 0 =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N 0 :=
+  polymerFreeEnergy_Λ_eq_mayerPartialSum_at_zero G (Λ.volume n) N
+
+/-- **Along-ex: polymerFreeEnergy = mayerPartialSum at β·J = 0**. -/
+theorem polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_betaJ_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβJ : β * J = 0) (N : ℕ) (n : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh (β * J)) :=
+  polymerFreeEnergy_Λ_eq_mayerPartialSum_at_betaJ_zero
+    G (Λ.volume n) hβJ N
+
+/-- **Along-ex: polymerFreeEnergy = mayerPartialSum at β = 0**. -/
+theorem polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J : ℝ) (N : ℕ) (n : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh ((0 : ℝ) * J)) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh ((0 : ℝ) * J)) :=
+  polymerFreeEnergy_Λ_eq_mayerPartialSum_at_beta_zero
+    G (Λ.volume n) J N
+
+/-- **Along-ex: polymerFreeEnergy = mayerPartialSum at J = 0**. -/
+theorem polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_J_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (N : ℕ) (n : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh (β * (0 : ℝ))) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh (β * (0 : ℝ))) :=
+  polymerFreeEnergy_Λ_eq_mayerPartialSum_at_J_zero
+    G (Λ.volume n) β N
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor: extract 4 ambient
\`polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_*\` wrappers
from \`AmbientLattice/SpecialCases/MayerEdgeCases.lean\` into new
child \`MayerEdgeCasesPolymerFreeEnergy.lean\`.

Moved declarations:
* \`polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_zero\`
* \`polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_betaJ_zero\`
* \`polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_beta_zero\`
* \`polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_J_zero\`

Parent retains 7 wrappers (4 \`mayer_identity_at_*_AlongExhaustion\` +
3 \`mayer_identity_at_*_polymer_free_energy_AlongExhaustion\`)
and re-imports the new child.
\`AmbientLattice/SpecialCases/Legacy.lean\` is updated.

Pure refactor — no mathematical change.