### PR TITLE
refactor: split ambient MayerVdRegularity tanh wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -45,6 +45,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer
 import IsingModel.AmbientLattice.SpecialCases.MagnetizationConvergence
 import IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer
 
 /-!
@@ -80,97 +81,15 @@ theorem mayerExpansionTermAlongExhaustion_differentiable
           (inducedGraph G (Λ.volume n)) k t) :=
   mayerExpansionTerm_Λ_differentiable G (Λ.volume n) k
 
-/-! ### §18.6 mayerPartialSum tanh β/J along-ex wraps -/
+/-! ### Moved: `mayerPartialSum` / `mayerExpansionTerm` tanh along-ex wraps
 
-/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (·*J) continuous in β**. -/
-theorem mayerPartialSumAlongExhaustion_tanh_continuous_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (J : ℝ) (n : ℕ) :
-    Continuous (fun β' : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N
-          (Real.tanh (β' * J))) :=
-  mayerPartialSum_Λ_tanh_continuous_beta G (Λ.volume n) N J
-
-/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (β*·) continuous in J**. -/
-theorem mayerPartialSumAlongExhaustion_tanh_continuous_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (β : ℝ) (n : ℕ) :
-    Continuous (fun J' : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N
-          (Real.tanh (β * J'))) :=
-  mayerPartialSum_Λ_tanh_continuous_J G (Λ.volume n) N β
-
-/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (·*J) differentiable in β**. -/
-theorem mayerPartialSumAlongExhaustion_tanh_differentiable_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (J : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun β' : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N
-          (Real.tanh (β' * J))) :=
-  mayerPartialSum_Λ_tanh_differentiable_beta G (Λ.volume n) N J
-
-/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (β*·) differentiable in J**. -/
-theorem mayerPartialSumAlongExhaustion_tanh_differentiable_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (β : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun J' : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N
-          (Real.tanh (β * J'))) :=
-  mayerPartialSum_Λ_tanh_differentiable_J G (Λ.volume n) N β
-
-/-! ### §18.5 mayerExpansionTerm tanh β/J along-ex wraps -/
-
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) continuous in β**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_continuous_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (J : ℝ) (n : ℕ) :
-    Continuous (fun β' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β' * J))) :=
-  mayerExpansionTerm_Λ_tanh_continuous_beta G (Λ.volume n) k J
-
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) continuous in J**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_continuous_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (β : ℝ) (n : ℕ) :
-    Continuous (fun J' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β * J'))) :=
-  mayerExpansionTerm_Λ_tanh_continuous_J G (Λ.volume n) k β
-
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) differentiable in β**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (J : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun β' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β' * J))) :=
-  mayerExpansionTerm_Λ_tanh_differentiable_beta G (Λ.volume n) k J
-
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) differentiable in J**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (β : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun J' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β * J'))) :=
-  mayerExpansionTerm_Λ_tanh_differentiable_J G (Λ.volume n) k β
+The eight `mayerPartialSumAlongExhaustion_tanh_*` and
+`mayerExpansionTermAlongExhaustion_tanh_*` continuity /
+differentiability wrappers (in `β` and `J`) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-! ### §18.6 vdPolymerFamilies_sum regularity in t along-ex wraps -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanh.lean
@@ -1,0 +1,113 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# `mayerPartialSum` / `mayerExpansionTerm` tanh regularity wrappers along an exhaustion
+
+Narrow child module for the eight §18.5--§18.6 along-exhaustion
+`mayerPartialSum` and `mayerExpansionTerm` tanh-composed continuity
+and differentiability wrappers in `β` and `J`. Each wrapper is a thin
+pass-through to the corresponding `mayerPartialSum_Λ_tanh_*` /
+`mayerExpansionTerm_Λ_tanh_*` ambient lemma. Theorem names are
+unchanged from the former `MayerVdRegularity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### §18.6 mayerPartialSum tanh β/J along-ex wraps -/
+
+/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (·*J) continuous in β**. -/
+theorem mayerPartialSumAlongExhaustion_tanh_continuous_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (J : ℝ) (n : ℕ) :
+    Continuous (fun β' : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N
+          (Real.tanh (β' * J))) :=
+  mayerPartialSum_Λ_tanh_continuous_beta G (Λ.volume n) N J
+
+/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (β*·) continuous in J**. -/
+theorem mayerPartialSumAlongExhaustion_tanh_continuous_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (β : ℝ) (n : ℕ) :
+    Continuous (fun J' : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N
+          (Real.tanh (β * J'))) :=
+  mayerPartialSum_Λ_tanh_continuous_J G (Λ.volume n) N β
+
+/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (·*J) differentiable in β**. -/
+theorem mayerPartialSumAlongExhaustion_tanh_differentiable_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (J : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun β' : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N
+          (Real.tanh (β' * J))) :=
+  mayerPartialSum_Λ_tanh_differentiable_beta G (Λ.volume n) N J
+
+/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (β*·) differentiable in J**. -/
+theorem mayerPartialSumAlongExhaustion_tanh_differentiable_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (β : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun J' : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N
+          (Real.tanh (β * J'))) :=
+  mayerPartialSum_Λ_tanh_differentiable_J G (Λ.volume n) N β
+
+/-! ### §18.5 mayerExpansionTerm tanh β/J along-ex wraps -/
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) continuous in β**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_continuous_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (J : ℝ) (n : ℕ) :
+    Continuous (fun β' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β' * J))) :=
+  mayerExpansionTerm_Λ_tanh_continuous_beta G (Λ.volume n) k J
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) continuous in J**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_continuous_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (β : ℝ) (n : ℕ) :
+    Continuous (fun J' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β * J'))) :=
+  mayerExpansionTerm_Λ_tanh_continuous_J G (Λ.volume n) k β
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) differentiable in β**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (J : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun β' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β' * J))) :=
+  mayerExpansionTerm_Λ_tanh_differentiable_beta G (Λ.volume n) k J
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) differentiable in J**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (β : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun J' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β * J'))) :=
+  mayerExpansionTerm_Λ_tanh_differentiable_J G (Λ.volume n) k β
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 8 ambient `mayerPartialSumAlongExhaustion_tanh_*` and `mayerExpansionTermAlongExhaustion_tanh_*` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanh.lean`.

Planned moves:
* `mayerPartialSumAlongExhaustion_tanh_continuous_beta`
* `mayerPartialSumAlongExhaustion_tanh_continuous_J`
* `mayerPartialSumAlongExhaustion_tanh_differentiable_beta`
* `mayerPartialSumAlongExhaustion_tanh_differentiable_J`
* `mayerExpansionTermAlongExhaustion_tanh_continuous_beta`
* `mayerExpansionTermAlongExhaustion_tanh_continuous_J`
* `mayerExpansionTermAlongExhaustion_tanh_differentiable_beta`
* `mayerExpansionTermAlongExhaustion_tanh_differentiable_J`

These are all thin pass-throughs to `mayerPartialSum_Λ_tanh_*` / `mayerExpansionTerm_Λ_tanh_*` ambient lemmas. The new child takes the parent's imports; the parent re-imports the new child for transitive visibility. Pure refactor — no mathematical change.