### PR TITLE
refactor: split ambient mayerExpansionTermAlongEx basic identity wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -28,6 +28,7 @@ import IsingModel.AmbientLattice.SpecialCases.JointRegularity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentities
+import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentitiesExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCases
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPolymerFreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCases

--- a/IsingModel/AmbientLattice/SpecialCases/MayerBasicIdentities.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerBasicIdentities.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentitiesExpansionTerm
 
 /-!
 # Mayer basic identity wrappers along an exhaustion
@@ -68,34 +69,14 @@ theorem mayerPartialSumAlongExhaustion_at_zero
         (inducedGraph G (Λ.volume n)) N 0 = 0 :=
   mayerPartialSum_Λ_at_zero G (Λ.volume n) N
 
-/-- **Along-ex: mayerExpansionTerm at n = 0 = 0**. -/
-theorem mayerExpansionTermAlongExhaustion_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (t : ℝ) (n : ℕ) :
-    IsingModel.mayerExpansionTerm
-        (inducedGraph G (Λ.volume n)) 0 t = 0 :=
-  mayerExpansionTerm_Λ_zero G (Λ.volume n) t
+/-! ## Moved: mayerExpansionTermAlongExhaustion basic identity wrappers
 
-/-- **Along-ex: mayerExpansionTerm at n = 1 = ∑_P t^|P|**. -/
-theorem mayerExpansionTermAlongExhaustion_one
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (t : ℝ) (n : ℕ) :
-    IsingModel.mayerExpansionTerm
-        (inducedGraph G (Λ.volume n)) 1 t =
-      ∑ P ∈ IsingModel.allPolymers
-            (inducedGraph G (Λ.volume n)), t ^ P.card :=
-  mayerExpansionTerm_Λ_one G (Λ.volume n) t
+The three `mayerExpansionTermAlongExhaustion_*` basic identity wrappers
+(`zero`, `one`, `at_zero`) now live in
+`MayerBasicIdentitiesExpansionTerm.lean`. They are re-imported here so
+downstream consumers continue to see the symbols. -/
 
-/-- **Along-ex: mayerExpansionTerm at t = 0 = 0**. -/
-theorem mayerExpansionTermAlongExhaustion_at_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (n : ℕ) :
-    IsingModel.mayerExpansionTerm
-        (inducedGraph G (Λ.volume n)) k 0 = 0 :=
-  mayerExpansionTerm_Λ_at_zero G (Λ.volume n) k
+
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerBasicIdentitiesExpansionTerm.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerBasicIdentitiesExpansionTerm.lean
@@ -1,0 +1,55 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Ambient mayerExpansionTermAlongExhaustion basic identity wrappers
+
+Narrow child module for 3 ambient `mayerExpansionTermAlongExhaustion_*`
+basic identity wrappers extracted from `MayerBasicIdentities.lean`:
+
+* `mayerExpansionTermAlongExhaustion_zero`,
+* `mayerExpansionTermAlongExhaustion_one`,
+* `mayerExpansionTermAlongExhaustion_at_zero`.
+
+Each result is a thin pass-through of the corresponding Λ-level
+`mayerExpansionTerm_Λ_*` lemma. The theorem names are unchanged from
+the former `MayerBasicIdentities` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+
+/-- **Along-ex: mayerExpansionTerm at n = 0 = 0**. -/
+theorem mayerExpansionTermAlongExhaustion_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (t : ℝ) (n : ℕ) :
+    IsingModel.mayerExpansionTerm
+        (inducedGraph G (Λ.volume n)) 0 t = 0 :=
+  mayerExpansionTerm_Λ_zero G (Λ.volume n) t
+
+/-- **Along-ex: mayerExpansionTerm at n = 1 = ∑_P t^|P|**. -/
+theorem mayerExpansionTermAlongExhaustion_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (t : ℝ) (n : ℕ) :
+    IsingModel.mayerExpansionTerm
+        (inducedGraph G (Λ.volume n)) 1 t =
+      ∑ P ∈ IsingModel.allPolymers
+            (inducedGraph G (Λ.volume n)), t ^ P.card :=
+  mayerExpansionTerm_Λ_one G (Λ.volume n) t
+
+/-- **Along-ex: mayerExpansionTerm at t = 0 = 0**. -/
+theorem mayerExpansionTermAlongExhaustion_at_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (n : ℕ) :
+    IsingModel.mayerExpansionTerm
+        (inducedGraph G (Λ.volume n)) k 0 = 0 :=
+  mayerExpansionTerm_Λ_at_zero G (Λ.volume n) k
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor: extract 3 ambient
\`mayerExpansionTermAlongExhaustion_*\` basic identity wrappers from
\`AmbientLattice/SpecialCases/MayerBasicIdentities.lean\` into new
child \`MayerBasicIdentitiesExpansionTerm.lean\`.

Moved declarations:
* \`mayerExpansionTermAlongExhaustion_zero\`
* \`mayerExpansionTermAlongExhaustion_one\`
* \`mayerExpansionTermAlongExhaustion_at_zero\`

Parent retains 5 wrappers (2 \`vdPolymerFamilies_sumAlongExhaustion_at_*\`
+ 3 \`mayerPartialSumAlongExhaustion_*\`) and re-imports the new child.
\`AmbientLattice/SpecialCases/Legacy.lean\` is updated.

Pure refactor — no mathematical change.