### PR TITLE
refactor: split ambient MayerVdRegularity vdPolymerFamilies wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -45,6 +45,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer
 import IsingModel.AmbientLattice.SpecialCases.MagnetizationConvergence
 import IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity
 import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionClosedForms

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer
 
 /-!
 # Mayer and polymer-family regularity wrappers along an exhaustion
@@ -173,87 +174,16 @@ theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_J
 
 /-! ### §18.6 vdPolymerFamilies_sum regularity in t along-ex wraps -/
 
-/-- **Along-ex: `vdPolymerFamilies_sum` is `Continuous` in `t`**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_continuous
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
-    Continuous (fun t : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_continuous G (Λ.volume n)
+/-! ### Moved: `vdPolymerFamilies_sum` along-ex regularity wraps
 
-/-- **Along-ex: `vdPolymerFamilies_sum` is `Differentiable ℝ`
-in `t`**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_differentiable
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
-    Differentiable ℝ (fun t : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_differentiable G (Λ.volume n)
-
-/-- **Along-ex: `vdPolymerFamilies_sum` `HasDerivAt`**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_hasDerivAt
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ) (t : ℝ) :
-    HasDerivAt (fun s : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, s ^ P.card)
-      (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-        ∑ Q ∈ Γ, (∏ P ∈ Γ.erase Q, t ^ P.card) *
-          ((Q.card : ℝ) * t ^ (Q.card - 1))) t :=
-  vdPolymerFamilies_sum_Λ_hasDerivAt G (Λ.volume n) t
-
-/-! ### §18.5 vdPolymerFamilies_sum tanh β/J along-ex wraps -/
-
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) continuous in β**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J : ℝ) (n : ℕ) :
-    Continuous (fun β' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_continuous_beta G (Λ.volume n) J
-
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) continuous in J**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (n : ℕ) :
-    Continuous (fun J' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_continuous_J G (Λ.volume n) β
-
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) differentiable in β**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun β' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_differentiable_beta G (Λ.volume n) J
-
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) differentiable in J**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun J' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_differentiable_J G (Λ.volume n) β
+The seven `vdPolymerFamilies_sumAlongExhaustion_*` wrappers
+(`continuous`, `differentiable`, `hasDerivAt`, and the four
+tanh-composed `_continuous_{beta,J}` / `_differentiable_{beta,J}`
+variants) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymer.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymer.lean
@@ -1,0 +1,104 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# `vdPolymerFamilies_sum` regularity wrappers along an exhaustion
+
+Narrow child module for the seven §18.5 `vdPolymerFamilies_sum`
+along-exhaustion regularity and tanh wrappers (`Continuous`,
+`Differentiable`, `HasDerivAt`, and the four tanh-composed
+continuity / differentiability wrappers in `β` and `J`). Theorem
+names are unchanged from the former `MayerVdRegularity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### §18.5 vdPolymerFamilies_sum regularity along-ex wraps -/
+
+/-- **Along-ex: `vdPolymerFamilies_sum` is `Continuous` in `t`**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_continuous
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
+    Continuous (fun t : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_continuous G (Λ.volume n)
+
+/-- **Along-ex: `vdPolymerFamilies_sum` is `Differentiable ℝ`
+in `t`**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_differentiable
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
+    Differentiable ℝ (fun t : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_differentiable G (Λ.volume n)
+
+/-- **Along-ex: `vdPolymerFamilies_sum` `HasDerivAt`**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_hasDerivAt
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ) (t : ℝ) :
+    HasDerivAt (fun s : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, s ^ P.card)
+      (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+        ∑ Q ∈ Γ, (∏ P ∈ Γ.erase Q, t ^ P.card) *
+          ((Q.card : ℝ) * t ^ (Q.card - 1))) t :=
+  vdPolymerFamilies_sum_Λ_hasDerivAt G (Λ.volume n) t
+
+/-! ### §18.5 vdPolymerFamilies_sum tanh β/J along-ex wraps -/
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) continuous in β**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J : ℝ) (n : ℕ) :
+    Continuous (fun β' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_continuous_beta G (Λ.volume n) J
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) continuous in J**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) :
+    Continuous (fun J' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_continuous_J G (Λ.volume n) β
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) differentiable in β**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun β' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_differentiable_beta G (Λ.volume n) J
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) differentiable in J**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun J' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_differentiable_J G (Λ.volume n) β
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 7 ambient `vdPolymerFamilies_sumAlongExhaustion_*` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymer.lean`.

Planned moves:
* `vdPolymerFamilies_sumAlongExhaustion_continuous`
* `vdPolymerFamilies_sumAlongExhaustion_differentiable`
* `vdPolymerFamilies_sumAlongExhaustion_hasDerivAt`
* `vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_beta`
* `vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_J`
* `vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_beta`
* `vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_J`

These are all thin pass-throughs to `vdPolymerFamilies_sum_Λ_*` ambient lemmas. The new child imports only `IsingModel.AmbientLattice.Analyticity` and `IsingModel.AmbientLattice.Exhaustion` (the parent's imports) — it does not import the parent. The parent re-imports the new child so callers continue to see the symbols. Pure refactor — no mathematical change.