### PR TITLE
refactor: split ambient MayerVdBounds generic-t wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -59,6 +59,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFE
 import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentity
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
+import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdBounds.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdBounds.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric
 
 /-!
 # Mayer vd bound wrappers along an exhaustion
@@ -51,51 +52,15 @@ theorem one_le_vdPolymerFamilies_sumAlongExhaustion
         ∏ P ∈ Γ, Real.tanh (β * J) ^ P.card :=
   one_le_vdPolymerFamilies_sum_Λ G (Λ.volume n) hβJ
 
-/-! ### §18.5 vdPolymerFamilies_sum generic-t bounds along-ex -/
+/-! ## Moved: vdPolymerFamilies_sum generic-t bound wrappers
 
-/-- **Along-ex: 1 ≤ vdSum** under `0 ≤ t`. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_ge_one_of_nonneg
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
-    1 ≤ ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card :=
-  vdPolymerFamilies_sum_Λ_ge_one_of_nonneg G (Λ.volume n) ht
-
-/-- **Along-ex: vdSum ≤ (1+t)^|E|** under `0 ≤ t`. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
-    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card)
-      ≤ (1 + t) ^ (inducedGraph G (Λ.volume n)).edgeFinset.card :=
-  vdPolymerFamilies_sum_Λ_le_one_plus_pow_of_nonneg G (Λ.volume n) ht
-
-/-- **Along-ex: 0 < vdSum** under `0 ≤ t`. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_pos_of_nonneg
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
-    0 < ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card :=
-  vdPolymerFamilies_sum_Λ_pos_of_nonneg G (Λ.volume n) ht
-
-/-- **Along-ex: vdSum = 1 + ε(t)** decomposition. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_eq_one_add
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (t : ℝ) (n : ℕ) :
-    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card) =
-      1 + ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-              ∏ P ∈ Γ, t ^ P.card :=
-  vdPolymerFamilies_sum_Λ_eq_one_add G (Λ.volume n) t
+The four `vdPolymerFamilies_sumAlongExhaustion_*` generic-`t`
+wrappers (`_ge_one_of_nonneg`, `_le_one_plus_pow_of_nonneg`,
+`_pos_of_nonneg`, `_eq_one_add`) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGeneric.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGeneric.lean
@@ -1,0 +1,69 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer vd generic-t bound wrappers along an exhaustion
+
+Narrow child module for four §18.5 along-exhaustion
+`vdPolymerFamilies_sum` generic-`t` bound and decomposition
+wrappers (separating from the tanh-form bounds that remain in the
+parent). Each wrapper is a thin pass-through to the corresponding
+`vdPolymerFamilies_sum_Λ_*` ambient lemma. Theorem names are
+unchanged from the former `MayerVdBounds` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### §18.5 vdPolymerFamilies_sum generic-t bounds along-ex -/
+
+/-- **Along-ex: 1 ≤ vdSum** under `0 ≤ t`. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_ge_one_of_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    1 ≤ ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card :=
+  vdPolymerFamilies_sum_Λ_ge_one_of_nonneg G (Λ.volume n) ht
+
+/-- **Along-ex: vdSum ≤ (1+t)^|E|** under `0 ≤ t`. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card)
+      ≤ (1 + t) ^ (inducedGraph G (Λ.volume n)).edgeFinset.card :=
+  vdPolymerFamilies_sum_Λ_le_one_plus_pow_of_nonneg G (Λ.volume n) ht
+
+/-- **Along-ex: 0 < vdSum** under `0 ≤ t`. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_pos_of_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    0 < ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card :=
+  vdPolymerFamilies_sum_Λ_pos_of_nonneg G (Λ.volume n) ht
+
+/-- **Along-ex: vdSum = 1 + ε(t)** decomposition. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_eq_one_add
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (t : ℝ) (n : ℕ) :
+    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card) =
+      1 + ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+              ∏ P ∈ Γ, t ^ P.card :=
+  vdPolymerFamilies_sum_Λ_eq_one_add G (Λ.volume n) t
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 4 ambient `vdPolymerFamilies_sumAlongExhaustion_*` generic-t bound wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerVdBounds.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGeneric.lean`.

Planned moves:
* `vdPolymerFamilies_sumAlongExhaustion_ge_one_of_nonneg`
* `vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg`
* `vdPolymerFamilies_sumAlongExhaustion_pos_of_nonneg`
* `vdPolymerFamilies_sumAlongExhaustion_eq_one_add`

All 4 are self-contained thin pass-throughs to `vdPolymerFamilies_sum_Λ_*` ambient lemmas. They work with a generic non-negative parameter `t` (or no positivity for `eq_one_add`), separating cleanly from the tanh-form bounds remaining in the parent. The new child takes the parent's imports but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 3 tanh-form bounds (`_le_two_pow`, `_le_one_plus_tanh_pow`, `one_le_vdPolymerFamilies_sumAlongExhaustion`).

Pure refactor — no mathematical change.