### PR TITLE
refactor: split ambient MayerStrictPositivity vdPolymerFamilies wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -46,6 +46,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivity
 import IsingModel.AmbientLattice.SpecialCases.MayerFilterConnected
 import IsingModel.AmbientLattice.SpecialCases.MayerRecurrenceHasSum
 import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivity
+import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSum
 import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIff
 import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds

--- a/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSum
 
 /-!
 # Mayer strict positivity wrappers along an exhaustion
@@ -18,36 +19,14 @@ variable {V : Type*} [DecidableEq V]
 /-! ### §18.5 strict-mono / strict-pos under polymers ≠ ∅ along-ex
 wraps -/
 
-/-- **Along-ex: vdSum(s) < vdSum(t) under polymers exist**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_lt_of_lt_of_polymers_nonempty
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ)
-    (h_poly : (IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n))).Nonempty)
-    {s t : ℝ} (hs : 0 ≤ s) (hst : s < t) :
-    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-        ∏ P ∈ Γ, s ^ P.card) <
-      ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card :=
-  vdPolymerFamilies_sum_Λ_lt_of_lt_of_polymers_nonempty
-    G (Λ.volume n) h_poly hs hst
+/-! ## Moved: vdPolymerFamilies_sum strict-positivity wrappers
 
-/-- **Along-ex: vdSum is `StrictMonoOn (Set.Ici 0)`**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_strictMonoOn_of_polymers_nonempty
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ)
-    (h_poly : (IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n))).Nonempty) :
-    StrictMonoOn
-      (fun t : ℝ => ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card) (Set.Ici 0) :=
-  vdPolymerFamilies_sum_Λ_strictMonoOn_of_polymers_nonempty
-    G (Λ.volume n) h_poly
+The seven `vdPolymerFamilies_sumAlongExhaustion_*_of_polymers_nonempty`
+wrappers now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSum`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-- **Along-ex: 0 < pFE under `0 < t` and polymers exist**. -/
 theorem polymerFreeEnergyAlongExhaustion_pos_of_t_pos_of_polymers_nonempty
@@ -59,34 +38,6 @@ theorem polymerFreeEnergyAlongExhaustion_pos_of_t_pos_of_polymers_nonempty
     0 < IsingModel.polymerFreeEnergy
         (inducedGraph G (Λ.volume n)) t :=
   polymerFreeEnergy_Λ_pos_of_t_pos_of_polymers_nonempty
-    G (Λ.volume n) h_t_pos h_poly
-
-/-- **Along-ex: 1 < vdSum under `0 < t` and polymers exist**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_gt_one_of_t_pos_of_polymers_nonempty
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (h_t_pos : 0 < t) (n : ℕ)
-    (h_poly : (IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n))).Nonempty) :
-    1 < (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-            ∏ P ∈ Γ, t ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_gt_one_of_t_pos_of_polymers_nonempty
-    G (Λ.volume n) h_t_pos h_poly
-
-/-- **Along-ex: 0 < ε(t) under `0 < t` and polymers exist**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_minus_one_pos_of_t_pos_of_polymers_nonempty
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (h_t_pos : 0 < t) (n : ℕ)
-    (h_poly : (IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n))).Nonempty) :
-    0 < (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, t ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_minus_one_pos_of_t_pos_of_polymers_nonempty
     G (Λ.volume n) h_t_pos h_poly
 
 /-- **Along-ex: 0 < pFE(tanh) under `0 < tanh` and polymers exist**. -/
@@ -102,35 +53,6 @@ polymerFreeEnergyAlongExhaustion_tanh_pos_of_tanh_pos_of_polymers_nonempty
   polymerFreeEnergy_Λ_tanh_pos_of_tanh_pos_of_polymers_nonempty
     G (Λ.volume n) h_tanh_pos h_poly
 
-/-- **Along-ex: 1 < vdSum(tanh) under `0 < tanh` and polymers
-exist**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_tanh_gt_one_of_tanh_pos_of_polymers_nonempty
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (h_tanh_pos : 0 < Real.tanh (β * J)) (n : ℕ)
-    (h_poly : (IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n))).Nonempty) :
-    1 < (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_gt_one_of_tanh_pos_of_polymers_nonempty
-    G (Λ.volume n) h_tanh_pos h_poly
-
-/-- **Along-ex: 0 < ε(tanh) under `0 < tanh` and polymers exist**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_pos_of_tanh_pos_of_polymers_nonempty
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (h_tanh_pos : 0 < Real.tanh (β * J)) (n : ℕ)
-    (h_poly : (IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n))).Nonempty) :
-    0 < (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_minus_one_tanh_pos_of_tanh_pos_of_polymers_nonempty
-    G (Λ.volume n) h_tanh_pos h_poly
-
 /-- **Along-ex: pFE is `StrictMonoOn (Set.Ioi 0)`**. -/
 theorem
 polymerFreeEnergyAlongExhaustion_strictMonoOn_Ioi_zero_of_polymers_nonempty
@@ -143,19 +65,6 @@ polymerFreeEnergyAlongExhaustion_strictMonoOn_Ioi_zero_of_polymers_nonempty
   polymerFreeEnergy_Λ_strictMonoOn_Ioi_zero_of_polymers_nonempty
     G (Λ.volume n) h_poly
 
-/-- **Along-ex: vdSum is `StrictMonoOn (Set.Ioi 0)`**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_strictMonoOn_Ioi_zero_of_polymers_nonempty
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ)
-    (h_poly : (IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n))).Nonempty) :
-    StrictMonoOn
-      (fun t : ℝ => ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card) (Set.Ioi 0) :=
-  vdPolymerFamilies_sum_Λ_strictMonoOn_Ioi_zero_of_polymers_nonempty
-    G (Λ.volume n) h_poly
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivityVdSum.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivityVdSum.lean
@@ -1,0 +1,124 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# `vdPolymerFamilies_sum` strict-positivity wrappers along an exhaustion
+
+Narrow child module for the seven §18.5 along-exhaustion
+`vdPolymerFamilies_sum` strict-monotonicity / strict-positivity
+wrappers under `allPolymers` nonempty hypotheses (general,
+tanh-composed, and `StrictMonoOn` on `Ici 0` / `Ioi 0`). Each
+wrapper is a thin pass-through to the corresponding
+`vdPolymerFamilies_sum_Λ_*` ambient lemma. Theorem names are
+unchanged from the former `MayerStrictPositivity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: vdSum(s) < vdSum(t) under polymers exist**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_lt_of_lt_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ)
+    (h_poly : (IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n))).Nonempty)
+    {s t : ℝ} (hs : 0 ≤ s) (hst : s < t) :
+    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+        ∏ P ∈ Γ, s ^ P.card) <
+      ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card :=
+  vdPolymerFamilies_sum_Λ_lt_of_lt_of_polymers_nonempty
+    G (Λ.volume n) h_poly hs hst
+
+/-- **Along-ex: vdSum is `StrictMonoOn (Set.Ici 0)`**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_strictMonoOn_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ)
+    (h_poly : (IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n))).Nonempty) :
+    StrictMonoOn
+      (fun t : ℝ => ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card) (Set.Ici 0) :=
+  vdPolymerFamilies_sum_Λ_strictMonoOn_of_polymers_nonempty
+    G (Λ.volume n) h_poly
+
+/-- **Along-ex: 1 < vdSum under `0 < t` and polymers exist**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_gt_one_of_t_pos_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (h_t_pos : 0 < t) (n : ℕ)
+    (h_poly : (IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n))).Nonempty) :
+    1 < (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+            ∏ P ∈ Γ, t ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_gt_one_of_t_pos_of_polymers_nonempty
+    G (Λ.volume n) h_t_pos h_poly
+
+/-- **Along-ex: 0 < ε(t) under `0 < t` and polymers exist**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_minus_one_pos_of_t_pos_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (h_t_pos : 0 < t) (n : ℕ)
+    (h_poly : (IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n))).Nonempty) :
+    0 < (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, t ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_minus_one_pos_of_t_pos_of_polymers_nonempty
+    G (Λ.volume n) h_t_pos h_poly
+
+/-- **Along-ex: 1 < vdSum(tanh) under `0 < tanh` and polymers
+exist**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_tanh_gt_one_of_tanh_pos_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (h_tanh_pos : 0 < Real.tanh (β * J)) (n : ℕ)
+    (h_poly : (IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n))).Nonempty) :
+    1 < (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_gt_one_of_tanh_pos_of_polymers_nonempty
+    G (Λ.volume n) h_tanh_pos h_poly
+
+/-- **Along-ex: 0 < ε(tanh) under `0 < tanh` and polymers exist**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_pos_of_tanh_pos_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (h_tanh_pos : 0 < Real.tanh (β * J)) (n : ℕ)
+    (h_poly : (IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n))).Nonempty) :
+    0 < (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_minus_one_tanh_pos_of_tanh_pos_of_polymers_nonempty
+    G (Λ.volume n) h_tanh_pos h_poly
+
+/-- **Along-ex: vdSum is `StrictMonoOn (Set.Ioi 0)`**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_strictMonoOn_Ioi_zero_of_polymers_nonempty
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ)
+    (h_poly : (IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n))).Nonempty) :
+    StrictMonoOn
+      (fun t : ℝ => ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card) (Set.Ioi 0) :=
+  vdPolymerFamilies_sum_Λ_strictMonoOn_Ioi_zero_of_polymers_nonempty
+    G (Λ.volume n) h_poly
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 7 §18.5 ambient `vdPolymerFamilies_sumAlongExhaustion_*_of_polymers_nonempty` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivity.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivityVdSum.lean`.

Planned moves:
* `vdPolymerFamilies_sumAlongExhaustion_lt_of_lt_of_polymers_nonempty`
* `vdPolymerFamilies_sumAlongExhaustion_strictMonoOn_of_polymers_nonempty`
* `vdPolymerFamilies_sumAlongExhaustion_gt_one_of_t_pos_of_polymers_nonempty`
* `vdPolymerFamilies_sumAlongExhaustion_minus_one_pos_of_t_pos_of_polymers_nonempty`
* `vdPolymerFamilies_sumAlongExhaustion_tanh_gt_one_of_tanh_pos_of_polymers_nonempty`
* `vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_pos_of_tanh_pos_of_polymers_nonempty`
* `vdPolymerFamilies_sumAlongExhaustion_strictMonoOn_Ioi_zero_of_polymers_nonempty`

All 7 are self-contained thin pass-throughs to `vdPolymerFamilies_sum_Λ_*` ambient lemmas (no dependence on remaining `polymerFreeEnergy` parent theorems). The new child takes the same imports as the parent (`Analyticity`, `Exhaustion`) and does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed. Pure refactor — no mathematical change.

Parent retains 3 `polymerFreeEnergyAlongExhaustion_*` wrappers.