### PR TITLE
refactor: split ambient FreeEnergy trivial-slice closed forms

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean
@@ -1,4 +1,5 @@
 import IsingModel.AmbientLattice.SpontaneousMono
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices
 
 /-!
 # Non-analytic free-energy special cases
@@ -71,138 +72,19 @@ theorem freeEnergyAlongExhaustion_le_uniform_upper_bound
     _ ≤ Real.log 2 + |p.β| * (|p.J| * c + |p.h|) := by
           gcongr
 
-/-! ## Trivial free-energy slices along exhaustion -/
+/-! ## Moved: trivial free-energy slices along exhaustion
 
-/-- **Along-exhaustion β=0 closed form**:
-for nonempty `Λ.volume n` and any ambient graph `G, Λ, J, h`,
-`freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n = log 2`.
-
-Specialization of `IsingModel.freeEnergy_beta_zero` (PR #131) via
-`change` + definitional unfolding of `freeEnergyAlongExhaustion`
-through `freeEnergyΛ` to `IsingModel.freeEnergy (inducedGraph …)`. -/
-theorem freeEnergyAlongExhaustion_beta_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h : ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
-    freeEnergyAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ) n
-      = Real.log 2 := by
-  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-      (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2
-  exact IsingModel.freeEnergy_beta_zero _ J h (Finset.Nonempty.fintype_card_coe_pos hne)
-
-/-- **Infinite-volume β=0 closed form**:
-under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2`
-for any `J, h, G, Λ`.
-
-The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n` is constantly
-`log 2` by `freeEnergyAlongExhaustion_beta_zero`, so its `limsup` on
-`atTop` is `log 2` by `Filter.limsup_const`.
-
-Sanity check: the β = 0 slice of the §4.6 Prop 4.6.1 infinite-volume
-free energy is trivially the maximum-entropy value.
-
-A weakened version requiring only `∀ᶠ n in atTop, (Λ.volume n).Nonempty`
-is provided as `freeEnergyInfinite_beta_zero_of_eventually_nonempty`
-in `AmbientLatticeSum.lean`. -/
-theorem freeEnergyInfinite_beta_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
-    freeEnergyInfinite G Λ (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2 := by
-  unfold freeEnergyInfinite
-  have hconst : freeEnergyAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ)
-      = fun _ : ℕ => Real.log 2 := by
-    funext n
-    exact freeEnergyAlongExhaustion_beta_zero G Λ J h n (hne n)
-  rw [hconst]
-  exact Filter.limsup_const (Real.log 2)
-
-/-- **Along-exhaustion J=h=0 closed form**:
-for nonempty `Λ.volume n` and any ambient graph `G, Λ` and any `β`,
-`freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n = log 2`.
-
-Specialization of `IsingModel.freeEnergy_zero_params` via `change` +
-definitional unfolding of `freeEnergyAlongExhaustion` through
-`freeEnergyΛ` to `IsingModel.freeEnergy (inducedGraph …)`. -/
-theorem freeEnergyAlongExhaustion_zero_params
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
-    freeEnergyAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ) n
-      = Real.log 2 := by
-  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-      (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2
-  exact IsingModel.freeEnergy_zero_params _ β (Finset.Nonempty.fintype_card_coe_pos hne)
-
-/-- **Infinite-volume J=h=0 closed form**:
-under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2`
-for any `β, G, Λ`.
-
-The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n` is constantly
-`log 2` by `freeEnergyAlongExhaustion_zero_params`, so its `limsup` on
-`atTop` is `log 2` by `Filter.limsup_const`.
-
-Companion to `freeEnergyInfinite_beta_zero`: both give the
-maximum-entropy value `log 2` from orthogonal degeneracies
-(β=0 vs. H ≡ 0).
-
-A weakened version requiring only `∀ᶠ n in atTop, (Λ.volume n).Nonempty`
-is provided as `freeEnergyInfinite_zero_params_of_eventually_nonempty`
-in `AmbientLatticeSum.lean`. -/
-theorem freeEnergyInfinite_zero_params
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
-    freeEnergyInfinite G Λ (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2 := by
-  unfold freeEnergyInfinite
-  have hconst : freeEnergyAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ)
-      = fun _ : ℕ => Real.log 2 := by
-    funext n
-    exact freeEnergyAlongExhaustion_zero_params G Λ β n (hne n)
-  rw [hconst]
-  exact Filter.limsup_const (Real.log 2)
-
-/-- **Along-exhaustion J=0 graph-independence**:
-`freeEnergyAlongExhaustion G Λ ⟨0, h, β⟩ n
-  = freeEnergyAlongExhaustion ⊥ Λ ⟨0, h, β⟩ n`
-for any `n`, any `G, Λ`, any `h, β` (no nonempty hypothesis).
-
-Lift of `IsingModel.freeEnergy_eq_bot_at_J_zero` (PR #175) through
-the definitional unfolding
-`freeEnergyAlongExhaustion = freeEnergy (inducedGraph …)`:
-apply the base identity on both sides to reduce to the same
-`freeEnergy_bot` expression. -/
-theorem freeEnergyAlongExhaustion_eq_bot_at_J_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    [∀ n, Fintype (inducedGraph (⊥ : SimpleGraph V) (Λ.volume n)).edgeSet]
-    (h β : ℝ) (n : ℕ) :
-    freeEnergyAlongExhaustion G Λ (⟨0, h, β⟩ : IsingParams ℝ) n
-      = freeEnergyAlongExhaustion (⊥ : SimpleGraph V) Λ
-          (⟨0, h, β⟩ : IsingParams ℝ) n := by
-  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-      (⟨0, h, β⟩ : IsingParams ℝ)
-    = IsingModel.freeEnergy (inducedGraph (⊥ : SimpleGraph V) (Λ.volume n))
-          (⟨0, h, β⟩ : IsingParams ℝ)
-  rw [IsingModel.freeEnergy_eq_bot_at_J_zero (inducedGraph G (Λ.volume n)),
-      IsingModel.freeEnergy_eq_bot_at_J_zero
-        (inducedGraph (⊥ : SimpleGraph V) (Λ.volume n))]
-
-/-- **Along-exhaustion J=0 closed form (graph-independent)**:
-for nonempty `Λ.volume n` and any ambient graph `G, Λ` and any `h, β`,
-`freeEnergyAlongExhaustion G Λ ⟨0, h, β⟩ n = log (2·cosh(β·h))`.
-
-Specialization of `IsingModel.freeEnergy_J_zero` via `change` +
-definitional unfolding. -/
-theorem freeEnergyAlongExhaustion_J_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (h β : ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
-    freeEnergyAlongExhaustion G Λ (⟨0, h, β⟩ : IsingParams ℝ) n
-      = Real.log (2 * Real.cosh (β * h)) := by
-  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-      (⟨0, h, β⟩ : IsingParams ℝ) = _
-  exact IsingModel.freeEnergy_J_zero _ h β (Finset.Nonempty.fintype_card_coe_pos hne)
+The six trivial-parameter-slice closed forms
+(`freeEnergyAlongExhaustion_beta_zero`,
+`freeEnergyInfinite_beta_zero`,
+`freeEnergyAlongExhaustion_zero_params`,
+`freeEnergyInfinite_zero_params`,
+`freeEnergyAlongExhaustion_eq_bot_at_J_zero`,
+`freeEnergyAlongExhaustion_J_zero`) now live in
+`IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-! ## Sharper high-temperature free-energy upper bounds -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlices.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlices.lean
@@ -1,0 +1,156 @@
+import IsingModel.AmbientLattice.SpontaneousMono
+
+/-!
+# Free-energy trivial-parameter-slice closed forms along an exhaustion
+
+Narrow child module for the six along-exhaustion / infinite-volume
+free-energy closed-form identities at trivial parameter slices
+(`β = 0`, `J = h = 0`, `J = 0`). Each wrapper is a thin pass-through
+to the corresponding `IsingModel.freeEnergy_*` ambient lemma, or
+(for the two `freeEnergyInfinite_*` variants) a `limsup`
+specialization of a constant sequence built from the
+along-exhaustion sibling. Theorem names are unchanged from the
+former `FreeEnergy` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+open scoped symmDiff
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-exhaustion β=0 closed form**:
+for nonempty `Λ.volume n` and any ambient graph `G, Λ, J, h`,
+`freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n = log 2`.
+
+Specialization of `IsingModel.freeEnergy_beta_zero` (PR #131) via
+`change` + definitional unfolding of `freeEnergyAlongExhaustion`
+through `freeEnergyΛ` to `IsingModel.freeEnergy (inducedGraph …)`. -/
+theorem freeEnergyAlongExhaustion_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    freeEnergyAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ) n
+      = Real.log 2 := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2
+  exact IsingModel.freeEnergy_beta_zero _ J h (Finset.Nonempty.fintype_card_coe_pos hne)
+
+/-- **Infinite-volume β=0 closed form**:
+under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2`
+for any `J, h, G, Λ`.
+
+The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n` is constantly
+`log 2` by `freeEnergyAlongExhaustion_beta_zero`, so its `limsup` on
+`atTop` is `log 2` by `Filter.limsup_const`.
+
+Sanity check: the β = 0 slice of the §4.6 Prop 4.6.1 infinite-volume
+free energy is trivially the maximum-entropy value.
+
+A weakened version requiring only `∀ᶠ n in atTop, (Λ.volume n).Nonempty`
+is provided as `freeEnergyInfinite_beta_zero_of_eventually_nonempty`
+in `AmbientLatticeSum.lean`. -/
+theorem freeEnergyInfinite_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite G Λ (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2 := by
+  unfold freeEnergyInfinite
+  have hconst : freeEnergyAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ)
+      = fun _ : ℕ => Real.log 2 := by
+    funext n
+    exact freeEnergyAlongExhaustion_beta_zero G Λ J h n (hne n)
+  rw [hconst]
+  exact Filter.limsup_const (Real.log 2)
+
+/-- **Along-exhaustion J=h=0 closed form**:
+for nonempty `Λ.volume n` and any ambient graph `G, Λ` and any `β`,
+`freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n = log 2`.
+
+Specialization of `IsingModel.freeEnergy_zero_params` via `change` +
+definitional unfolding of `freeEnergyAlongExhaustion` through
+`freeEnergyΛ` to `IsingModel.freeEnergy (inducedGraph …)`. -/
+theorem freeEnergyAlongExhaustion_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    freeEnergyAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ) n
+      = Real.log 2 := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2
+  exact IsingModel.freeEnergy_zero_params _ β (Finset.Nonempty.fintype_card_coe_pos hne)
+
+/-- **Infinite-volume J=h=0 closed form**:
+under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2`
+for any `β, G, Λ`.
+
+The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n` is constantly
+`log 2` by `freeEnergyAlongExhaustion_zero_params`, so its `limsup` on
+`atTop` is `log 2` by `Filter.limsup_const`.
+
+Companion to `freeEnergyInfinite_beta_zero`: both give the
+maximum-entropy value `log 2` from orthogonal degeneracies
+(β=0 vs. H ≡ 0).
+
+A weakened version requiring only `∀ᶠ n in atTop, (Λ.volume n).Nonempty`
+is provided as `freeEnergyInfinite_zero_params_of_eventually_nonempty`
+in `AmbientLatticeSum.lean`. -/
+theorem freeEnergyInfinite_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite G Λ (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2 := by
+  unfold freeEnergyInfinite
+  have hconst : freeEnergyAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ)
+      = fun _ : ℕ => Real.log 2 := by
+    funext n
+    exact freeEnergyAlongExhaustion_zero_params G Λ β n (hne n)
+  rw [hconst]
+  exact Filter.limsup_const (Real.log 2)
+
+/-- **Along-exhaustion J=0 graph-independence**:
+`freeEnergyAlongExhaustion G Λ ⟨0, h, β⟩ n
+  = freeEnergyAlongExhaustion ⊥ Λ ⟨0, h, β⟩ n`
+for any `n`, any `G, Λ`, any `h, β` (no nonempty hypothesis).
+
+Lift of `IsingModel.freeEnergy_eq_bot_at_J_zero` (PR #175) through
+the definitional unfolding
+`freeEnergyAlongExhaustion = freeEnergy (inducedGraph …)`:
+apply the base identity on both sides to reduce to the same
+`freeEnergy_bot` expression. -/
+theorem freeEnergyAlongExhaustion_eq_bot_at_J_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    [∀ n, Fintype (inducedGraph (⊥ : SimpleGraph V) (Λ.volume n)).edgeSet]
+    (h β : ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ (⟨0, h, β⟩ : IsingParams ℝ) n
+      = freeEnergyAlongExhaustion (⊥ : SimpleGraph V) Λ
+          (⟨0, h, β⟩ : IsingParams ℝ) n := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨0, h, β⟩ : IsingParams ℝ)
+    = IsingModel.freeEnergy (inducedGraph (⊥ : SimpleGraph V) (Λ.volume n))
+          (⟨0, h, β⟩ : IsingParams ℝ)
+  rw [IsingModel.freeEnergy_eq_bot_at_J_zero (inducedGraph G (Λ.volume n)),
+      IsingModel.freeEnergy_eq_bot_at_J_zero
+        (inducedGraph (⊥ : SimpleGraph V) (Λ.volume n))]
+
+/-- **Along-exhaustion J=0 closed form (graph-independent)**:
+for nonempty `Λ.volume n` and any ambient graph `G, Λ` and any `h, β`,
+`freeEnergyAlongExhaustion G Λ ⟨0, h, β⟩ n = log (2·cosh(β·h))`.
+
+Specialization of `IsingModel.freeEnergy_J_zero` via `change` +
+definitional unfolding. -/
+theorem freeEnergyAlongExhaustion_J_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (h β : ℝ) (n : ℕ) (hne : (Λ.volume n).Nonempty) :
+    freeEnergyAlongExhaustion G Λ (⟨0, h, β⟩ : IsingParams ℝ) n
+      = Real.log (2 * Real.cosh (β * h)) := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨0, h, β⟩ : IsingParams ℝ) = _
+  exact IsingModel.freeEnergy_J_zero _ h β (Finset.Nonempty.fintype_card_coe_pos hne)
+
+end Ambient
+end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -1,4 +1,5 @@
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZero
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityOnNhd


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 6 ambient FreeEnergy trivial-parameter-slice closed-form wrappers from `IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlices.lean`.

Planned moves (all closed-form parameter-slice identities):
* `freeEnergyAlongExhaustion_beta_zero`
* `freeEnergyInfinite_beta_zero`
* `freeEnergyAlongExhaustion_zero_params`
* `freeEnergyInfinite_zero_params`
* `freeEnergyAlongExhaustion_eq_bot_at_J_zero`
* `freeEnergyAlongExhaustion_J_zero`

All 6 are self-contained: each reduces to `IsingModel.freeEnergy_*` ambient lemmas via `change`/`unfold`/`rw`, or (for the two `Infinite` variants) to `Filter.limsup_const` after using a previously-moved sibling. Internal dependencies (`_Infinite_beta_zero` → `_beta_zero`; `_Infinite_zero_params` → `_zero_params`) stay inside the child. The new child takes the parent's only import (`AmbientLattice.SpontaneousMono`) but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 7 wrappers (uniform upper bound, sharper HT bounds + uniform variant, h-symmetry / `|h|`-monotonicity, BddAbove range).

Pure refactor — no mathematical change.