### PR TITLE
refactor: split ambient JointRegularity At wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/JointRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointRegularity.lean
@@ -103,59 +103,15 @@ theorem susceptibilityAlongExhaustion_differentiable_joint_gen
   · simp only [hi, dif_neg, not_false_iff]
     exact differentiable_const _
 
-/-- **Along-ex: correlation jointly ContinuousAt** (general G). -/
-theorem correlationAlongExhaustion_continuousAt_joint_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (A : Finset V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
-    ContinuousAt (fun q : ℝ × ℝ × ℝ =>
-      correlationAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ A n) p :=
-  (correlationAlongExhaustion_continuous_joint_gen G Λ A n).continuousAt
+/-! ## Moved: joint ContinuousAt / DifferentiableAt along-ex wrappers
 
-/-- **Along-ex: correlation jointly DifferentiableAt** (general G). -/
-theorem correlationAlongExhaustion_differentiableAt_joint_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (A : Finset V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
-    DifferentiableAt ℝ (fun q : ℝ × ℝ × ℝ =>
-      correlationAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ A n) p :=
-  (correlationAlongExhaustion_differentiable_joint_gen G Λ A n).differentiableAt
-
-/-- **Along-ex: magnetization jointly ContinuousAt** (general G). -/
-theorem magnetizationAlongExhaustion_continuousAt_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (i : V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
-    ContinuousAt (fun q : ℝ × ℝ × ℝ =>
-      magnetizationAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ i n) p :=
-  (magnetizationAlongExhaustion_continuous_joint G Λ i n).continuousAt
-
-/-- **Along-ex: magnetization jointly DifferentiableAt** (general G). -/
-theorem magnetizationAlongExhaustion_differentiableAt_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (i : V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
-    DifferentiableAt ℝ (fun q : ℝ × ℝ × ℝ =>
-      magnetizationAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ i n) p :=
-  (magnetizationAlongExhaustion_differentiable_joint G Λ i n).differentiableAt
-
-/-- **Along-ex: susceptibility jointly ContinuousAt** (general G). -/
-theorem susceptibilityAlongExhaustion_continuousAt_joint_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (i : V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
-    ContinuousAt (fun q : ℝ × ℝ × ℝ =>
-      susceptibilityAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ i n) p :=
-  (susceptibilityAlongExhaustion_continuous_joint_gen G Λ i n).continuousAt
-
-/-- **Along-ex: susceptibility jointly DifferentiableAt** (general G). -/
-theorem susceptibilityAlongExhaustion_differentiableAt_joint_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (i : V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
-    DifferentiableAt ℝ (fun q : ℝ × ℝ × ℝ =>
-      susceptibilityAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ i n) p :=
-  (susceptibilityAlongExhaustion_differentiable_joint_gen G Λ i n).differentiableAt
+The six joint `_continuousAt_joint*` / `_differentiableAt_joint*`
+wrappers for correlation, magnetization, and susceptibility now live
+in `IsingModel.AmbientLattice.SpecialCases.JointRegularityAt`. The
+legacy import path is preserved by re-exporting the new child from
+`Legacy.lean` and from each downstream consumer that previously
+imported only this parent.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/JointRegularityAt.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointRegularityAt.lean
@@ -1,0 +1,75 @@
+import IsingModel.AmbientLattice.SpecialCases.JointRegularity
+
+/-!
+# Joint `ContinuousAt` / `DifferentiableAt` along-ex wrappers
+
+Narrow child module for the six pointwise joint `ContinuousAt` /
+`DifferentiableAt` wrappers along an exhaustion (correlation,
+magnetization, susceptibility), obtained from the corresponding
+`_continuous_joint*` / `_differentiable_joint*` wrappers in the
+parent `JointRegularity` module via the `.continuousAt` /
+`.differentiableAt` projections. Theorem names are unchanged from
+the former `JointRegularity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: correlation jointly ContinuousAt** (general G). -/
+theorem correlationAlongExhaustion_continuousAt_joint_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (A : Finset V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
+    ContinuousAt (fun q : ℝ × ℝ × ℝ =>
+      correlationAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ A n) p :=
+  (correlationAlongExhaustion_continuous_joint_gen G Λ A n).continuousAt
+
+/-- **Along-ex: correlation jointly DifferentiableAt** (general G). -/
+theorem correlationAlongExhaustion_differentiableAt_joint_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (A : Finset V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
+    DifferentiableAt ℝ (fun q : ℝ × ℝ × ℝ =>
+      correlationAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ A n) p :=
+  (correlationAlongExhaustion_differentiable_joint_gen G Λ A n).differentiableAt
+
+/-- **Along-ex: magnetization jointly ContinuousAt** (general G). -/
+theorem magnetizationAlongExhaustion_continuousAt_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (i : V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
+    ContinuousAt (fun q : ℝ × ℝ × ℝ =>
+      magnetizationAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ i n) p :=
+  (magnetizationAlongExhaustion_continuous_joint G Λ i n).continuousAt
+
+/-- **Along-ex: magnetization jointly DifferentiableAt** (general G). -/
+theorem magnetizationAlongExhaustion_differentiableAt_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (i : V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
+    DifferentiableAt ℝ (fun q : ℝ × ℝ × ℝ =>
+      magnetizationAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ i n) p :=
+  (magnetizationAlongExhaustion_differentiable_joint G Λ i n).differentiableAt
+
+/-- **Along-ex: susceptibility jointly ContinuousAt** (general G). -/
+theorem susceptibilityAlongExhaustion_continuousAt_joint_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (i : V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
+    ContinuousAt (fun q : ℝ × ℝ × ℝ =>
+      susceptibilityAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ i n) p :=
+  (susceptibilityAlongExhaustion_continuous_joint_gen G Λ i n).continuousAt
+
+/-- **Along-ex: susceptibility jointly DifferentiableAt** (general G). -/
+theorem susceptibilityAlongExhaustion_differentiableAt_joint_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (i : V) (n : ℕ) (p : ℝ × ℝ × ℝ) :
+    DifferentiableAt ℝ (fun q : ℝ × ℝ × ℝ =>
+      susceptibilityAlongExhaustion G Λ ⟨q.2.1, q.2.2, q.1⟩ i n) p :=
+  (susceptibilityAlongExhaustion_differentiable_joint_gen G Λ i n).differentiableAt
+
+end Ambient
+end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -31,6 +31,7 @@ import IsingModel.AmbientLattice.SpecialCases.InfiniteVolume
 import IsingModel.AmbientLattice.SpecialCases.JointAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.JointAnalyticityPartitionFreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.JointRegularity
+import IsingModel.AmbientLattice.SpecialCases.JointRegularityAt
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentities

--- a/IsingModel/Concrete/LatticeGraphCorrelation/JointRegularityPointwiseAlongEx.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/JointRegularityPointwiseAlongEx.lean
@@ -1,5 +1,6 @@
 import IsingModel.Lattice
 import IsingModel.AmbientLattice.SpecialCases.JointRegularity
+import IsingModel.AmbientLattice.SpecialCases.JointRegularityAt
 
 /-!
 # ℤ^d AlongExhaustion joint pointwise regularity wrappers

--- a/IsingModel/Concrete/LatticeGraphCorrelation/JointRegularityPointwiseAlongExMagSusc.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/JointRegularityPointwiseAlongExMagSusc.lean
@@ -1,5 +1,6 @@
 import IsingModel.Lattice
 import IsingModel.AmbientLattice.SpecialCases.JointRegularity
+import IsingModel.AmbientLattice.SpecialCases.JointRegularityAt
 
 /-!
 # ℤ^d AlongExhaustion joint pointwise mag + susc wrappers


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 6 ambient joint `_continuousAt_joint*` / `_differentiableAt_joint*` wrappers from `IsingModel/AmbientLattice/SpecialCases/JointRegularity.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/JointRegularityAt.lean`.

Planned moves:
* `correlationAlongExhaustion_continuousAt_joint_gen`
* `correlationAlongExhaustion_differentiableAt_joint_gen`
* `magnetizationAlongExhaustion_continuousAt_joint`
* `magnetizationAlongExhaustion_differentiableAt_joint`
* `susceptibilityAlongExhaustion_continuousAt_joint_gen`
* `susceptibilityAlongExhaustion_differentiableAt_joint_gen`

These are thin pass-throughs to the parent's `_continuous_joint*` / `_differentiable_joint*` wrappers via the `.continuousAt` / `.differentiableAt` projections. The new child imports the parent. The parent does NOT re-import the child (cycle prevention). `Legacy.lean` and two Concrete consumer files (`JointRegularityPointwiseAlongEx.lean`, `JointRegularityPointwiseAlongExMagSusc.lean`) add the new child import.

Parent retains 6 `_continuous_joint*` / `_differentiable_joint*` wrappers.