### PR TITLE
refactor: split ambient MayerTanhFerromagneticIff polymerFreeEnergy wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -48,6 +48,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerRecurrenceHasSum
 import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivity
 import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSum
 import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIff
+import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFE
 import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIff.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIff.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFE
 
 /-!
 # Mayer tanh ferromagnetic iff wrappers along an exhaustion
@@ -17,70 +18,14 @@ variable {V : Type*} [DecidableEq V]
 /-! ### §18.5 polymerFreeEnergy/vdSum tanh ferromagnetic iff family
 along-ex wraps -/
 
-/-- **Along-ex: pFE(tanh) < ε(tanh) ↔ ε(tanh) > 0** (ferro). -/
-theorem polymerFreeEnergyAlongExhaustion_tanh_lt_eps_iff_eps_pos_ferro
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) <
-        ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-                (inducedGraph G (Λ.volume n))).erase ∅,
-              ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card ↔
-      0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-                (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
-  polymerFreeEnergy_Λ_tanh_lt_eps_iff_eps_pos_ferro
-    G (Λ.volume n) hβ hJ
+/-! ## Moved: polymerFreeEnergy tanh-ferro iff wrappers
 
-/-- **Along-ex: pFE(tanh) = 0 ↔ ε(tanh) = 0** (ferro). -/
-theorem
-polymerFreeEnergyAlongExhaustion_tanh_eq_zero_iff_eps_eq_zero_ferro
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) = 0 ↔
-      (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-          ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) = 0 :=
-  polymerFreeEnergy_Λ_tanh_eq_zero_iff_eps_eq_zero_ferro
-    G (Λ.volume n) hβ hJ
-
-/-- **Along-ex: 0 < pFE(tanh) ↔ 0 < ε(tanh)** (ferro). -/
-theorem polymerFreeEnergyAlongExhaustion_tanh_pos_iff_eps_pos_ferro
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
-    0 < IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-          (Real.tanh (β * J)) ↔
-      0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-                (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
-  polymerFreeEnergy_Λ_tanh_pos_iff_eps_pos_ferro G (Λ.volume n) hβ hJ
-
-/-- **Along-ex: 0 < pFE(tanh) ↔ 0 < tanh ∧ allPolymers ≠ ∅** (ferro). -/
-theorem polymerFreeEnergyAlongExhaustion_tanh_pos_iff_ferro
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
-    0 < IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-          (Real.tanh (β * J)) ↔
-      0 < Real.tanh (β * J) ∧
-        (IsingModel.allPolymers
-          (inducedGraph G (Λ.volume n))).Nonempty :=
-  polymerFreeEnergy_Λ_tanh_pos_iff_ferro G (Λ.volume n) hβ hJ
-
-/-- **Along-ex: pFE(tanh) = 0 ↔ tanh = 0 ∨ allPolymers = ∅** (ferro). -/
-theorem polymerFreeEnergyAlongExhaustion_tanh_eq_zero_iff_ferro
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) = 0 ↔
-      Real.tanh (β * J) = 0 ∨
-        IsingModel.allPolymers (inducedGraph G (Λ.volume n)) = ∅ :=
-  polymerFreeEnergy_Λ_tanh_eq_zero_iff_ferro G (Λ.volume n) hβ hJ
+The seven `polymerFreeEnergyAlongExhaustion_tanh_*_ferro` wrappers
+now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFE`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-- **Along-ex: 1 < vdSum(tanh) ↔ 0 < tanh ∧ allPolymers ≠ ∅**
 (ferro). -/
@@ -108,39 +53,6 @@ theorem vdPolymerFamilies_sumAlongExhaustion_tanh_eq_one_iff_ferro
       Real.tanh (β * J) = 0 ∨
         IsingModel.allPolymers (inducedGraph G (Λ.volume n)) = ∅ :=
   vdPolymerFamilies_sum_Λ_tanh_eq_one_iff_ferro G (Λ.volume n) hβ hJ
-
-/-- **Along-ex: pFE(tanh) < (1+tanh)^|E| - 1** under ε(tanh) > 0
-(ferro). -/
-theorem
-polymerFreeEnergyAlongExhaustion_tanh_lt_pow_sub_one_of_eps_pos_ferro
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ)
-    (h_eps_pos : 0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-                (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) <
-      (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 :=
-  polymerFreeEnergy_Λ_tanh_lt_pow_sub_one_of_eps_pos_ferro
-    G (Λ.volume n) hβ hJ h_eps_pos
-
-/-- **Along-ex: pFE(tanh) < ε(tanh)** under ε(tanh) > 0 (ferro). -/
-theorem polymerFreeEnergyAlongExhaustion_tanh_lt_eps_of_eps_pos_ferro
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ)
-    (h_eps_pos : 0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-                (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) <
-      ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
-  polymerFreeEnergy_Λ_tanh_lt_eps_of_eps_pos_ferro
-    G (Λ.volume n) hβ hJ h_eps_pos
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIffPFE.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIffPFE.lean
@@ -1,0 +1,118 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer ferromagnetic tanh iff wrappers for `polymerFreeEnergy`
+
+Narrow child module for the seven §18.5 along-exhaustion
+ferromagnetic tanh iff wrappers for `polymerFreeEnergy`. Each
+wrapper is a thin pass-through to the corresponding
+`polymerFreeEnergy_Λ_tanh_*_ferro` ambient lemma. Theorem names are
+unchanged from the former `MayerTanhFerromagneticIff` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: pFE(tanh) < ε(tanh) ↔ ε(tanh) > 0** (ferro). -/
+theorem polymerFreeEnergyAlongExhaustion_tanh_lt_eps_iff_eps_pos_ferro
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) <
+        ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+                (inducedGraph G (Λ.volume n))).erase ∅,
+              ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card ↔
+      0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+                (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
+  polymerFreeEnergy_Λ_tanh_lt_eps_iff_eps_pos_ferro
+    G (Λ.volume n) hβ hJ
+
+/-- **Along-ex: pFE(tanh) = 0 ↔ ε(tanh) = 0** (ferro). -/
+theorem
+polymerFreeEnergyAlongExhaustion_tanh_eq_zero_iff_eps_eq_zero_ferro
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) = 0 ↔
+      (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+          ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) = 0 :=
+  polymerFreeEnergy_Λ_tanh_eq_zero_iff_eps_eq_zero_ferro
+    G (Λ.volume n) hβ hJ
+
+/-- **Along-ex: 0 < pFE(tanh) ↔ 0 < ε(tanh)** (ferro). -/
+theorem polymerFreeEnergyAlongExhaustion_tanh_pos_iff_eps_pos_ferro
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
+    0 < IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+          (Real.tanh (β * J)) ↔
+      0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+                (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
+  polymerFreeEnergy_Λ_tanh_pos_iff_eps_pos_ferro G (Λ.volume n) hβ hJ
+
+/-- **Along-ex: 0 < pFE(tanh) ↔ 0 < tanh ∧ allPolymers ≠ ∅** (ferro). -/
+theorem polymerFreeEnergyAlongExhaustion_tanh_pos_iff_ferro
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
+    0 < IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+          (Real.tanh (β * J)) ↔
+      0 < Real.tanh (β * J) ∧
+        (IsingModel.allPolymers
+          (inducedGraph G (Λ.volume n))).Nonempty :=
+  polymerFreeEnergy_Λ_tanh_pos_iff_ferro G (Λ.volume n) hβ hJ
+
+/-- **Along-ex: pFE(tanh) = 0 ↔ tanh = 0 ∨ allPolymers = ∅** (ferro). -/
+theorem polymerFreeEnergyAlongExhaustion_tanh_eq_zero_iff_ferro
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ) :
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) = 0 ↔
+      Real.tanh (β * J) = 0 ∨
+        IsingModel.allPolymers (inducedGraph G (Λ.volume n)) = ∅ :=
+  polymerFreeEnergy_Λ_tanh_eq_zero_iff_ferro G (Λ.volume n) hβ hJ
+
+/-- **Along-ex: pFE(tanh) < (1+tanh)^|E| - 1** under ε(tanh) > 0
+(ferro). -/
+theorem
+polymerFreeEnergyAlongExhaustion_tanh_lt_pow_sub_one_of_eps_pos_ferro
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ)
+    (h_eps_pos : 0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+                (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) <
+      (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 :=
+  polymerFreeEnergy_Λ_tanh_lt_pow_sub_one_of_eps_pos_ferro
+    G (Λ.volume n) hβ hJ h_eps_pos
+
+/-- **Along-ex: pFE(tanh) < ε(tanh)** under ε(tanh) > 0 (ferro). -/
+theorem polymerFreeEnergyAlongExhaustion_tanh_lt_eps_of_eps_pos_ferro
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβ : 0 ≤ β) (hJ : 0 ≤ J) (n : ℕ)
+    (h_eps_pos : 0 < ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+                (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) :
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) <
+      ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card :=
+  polymerFreeEnergy_Λ_tanh_lt_eps_of_eps_pos_ferro
+    G (Λ.volume n) hβ hJ h_eps_pos
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 7 §18.5 ambient `polymerFreeEnergyAlongExhaustion_tanh_*_ferro` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIff.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIffPFE.lean`.

Planned moves:
* `polymerFreeEnergyAlongExhaustion_tanh_lt_eps_iff_eps_pos_ferro`
* `polymerFreeEnergyAlongExhaustion_tanh_eq_zero_iff_eps_eq_zero_ferro`
* `polymerFreeEnergyAlongExhaustion_tanh_pos_iff_eps_pos_ferro`
* `polymerFreeEnergyAlongExhaustion_tanh_pos_iff_ferro`
* `polymerFreeEnergyAlongExhaustion_tanh_eq_zero_iff_ferro`
* `polymerFreeEnergyAlongExhaustion_tanh_lt_pow_sub_one_of_eps_pos_ferro`
* `polymerFreeEnergyAlongExhaustion_tanh_lt_eps_of_eps_pos_ferro`

All 7 are self-contained thin pass-throughs to `polymerFreeEnergy_Λ_tanh_*_ferro` ambient lemmas (no dependence on remaining `vdPolymerFamilies_sum` parent theorems). The new child takes the parent's imports (`Analyticity`, `Exhaustion`) but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed. Pure refactor — no mathematical change.

Parent retains 2 `vdPolymerFamilies_sumAlongExhaustion_tanh_*_ferro` wrappers.