### PR TITLE
refactor: split ambient MayerExpansionEdgeCases _two wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -51,6 +51,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCases
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPFE
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPolymerFreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCases
+import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCasesTwo
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonInfrastructure
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivity
 import IsingModel.AmbientLattice.SpecialCases.MayerFilterConnected

--- a/IsingModel/AmbientLattice/SpecialCases/MayerExpansionEdgeCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerExpansionEdgeCases.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCasesTwo
 
 /-!
 # Mayer expansion edge-case wrappers along an exhaustion
@@ -16,55 +17,16 @@ open Finset Real
 
 variable {V : Type*} [DecidableEq V]
 
-/-! ### §18.5 Mayer expansion edge-cases + n=2 + abs_le along-ex -/
+/-! ### §18.5 Mayer expansion edge-cases + abs_le along-ex -/
 
-/-- **Along-ex: mayerExpansionTerm at `n = 2`**. -/
-theorem mayerExpansionTermAlongExhaustion_two
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (t : ℝ) (n : ℕ) :
-    IsingModel.mayerExpansionTerm
-        (inducedGraph G (Λ.volume n)) 2 t =
-      ∑ pq ∈ (IsingModel.allPolymers
-              (inducedGraph G (Λ.volume n))) ×ˢ
-              (IsingModel.allPolymers (inducedGraph G (Λ.volume n))),
-        (if IsingModel.PolymersIncompatible pq.1 pq.2 then (-1/2 : ℝ)
-          else 0) *
-          (t ^ pq.1.card * t ^ pq.2.card) :=
-  mayerExpansionTerm_Λ_two G (Λ.volume n) t
+/-! ## Moved: mayer expansion `_two` wrappers
 
-/-- **Along-ex: mayerExpansionTerm at `n = 2`, filter form**. -/
-theorem mayerExpansionTermAlongExhaustion_two_filter
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (t : ℝ) (n : ℕ) :
-    IsingModel.mayerExpansionTerm
-        (inducedGraph G (Λ.volume n)) 2 t =
-      (-1/2 : ℝ) *
-        ∑ pq ∈ ((IsingModel.allPolymers
-                  (inducedGraph G (Λ.volume n))) ×ˢ
-                (IsingModel.allPolymers
-                  (inducedGraph G (Λ.volume n)))).filter
-            (fun pq => IsingModel.PolymersIncompatible pq.1 pq.2),
-          (t ^ pq.1.card * t ^ pq.2.card) :=
-  mayerExpansionTerm_Λ_two_filter G (Λ.volume n) t
-
-/-- **Along-ex: mayerPartialSum at `N = 2`**. -/
-theorem mayerPartialSumAlongExhaustion_two
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (t : ℝ) (n : ℕ) :
-    IsingModel.mayerPartialSum (inducedGraph G (Λ.volume n)) 2 t =
-      (∑ P ∈ IsingModel.allPolymers (inducedGraph G (Λ.volume n)),
-            t ^ P.card) +
-        (-1/2 : ℝ) *
-          ∑ pq ∈ ((IsingModel.allPolymers
-                    (inducedGraph G (Λ.volume n))) ×ˢ
-                  (IsingModel.allPolymers
-                    (inducedGraph G (Λ.volume n)))).filter
-              (fun pq => IsingModel.PolymersIncompatible pq.1 pq.2),
-            (t ^ pq.1.card * t ^ pq.2.card) :=
-  mayerPartialSum_Λ_two G (Λ.volume n) t
+The three `mayer*AlongExhaustion_two*` wrappers (`_two`,
+`_two_filter`, `mayerPartialSumAlongExhaustion_two`) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCasesTwo`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-- **Along-ex: mayerPartialSum = 0 on no-polymer graphs**. -/
 theorem mayerPartialSumAlongExhaustion_eq_zero_of_no_polymers

--- a/IsingModel/AmbientLattice/SpecialCases/MayerExpansionEdgeCasesTwo.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerExpansionEdgeCasesTwo.lean
@@ -1,0 +1,71 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer expansion `n = 2` wrappers along an exhaustion
+
+Narrow child module for the three §18.5 along-exhaustion Mayer
+expansion `n = 2` / `N = 2` wrappers extracted from
+`MayerExpansionEdgeCases.lean`. Each wrapper is a thin
+pass-through to the corresponding `mayer*_Λ_two*` ambient lemma.
+Theorem names are unchanged from the former
+`MayerExpansionEdgeCases` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: mayerExpansionTerm at `n = 2`**. -/
+theorem mayerExpansionTermAlongExhaustion_two
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (t : ℝ) (n : ℕ) :
+    IsingModel.mayerExpansionTerm
+        (inducedGraph G (Λ.volume n)) 2 t =
+      ∑ pq ∈ (IsingModel.allPolymers
+              (inducedGraph G (Λ.volume n))) ×ˢ
+              (IsingModel.allPolymers (inducedGraph G (Λ.volume n))),
+        (if IsingModel.PolymersIncompatible pq.1 pq.2 then (-1/2 : ℝ)
+          else 0) *
+          (t ^ pq.1.card * t ^ pq.2.card) :=
+  mayerExpansionTerm_Λ_two G (Λ.volume n) t
+
+/-- **Along-ex: mayerExpansionTerm at `n = 2`, filter form**. -/
+theorem mayerExpansionTermAlongExhaustion_two_filter
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (t : ℝ) (n : ℕ) :
+    IsingModel.mayerExpansionTerm
+        (inducedGraph G (Λ.volume n)) 2 t =
+      (-1/2 : ℝ) *
+        ∑ pq ∈ ((IsingModel.allPolymers
+                  (inducedGraph G (Λ.volume n))) ×ˢ
+                (IsingModel.allPolymers
+                  (inducedGraph G (Λ.volume n)))).filter
+            (fun pq => IsingModel.PolymersIncompatible pq.1 pq.2),
+          (t ^ pq.1.card * t ^ pq.2.card) :=
+  mayerExpansionTerm_Λ_two_filter G (Λ.volume n) t
+
+/-- **Along-ex: mayerPartialSum at `N = 2`**. -/
+theorem mayerPartialSumAlongExhaustion_two
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (t : ℝ) (n : ℕ) :
+    IsingModel.mayerPartialSum (inducedGraph G (Λ.volume n)) 2 t =
+      (∑ P ∈ IsingModel.allPolymers (inducedGraph G (Λ.volume n)),
+            t ^ P.card) +
+        (-1/2 : ℝ) *
+          ∑ pq ∈ ((IsingModel.allPolymers
+                    (inducedGraph G (Λ.volume n))) ×ˢ
+                  (IsingModel.allPolymers
+                    (inducedGraph G (Λ.volume n)))).filter
+              (fun pq => IsingModel.PolymersIncompatible pq.1 pq.2),
+            (t ^ pq.1.card * t ^ pq.2.card) :=
+  mayerPartialSum_Λ_two G (Λ.volume n) t
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 3 ambient `mayer*AlongExhaustion_two*` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerExpansionEdgeCases.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerExpansionEdgeCasesTwo.lean`.

Planned moves:
* `mayerExpansionTermAlongExhaustion_two`
* `mayerExpansionTermAlongExhaustion_two_filter`
* `mayerPartialSumAlongExhaustion_two`

All 3 are self-contained thin pass-throughs to `mayer*_Λ_two*` ambient lemmas. The new child takes the parent's imports but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 3 `_eq_zero_of_*` and `_abs_le` wrappers.

Pure refactor — no mathematical change.