### PR TITLE
refactor: split ambient MayerTrivialCases mayer_identity wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -50,6 +50,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSum
 import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIff
 import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFE
 import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
+import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentity
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCases.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentity
 
 /-!
 # Mayer trivial-case wrappers along an exhaustion
@@ -57,80 +58,13 @@ mayerPartialSum_zero_AlongExhaustion_tanh_le_polymerFreeEnergy_ferromagnetic
   mayerPartialSum_zero_Λ_tanh_le_polymerFreeEnergy_ferromagnetic
     G (Λ.volume n) hJ hβ
 
-/-! ### §18.5 mayer_identity_of edge-case along-ex wraps -/
+/-! ## Moved: mayer_identity edge-case wrappers
 
-/-- **Along-ex: Mayer identity for empty-polymer induced graphs**. -/
-theorem mayer_identity_of_no_polymers_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ)
-    (h_no : IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n)) = ∅) (t : ℝ) (N : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) t =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N t :=
-  mayer_identity_of_no_polymers_Λ G (Λ.volume n) h_no t N
-
-/-- **Along-ex: Mayer identity for empty-polymer induced graphs
-(tanh form)**. -/
-theorem mayer_identity_of_no_polymers_tanh_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ)
-    (h_no : IsingModel.allPolymers
-      (inducedGraph G (Λ.volume n)) = ∅) (β J : ℝ) (N : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh (β * J)) :=
-  mayer_identity_of_no_polymers_tanh_Λ G (Λ.volume n) h_no β J N
-
-/-- **Along-ex: Mayer identity under disjunctive trivial conditions**. -/
-theorem mayer_identity_of_trivial_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ) {β J : ℝ}
-    (h : β * J = 0 ∨
-      IsingModel.allPolymers
-        (inducedGraph G (Λ.volume n)) = ∅) (N : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh (β * J)) :=
-  mayer_identity_of_trivial_Λ G (Λ.volume n) h N
-
-/-- **Along-ex: Mayer identity for edgeless induced graphs**. -/
-theorem mayer_identity_of_edgeFinset_empty_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ)
-    (h_empty : (inducedGraph G (Λ.volume n)).edgeFinset = ∅)
-    (t : ℝ) (N : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) t =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N t :=
-  mayer_identity_of_edgeFinset_empty_Λ G (Λ.volume n) h_empty t N
-
-/-- **Along-ex: Mayer identity for edgeless induced graphs (tanh
-form)**. -/
-theorem mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ)
-    (h_empty : (inducedGraph G (Λ.volume n)).edgeFinset = ∅)
-    (β J : ℝ) (N : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh (β * J)) :=
-  mayer_identity_of_edgeFinset_empty_tanh_Λ
-    G (Λ.volume n) h_empty β J N
-
+The five `mayer_identity_of_*_AlongExhaustion` wrappers now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentity`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentity.lean
@@ -1,0 +1,94 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer identity edge-case wrappers along an exhaustion
+
+Narrow child module for the five §18.5 along-exhaustion Mayer
+identity wrappers for no-polymer, trivial, and edgeless cases. Each
+wrapper is a thin pass-through to the corresponding
+`mayer_identity_of_*_Λ` ambient lemma. Theorem names are unchanged
+from the former `MayerTrivialCases` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### §18.5 mayer_identity_of edge-case along-ex wraps -/
+
+/-- **Along-ex: Mayer identity for empty-polymer induced graphs**. -/
+theorem mayer_identity_of_no_polymers_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ)
+    (h_no : IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n)) = ∅) (t : ℝ) (N : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) t =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N t :=
+  mayer_identity_of_no_polymers_Λ G (Λ.volume n) h_no t N
+
+/-- **Along-ex: Mayer identity for empty-polymer induced graphs
+(tanh form)**. -/
+theorem mayer_identity_of_no_polymers_tanh_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ)
+    (h_no : IsingModel.allPolymers
+      (inducedGraph G (Λ.volume n)) = ∅) (β J : ℝ) (N : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh (β * J)) :=
+  mayer_identity_of_no_polymers_tanh_Λ G (Λ.volume n) h_no β J N
+
+/-- **Along-ex: Mayer identity under disjunctive trivial conditions**. -/
+theorem mayer_identity_of_trivial_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ) {β J : ℝ}
+    (h : β * J = 0 ∨
+      IsingModel.allPolymers
+        (inducedGraph G (Λ.volume n)) = ∅) (N : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh (β * J)) :=
+  mayer_identity_of_trivial_Λ G (Λ.volume n) h N
+
+/-- **Along-ex: Mayer identity for edgeless induced graphs**. -/
+theorem mayer_identity_of_edgeFinset_empty_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ)
+    (h_empty : (inducedGraph G (Λ.volume n)).edgeFinset = ∅)
+    (t : ℝ) (N : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) t =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N t :=
+  mayer_identity_of_edgeFinset_empty_Λ G (Λ.volume n) h_empty t N
+
+/-- **Along-ex: Mayer identity for edgeless induced graphs (tanh
+form)**. -/
+theorem mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ)
+    (h_empty : (inducedGraph G (Λ.volume n)).edgeFinset = ∅)
+    (β J : ℝ) (N : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh (β * J)) :=
+  mayer_identity_of_edgeFinset_empty_tanh_Λ
+    G (Λ.volume n) h_empty β J N
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 5 §18.5 ambient `mayer_identity_of_*_AlongExhaustion` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerTrivialCases.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentity.lean`.

Planned moves:
* `mayer_identity_of_no_polymers_AlongExhaustion`
* `mayer_identity_of_no_polymers_tanh_AlongExhaustion`
* `mayer_identity_of_trivial_AlongExhaustion`
* `mayer_identity_of_edgeFinset_empty_AlongExhaustion`
* `mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion`

All 5 are self-contained thin pass-throughs to `mayer_identity_of_*_Λ` ambient lemmas (no dependence on remaining `mayerPartialSum_zero_AlongExhaustion_le_polymerFreeEnergy` parent theorems). The new child takes the parent's imports (`Analyticity`, `Exhaustion`) but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed. Pure refactor — no mathematical change.

Parent retains 3 `mayerPartialSum_zero_AlongExhaustion_le_polymerFreeEnergy` wrappers (general, tanh, tanh ferromagnetic).