### PR TITLE
fix: clean up pre-existing long-line linter warnings

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/CubicPseudoMassNamedRate.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/CubicPseudoMassNamedRate.lean
@@ -17,8 +17,10 @@ namespace Ambient
 
 /-! ## Moved: `_of_le_high_temp_rate` family
 
-The six wrappers
-`{HasExponentialDecay,latticeMass_ge,cubicNamedRate_ofReal_mem_Icc_latticeMass,latticeMass_pos,cubicNamedRate_ofReal_mem_Ioc_latticeMass,latticeMass_ne_zero}_*_of_le_high_temp_rate`
+The six wrappers (each of form `<head>_*_of_le_high_temp_rate`,
+with heads `HasExponentialDecay`, `latticeMass_ge`,
+`cubicNamedRate_ofReal_mem_Icc_latticeMass`, `latticeMass_pos`,
+`cubicNamedRate_ofReal_mem_Ioc_latticeMass`, `latticeMass_ne_zero`)
 now live in `CubicPseudoMassNamedRateLeHighTempRate.lean`. -/
 
 /-- **Anchored cubic named-rate comparison from a cubic profile lower bound**:

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsAlongExhaustionRatioLogFe.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsAlongExhaustionRatioLogFe.lean
@@ -172,8 +172,9 @@ wrappers (`bound_exp_of_nonempty`, `pos_of_nonempty`) now live in
 
 /-! ## Moved: freeEnergyAlongEx ratio_bound wrappers
 
-The four wrappers
-`freeEnergyAlongExhaustion_latticeGraph_high_temp_h_zero_ratio_bound{,_beta_zero,_ferromagnetic,_beta_zero_ferromagnetic}`
+The four
+`freeEnergyAlongExhaustion_latticeGraph_high_temp_h_zero_ratio_bound`
+wrappers (`{,_beta_zero,_ferromagnetic,_beta_zero_ferromagnetic}`)
 now live in `HighTemperatureBoundsAlongExRatioLogFeBound.lean`. -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsDecayCapstonesHighTempExpRate.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsDecayCapstonesHighTempExpRate.lean
@@ -10,8 +10,10 @@ Narrow child module for two ℤ^d
 wrappers (Λ and AlongExhaustion variants) extracted from
 `HighTemperatureBoundsDecayCapstones.lean`:
 
-* `correlationΛ_latticeGraph_h_zero_at_pair_le_two_pow_edges_mul_exp_highTempExpRate_dist`,
-* `correlationAlongExhaustion_latticeGraph_h_zero_at_pair_le_two_pow_edges_mul_exp_highTempExpRate_dist`.
+* `correlationΛ_latticeGraph_*_two_pow_edges_mul_exp_highTempExpRate_dist`
+  (Λ variant),
+* `correlationAlongExhaustion_latticeGraph_*_two_pow_edges_mul_exp_highTempExpRate_dist`
+  (AlongExhaustion variant). Both at `_h_zero_at_pair_le_`.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerEdgeCases.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerEdgeCases.lean
@@ -39,9 +39,10 @@ now live in `MayerEdgeCasesLambdaPolymer.lean`. -/
 
 /-! ## Moved: along-ex polymerFreeEnergy = mayerPartialSum edge cases
 
-The four wrappers
-`polymerFreeEnergyAlongExhaustion_latticeGraph_eq_mayerPartialSum_at_{zero,betaJ_zero,beta_zero,J_zero}`
-now live in `MayerEdgeCasesAlongExPolymer.lean`. -/
+The four
+`polymerFreeEnergyAlongExhaustion_latticeGraph_eq_mayerPartialSum_at`
+wrappers (`{_zero, _betaJ_zero, _beta_zero, _J_zero}`) now live in
+`MayerEdgeCasesAlongExPolymer.lean`. -/
 
 
 /-! ## Moved: `mayer_identity_*_polymer_free_energy_*` edge cases

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerEdgeCasesAlongExPolymer.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerEdgeCasesAlongExPolymer.lean
@@ -5,8 +5,9 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCases
 # Concrete along-ex polymerFreeEnergy = mayerPartialSum edge cases
 
 Narrow child module for four ℤ^d
-`polymerFreeEnergyAlongExhaustion_latticeGraph_eq_mayerPartialSum_at_{zero,betaJ_zero,beta_zero,J_zero}`
-wrappers. Each wrapper is a thin pass-through to the corresponding
+`polymerFreeEnergyAlongExhaustion_latticeGraph_eq_mayerPartialSum_at`
+wrappers (`{_zero, _betaJ_zero, _beta_zero, _J_zero}`).
+Each wrapper is a thin pass-through to the corresponding
 ambient `polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_*`
 lemma at `IsingModel.latticeGraph d`.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerVdBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerVdBounds.lean
@@ -70,9 +70,10 @@ wrappers (`ge_one_of_nonneg`, `le_one_plus_pow_of_nonneg`,
 
 /-! ## Moved: AlongEx vdPolymerFamilies_sum `_of_nonneg` family
 
-The four wrappers
-`vdPolymerFamilies_sumAlongExhaustion_latticeGraph_{ge_one,le_one_plus_pow,pos,eq_one_add}_of_nonneg`
-now live in `MayerVdBoundsAlongExNonneg.lean`. -/
+The four
+`vdPolymerFamilies_sumAlongExhaustion_latticeGraph_*_of_nonneg`
+wrappers (`{ge_one, le_one_plus_pow, pos, eq_one_add}`) now live
+in `MayerVdBoundsAlongExNonneg.lean`. -/
 
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionClosedForms.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionClosedForms.lean
@@ -62,17 +62,20 @@ now live in `PartitionFunctionClosedFormsCubicLambda.lean`. -/
 /-! ## Moved: along-ex closed-form trivial-slice wrappers
 
 The six wrappers
-`{partitionFunction,log_partitionFunction}AlongExhaustion_latticeGraph_{beta_zero,zero_params,J_zero}`
-now live in `PartitionFunctionClosedFormsAlongEx.lean`. -/
+`{partitionFunction,log_partitionFunction}AlongExhaustion_latticeGraph_*`
+(`{_beta_zero, _zero_params, _J_zero}`) now live in
+`PartitionFunctionClosedFormsAlongEx.lean`. -/
 
 
 
 /-! ## Moved: cubicExhaustion-alongEx closed-form wrappers
 
 The six wrappers
-`partitionFunctionAlongExhaustion_latticeGraph_cubicExhaustion_{J_zero,beta_zero,zero_params}`
-and `log_partitionFunctionAlongExhaustion_latticeGraph_cubicExhaustion_{J_zero,beta_zero,zero_params}`
-now live in `PartitionFunctionClosedFormsCubicAlongEx.lean`. -/
+`partitionFunctionAlongExhaustion_latticeGraph_cubicExhaustion_*`
+and
+`log_partitionFunctionAlongExhaustion_latticeGraph_cubicExhaustion_*`
+(`{_J_zero, _beta_zero, _zero_params}` each) now live in
+`PartitionFunctionClosedFormsCubicAlongEx.lean`. -/
 
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMag.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMag.lean
@@ -119,7 +119,8 @@ The legacy import path is preserved by re-importing the new child.
 
 /-! ## Moved: uniformMagnetization trivial-slice + monotonicity wrappers
 
-The seven wrappers `uniformMagnetization_{beta_zero,monotone_J,monotone_h,monotone_beta,J_zero,zero_params,zero_at_h_zero}`
+The seven `uniformMagnetization_*` wrappers
+(`{beta_zero,monotone_J,monotone_h,monotone_beta,J_zero,zero_params,zero_at_h_zero}`)
 now live in `SiteIndepMagTrivialSlice.lean`. -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularity.lean
@@ -65,9 +65,9 @@ theorem susceptibilityAlongExhaustion_differentiable_J
 
 /-! ## Moved: ℤ^d-specialized susceptibilityAlongExhaustion pointwise wrappers
 
-The six wrappers
-`susceptibilityAlongExhaustion_latticeGraph_{continuousAt,differentiableAt}_{beta_general_h,field,J}`
-now live in `SusceptibilityPointwiseRegularityLatticeGraph.lean`. -/
+The six `susceptibilityAlongExhaustion_latticeGraph_*` wrappers
+(`{continuousAt,differentiableAt}_{beta_general_h,field,J}`) now
+live in `SusceptibilityPointwiseRegularityLatticeGraph.lean`. -/
 
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularityLatticeGraph.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularityLatticeGraph.lean
@@ -7,8 +7,9 @@ import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityA
 # Concrete ℤ^d-specialized susceptibilityAlongExhaustion pointwise wrappers
 
 Narrow child module for six ℤ^d
-`susceptibilityAlongExhaustion_latticeGraph_{continuousAt,differentiableAt}_{beta_general_h,field,J}`
-wrappers, each a thin pass-through to the corresponding ambient
+`susceptibilityAlongExhaustion_latticeGraph_*` wrappers
+(`{continuousAt,differentiableAt}_{beta_general_h,field,J}`),
+each a thin pass-through to the corresponding ambient
 `susceptibilityAlongExhaustion_{continuousAt,differentiableAt}_*` lemma
 at `IsingModel.latticeGraph d`.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/UniformMag.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/UniformMag.lean
@@ -31,7 +31,8 @@ of_not_mem}`, `magnetizationInfinite_latticeGraph_apply`, and
 The legacy import path is preserved by re-importing the new child.
 -/
 
-/-! ## Moved: magnetizationAlongExhaustion / correlationAlongExhaustion bounds + convergence wrappers
+/-! ## Moved: magnetizationAlongExhaustion / correlationAlongExhaustion
+bounds + convergence wrappers
 
 The 17 ℤ^d `magnetizationAlongExhaustion_latticeGraph_*` and
 `correlationAlongExhaustion_latticeGraph_*` bound / monotone /


### PR DESCRIPTION
Cleanup PR: resolve all 12 pre-existing 100-character long-line linter warnings in the codebase. Each fix reflows the offending doc comment, comment, or signature to stay within the column budget without changing any code semantics.

Files touched:
* SiteIndepMag.lean:122
* UniformMag.lean:34
* SusceptibilityPointwiseRegularity.lean:69
* HighTemperatureBoundsDecayCapstonesHighTempExpRate.lean:14
* HighTemperatureBoundsAlongExhaustionRatioLogFe.lean:176
* CubicPseudoMassNamedRate.lean:21
* MayerEdgeCases.lean:43
* MayerEdgeCasesAlongExPolymer.lean:8
* MayerVdBounds.lean:74
* PartitionFunctionClosedForms.lean:65, 74
* SusceptibilityPointwiseRegularityLatticeGraph.lean:10

Pure refactor — no mathematical change. Restores `lake build` to zero warnings.