### PR TITLE
refactor: split ambient MayerVdRegularityVdPolymer tanh wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -63,6 +63,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymerTanh
 import IsingModel.AmbientLattice.SpecialCases.MagnetizationConvergence
 import IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity
 import IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularityAt

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymer.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymer.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymerTanh
 
 /-!
 # `vdPolymerFamilies_sum` regularity wrappers along an exhaustion
@@ -54,51 +55,15 @@ theorem vdPolymerFamilies_sumAlongExhaustion_hasDerivAt
           ((Q.card : ℝ) * t ^ (Q.card - 1))) t :=
   vdPolymerFamilies_sum_Λ_hasDerivAt G (Λ.volume n) t
 
-/-! ### §18.5 vdPolymerFamilies_sum tanh β/J along-ex wraps -/
+/-! ## Moved: vdPolymerFamilies_sum tanh β/J along-ex wraps
 
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) continuous in β**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J : ℝ) (n : ℕ) :
-    Continuous (fun β' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_continuous_beta G (Λ.volume n) J
-
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) continuous in J**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (n : ℕ) :
-    Continuous (fun J' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_continuous_J G (Λ.volume n) β
-
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) differentiable in β**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun β' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_differentiable_beta G (Λ.volume n) J
-
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) differentiable in J**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun J' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) :=
-  vdPolymerFamilies_sum_Λ_tanh_differentiable_J G (Λ.volume n) β
+The four `vdPolymerFamilies_sumAlongExhaustion_tanh_*` wrappers
+(`_continuous_beta`, `_continuous_J`, `_differentiable_beta`,
+`_differentiable_J`) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymerTanh`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymerTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymerTanh.lean
@@ -1,0 +1,67 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# `vdPolymerFamilies_sum` tanh regularity wrappers along an exhaustion
+
+Narrow child module for four §18.5 `vdPolymerFamilies_sum`
+along-exhaustion tanh-composed continuity / differentiability
+wrappers in `β` and `J`. Each wrapper is a thin pass-through to the
+corresponding `vdPolymerFamilies_sum_Λ_tanh_*` ambient lemma.
+Theorem names are unchanged from the former `MayerVdRegularityVdPolymer`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### §18.5 vdPolymerFamilies_sum tanh β/J along-ex wraps -/
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) continuous in β**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J : ℝ) (n : ℕ) :
+    Continuous (fun β' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_continuous_beta G (Λ.volume n) J
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) continuous in J**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) :
+    Continuous (fun J' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_continuous_J G (Λ.volume n) β
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) differentiable in β**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun β' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_differentiable_beta G (Λ.volume n) J
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) differentiable in J**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun J' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) :=
+  vdPolymerFamilies_sum_Λ_tanh_differentiable_J G (Λ.volume n) β
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 4 ambient `vdPolymerFamilies_sumAlongExhaustion_tanh_*` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymer.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymerTanh.lean`.

Planned moves:
* `vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_beta`
* `vdPolymerFamilies_sumAlongExhaustion_tanh_continuous_J`
* `vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_beta`
* `vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_J`

All 4 are self-contained thin pass-throughs to `vdPolymerFamilies_sum_Λ_tanh_*` ambient lemmas. The new child takes the parent's imports but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 3 non-tanh wrappers (`_continuous`, `_differentiable`, `_hasDerivAt`).

Pure refactor — no mathematical change.