### PR TITLE
refactor: split ambient MayerVdRegularityTanh expansionTerm wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -65,6 +65,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanhExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymerTanh
 import IsingModel.AmbientLattice.SpecialCases.MagnetizationConvergence

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanh.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanhExpansionTerm
 
 /-!
 # `mayerPartialSum` / `mayerExpansionTerm` tanh regularity wrappers along an exhaustion
@@ -63,51 +64,14 @@ theorem mayerPartialSumAlongExhaustion_tanh_differentiable_J
           (Real.tanh (β * J'))) :=
   mayerPartialSum_Λ_tanh_differentiable_J G (Λ.volume n) N β
 
-/-! ### §18.5 mayerExpansionTerm tanh β/J along-ex wraps -/
+/-! ## Moved: mayerExpansionTerm tanh β/J along-ex wraps
 
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) continuous in β**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_continuous_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (J : ℝ) (n : ℕ) :
-    Continuous (fun β' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β' * J))) :=
-  mayerExpansionTerm_Λ_tanh_continuous_beta G (Λ.volume n) k J
-
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) continuous in J**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_continuous_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (β : ℝ) (n : ℕ) :
-    Continuous (fun J' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β * J'))) :=
-  mayerExpansionTerm_Λ_tanh_continuous_J G (Λ.volume n) k β
-
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) differentiable in β**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (J : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun β' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β' * J))) :=
-  mayerExpansionTerm_Λ_tanh_differentiable_beta G (Λ.volume n) k J
-
-/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) differentiable in J**. -/
-theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (β : ℝ) (n : ℕ) :
-    Differentiable ℝ (fun J' : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k
-          (Real.tanh (β * J'))) :=
-  mayerExpansionTerm_Λ_tanh_differentiable_J G (Λ.volume n) k β
+The four `mayerExpansionTermAlongExhaustion_tanh_*` continuity /
+differentiability wrappers (in `β` and `J`) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanhExpansionTerm`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanhExpansionTerm.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanhExpansionTerm.lean
@@ -1,0 +1,67 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# `mayerExpansionTerm` tanh regularity wrappers along an exhaustion
+
+Narrow child module for the four §18.5 along-exhaustion
+`mayerExpansionTerm` tanh-composed continuity / differentiability
+wrappers in `β` and `J`. Each wrapper is a thin pass-through to
+the corresponding `mayerExpansionTerm_Λ_tanh_*` ambient lemma.
+Theorem names are unchanged from the former `MayerVdRegularityTanh`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### §18.5 mayerExpansionTerm tanh β/J along-ex wraps -/
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) continuous in β**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_continuous_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (J : ℝ) (n : ℕ) :
+    Continuous (fun β' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β' * J))) :=
+  mayerExpansionTerm_Λ_tanh_continuous_beta G (Λ.volume n) k J
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) continuous in J**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_continuous_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (β : ℝ) (n : ℕ) :
+    Continuous (fun J' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β * J'))) :=
+  mayerExpansionTerm_Λ_tanh_continuous_J G (Λ.volume n) k β
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (·*J) differentiable in β**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (J : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun β' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β' * J))) :=
+  mayerExpansionTerm_Λ_tanh_differentiable_beta G (Λ.volume n) k J
+
+/-- **Along-ex: mayerExpansionTerm ∘ tanh ∘ (β*·) differentiable in J**. -/
+theorem mayerExpansionTermAlongExhaustion_tanh_differentiable_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (β : ℝ) (n : ℕ) :
+    Differentiable ℝ (fun J' : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k
+          (Real.tanh (β * J'))) :=
+  mayerExpansionTerm_Λ_tanh_differentiable_J G (Λ.volume n) k β
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 4 ambient `mayerExpansionTermAlongExhaustion_tanh_*` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanh.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanhExpansionTerm.lean`.

Planned moves:
* `mayerExpansionTermAlongExhaustion_tanh_continuous_beta`
* `mayerExpansionTermAlongExhaustion_tanh_continuous_J`
* `mayerExpansionTermAlongExhaustion_tanh_differentiable_beta`
* `mayerExpansionTermAlongExhaustion_tanh_differentiable_J`

All 4 are self-contained thin pass-throughs to `mayerExpansionTerm_Λ_tanh_*` ambient lemmas. The new child takes the parent's imports but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 4 `mayerPartialSumAlongExhaustion_tanh_*` wrappers.

Pure refactor — no mathematical change.