### PR TITLE
refactor: split ambient FreeEnergy h-symmetry wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean
@@ -1,4 +1,5 @@
 import IsingModel.AmbientLattice.SpontaneousMono
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyHSymmetry
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices
 
 /-!
@@ -147,51 +148,14 @@ theorem freeEnergyAlongExhaustion_high_temp_h_zero_upper_bound_exp_uniform
     exact mul_le_mul_of_nonneg_left h_edgeRatio hβJ
   linarith
 
-/-! ## `h`-symmetry / `|h|` monotonicity along exhaustion -/
+/-! ## Moved: `h`-symmetry / `|h|`-monotonicity wrappers
 
-/-- **Along-exhaustion h-evenness**:
-`freeEnergyAlongExhaustion G Λ ⟨J, -h, β⟩ n = freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n`. -/
-theorem freeEnergyAlongExhaustion_neg_h
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (n : ℕ) :
-    freeEnergyAlongExhaustion G Λ (⟨J, -h, β⟩ : IsingParams ℝ) n
-      = freeEnergyAlongExhaustion G Λ (⟨J, h, β⟩ : IsingParams ℝ) n := by
-  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-      (⟨J, -h, β⟩ : IsingParams ℝ)
-    = IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-        (⟨J, h, β⟩ : IsingParams ℝ)
-  exact IsingModel.freeEnergy_neg_h _ J h β
-
-/-- **Along-exhaustion `|h|`-rewrite**:
-`freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n = freeEnergyAlongExhaustion G Λ ⟨J, |h|, β⟩ n`. -/
-theorem freeEnergyAlongExhaustion_eq_abs_h
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h β : ℝ) (n : ℕ) :
-    freeEnergyAlongExhaustion G Λ (⟨J, h, β⟩ : IsingParams ℝ) n
-      = freeEnergyAlongExhaustion G Λ (⟨J, |h|, β⟩ : IsingParams ℝ) n := by
-  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-      (⟨J, h, β⟩ : IsingParams ℝ)
-    = IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-        (⟨J, |h|, β⟩ : IsingParams ℝ)
-  exact IsingModel.freeEnergy_eq_abs_h _ J h β
-
-/-- **Along-exhaustion ferromagnetic `|h|`-monotonicity**:
-for `J ≥ 0`, `β > 0` and any real `h₁, h₂` with `|h₁| ≤ |h₂|`,
-`freeEnergyAlongExhaustion G Λ ⟨J, h₁, β⟩ n ≤ freeEnergyAlongExhaustion G Λ ⟨J, h₂, β⟩ n`. -/
-theorem freeEnergyAlongExhaustion_monotone_abs_h
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β)
-    {h₁ h₂ : ℝ} (hh : |h₁| ≤ |h₂|) (n : ℕ) :
-    freeEnergyAlongExhaustion G Λ (⟨J, h₁, β⟩ : IsingParams ℝ) n
-      ≤ freeEnergyAlongExhaustion G Λ (⟨J, h₂, β⟩ : IsingParams ℝ) n := by
-  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-      (⟨J, h₁, β⟩ : IsingParams ℝ)
-    ≤ IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
-        (⟨J, h₂, β⟩ : IsingParams ℝ)
-  exact IsingModel.freeEnergy_monotone_abs_h _ J β hJ hβ hh
+The three `freeEnergyAlongExhaustion_{neg_h, eq_abs_h, monotone_abs_h}`
+wrappers now live in
+`IsingModel.AmbientLattice.SpecialCases.FreeEnergyHSymmetry`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-- **BddAbove for `freeEnergyAlongExhaustion` under bounded edge density**:
 assuming `BoundedEdgeDensity G Λ`, the range of the exhaustion free energy

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyHSymmetry.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyHSymmetry.lean
@@ -1,0 +1,67 @@
+import IsingModel.AmbientLattice.SpontaneousMono
+
+/-!
+# Free-energy `h`-symmetry / `|h|`-monotonicity along an exhaustion
+
+Narrow child module for three along-exhaustion `freeEnergyAlongExhaustion`
+`h`-symmetry / `|h|`-monotonicity wrappers extracted from
+`FreeEnergy.lean`. Each wrapper is a thin pass-through to the
+corresponding `IsingModel.freeEnergy_*` ambient lemma via
+`change` + `exact`. Theorem names are unchanged from the former
+`FreeEnergy` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+open scoped symmDiff
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-exhaustion h-evenness**:
+`freeEnergyAlongExhaustion G Λ ⟨J, -h, β⟩ n = freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n`. -/
+theorem freeEnergyAlongExhaustion_neg_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ (⟨J, -h, β⟩ : IsingParams ℝ) n
+      = freeEnergyAlongExhaustion G Λ (⟨J, h, β⟩ : IsingParams ℝ) n := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨J, -h, β⟩ : IsingParams ℝ)
+    = IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+        (⟨J, h, β⟩ : IsingParams ℝ)
+  exact IsingModel.freeEnergy_neg_h _ J h β
+
+/-- **Along-exhaustion `|h|`-rewrite**:
+`freeEnergyAlongExhaustion G Λ ⟨J, h, β⟩ n = freeEnergyAlongExhaustion G Λ ⟨J, |h|, β⟩ n`. -/
+theorem freeEnergyAlongExhaustion_eq_abs_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h β : ℝ) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ (⟨J, h, β⟩ : IsingParams ℝ) n
+      = freeEnergyAlongExhaustion G Λ (⟨J, |h|, β⟩ : IsingParams ℝ) n := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨J, h, β⟩ : IsingParams ℝ)
+    = IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+        (⟨J, |h|, β⟩ : IsingParams ℝ)
+  exact IsingModel.freeEnergy_eq_abs_h _ J h β
+
+/-- **Along-exhaustion ferromagnetic `|h|`-monotonicity**:
+for `J ≥ 0`, `β > 0` and any real `h₁, h₂` with `|h₁| ≤ |h₂|`,
+`freeEnergyAlongExhaustion G Λ ⟨J, h₁, β⟩ n ≤ freeEnergyAlongExhaustion G Λ ⟨J, h₂, β⟩ n`. -/
+theorem freeEnergyAlongExhaustion_monotone_abs_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hJ : 0 ≤ J) (hβ : 0 < β)
+    {h₁ h₂ : ℝ} (hh : |h₁| ≤ |h₂|) (n : ℕ) :
+    freeEnergyAlongExhaustion G Λ (⟨J, h₁, β⟩ : IsingParams ℝ) n
+      ≤ freeEnergyAlongExhaustion G Λ (⟨J, h₂, β⟩ : IsingParams ℝ) n := by
+  change IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+      (⟨J, h₁, β⟩ : IsingParams ℝ)
+    ≤ IsingModel.freeEnergy (inducedGraph G (Λ.volume n))
+        (⟨J, h₂, β⟩ : IsingParams ℝ)
+  exact IsingModel.freeEnergy_monotone_abs_h _ J β hJ hβ hh
+
+end Ambient
+end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -1,4 +1,5 @@
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyHSymmetry
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZero


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 3 ambient `freeEnergyAlongExhaustion` h-symmetry / `|h|`-monotonicity wrappers from `IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/FreeEnergyHSymmetry.lean`.

Planned moves:
* `freeEnergyAlongExhaustion_neg_h`
* `freeEnergyAlongExhaustion_eq_abs_h`
* `freeEnergyAlongExhaustion_monotone_abs_h`

All 3 are self-contained thin pass-throughs to `IsingModel.freeEnergy_neg_h`, `_eq_abs_h`, `_monotone_abs_h` via `change`/`exact`. The new child takes the parent's only import (`AmbientLattice.SpontaneousMono`) but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 4 wrappers (`_le_uniform_upper_bound`, `_high_temp_h_zero_upper_bound_exp`, `_high_temp_h_zero_upper_bound_exp_uniform`, `BddAbove_..._range`).

Pure refactor — no mathematical change.