### PR TITLE
refactor: split ambient JointRegularity Differentiable wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/JointRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointRegularity.lean
@@ -1,6 +1,7 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
 import IsingModel.AmbientLattice.MagnetizationAlongExhaustion
+import IsingModel.AmbientLattice.SpecialCases.JointRegularityDifferentiable
 
 /-!
 # Ambient joint regularity wrappers
@@ -33,20 +34,6 @@ theorem correlationAlongExhaustion_continuous_joint_gen
   · simp only [hA, dif_neg, not_false_iff]
     exact continuous_const
 
-/-- **Along-ex: correlation jointly Differentiable ℝ in `(β, J, h)`** (general G). -/
-theorem correlationAlongExhaustion_differentiable_joint_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (A : Finset V) (n : ℕ) :
-    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
-      correlationAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ A n) := by
-  unfold correlationAlongExhaustion
-  by_cases hA : A ⊆ Λ.volume n
-  · simp only [hA, dif_pos]
-    exact correlationΛ_differentiable_joint G (Λ.volume n) (liftFinset A hA)
-  · simp only [hA, dif_neg, not_false_iff]
-    exact differentiable_const _
-
 /-- **Along-ex: magnetization jointly Continuous in `(β, J, h)`** (general G). -/
 theorem magnetizationAlongExhaustion_continuous_joint
     (G : SimpleGraph V) (Λ : Exhaustion V)
@@ -60,20 +47,6 @@ theorem magnetizationAlongExhaustion_continuous_joint
     exact correlationΛ_continuous_joint G (Λ.volume n) (liftFinset {i} hi)
   · simp only [hi, dif_neg, not_false_iff]
     exact continuous_const
-
-/-- **Along-ex: magnetization jointly Differentiable ℝ in `(β, J, h)`** (general G). -/
-theorem magnetizationAlongExhaustion_differentiable_joint
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (i : V) (n : ℕ) :
-    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
-      magnetizationAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ i n) := by
-  unfold magnetizationAlongExhaustion correlationAlongExhaustion
-  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact correlationΛ_differentiable_joint G (Λ.volume n) (liftFinset {i} hi)
-  · simp only [hi, dif_neg, not_false_iff]
-    exact differentiable_const _
 
 /-- **Along-ex: susceptibility jointly Continuous in `(β, J, h)`** (general G). -/
 theorem susceptibilityAlongExhaustion_continuous_joint_gen
@@ -89,19 +62,14 @@ theorem susceptibilityAlongExhaustion_continuous_joint_gen
   · simp only [hi, dif_neg, not_false_iff]
     exact continuous_const
 
-/-- **Along-ex: susceptibility jointly Differentiable ℝ in `(β, J, h)`** (general G). -/
-theorem susceptibilityAlongExhaustion_differentiable_joint_gen
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (i : V) (n : ℕ) :
-    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
-      susceptibilityAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ i n) := by
-  unfold susceptibilityAlongExhaustion
-  by_cases hi : i ∈ Λ.volume n
-  · simp only [hi, dif_pos]
-    exact susceptibilityΛ_differentiable_joint G (Λ.volume n) ⟨i, hi⟩
-  · simp only [hi, dif_neg, not_false_iff]
-    exact differentiable_const _
+/-! ## Moved: joint Differentiable along-ex wrappers
+
+The three joint `_differentiable_joint*` wrappers (correlation,
+magnetization, susceptibility) now live in
+`IsingModel.AmbientLattice.SpecialCases.JointRegularityDifferentiable`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-! ## Moved: joint ContinuousAt / DifferentiableAt along-ex wrappers
 

--- a/IsingModel/AmbientLattice/SpecialCases/JointRegularityDifferentiable.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointRegularityDifferentiable.lean
@@ -1,0 +1,64 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.MagnetizationAlongExhaustion
+
+/-!
+# Joint `Differentiable` along-ex wrappers
+
+Narrow child module for the three along-exhaustion joint
+`Differentiable` wrappers (correlation, magnetization,
+susceptibility) extracted from `JointRegularity.lean`. Each wrapper
+is a thin pass-through to the corresponding `_differentiable_joint*`
+ambient lemma via `unfold` + `by_cases`. Theorem names are
+unchanged from the former `JointRegularity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: correlation jointly Differentiable ℝ in `(β, J, h)`** (general G). -/
+theorem correlationAlongExhaustion_differentiable_joint_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (A : Finset V) (n : ℕ) :
+    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
+      correlationAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ A n) := by
+  unfold correlationAlongExhaustion
+  by_cases hA : A ⊆ Λ.volume n
+  · simp only [hA, dif_pos]
+    exact correlationΛ_differentiable_joint G (Λ.volume n) (liftFinset A hA)
+  · simp only [hA, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+/-- **Along-ex: magnetization jointly Differentiable ℝ in `(β, J, h)`** (general G). -/
+theorem magnetizationAlongExhaustion_differentiable_joint
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (i : V) (n : ℕ) :
+    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
+      magnetizationAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ i n) := by
+  unfold magnetizationAlongExhaustion correlationAlongExhaustion
+  by_cases hi : ({i} : Finset V) ⊆ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact correlationΛ_differentiable_joint G (Λ.volume n) (liftFinset {i} hi)
+  · simp only [hi, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+/-- **Along-ex: susceptibility jointly Differentiable ℝ in `(β, J, h)`** (general G). -/
+theorem susceptibilityAlongExhaustion_differentiable_joint_gen
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (i : V) (n : ℕ) :
+    Differentiable ℝ (fun p : ℝ × ℝ × ℝ =>
+      susceptibilityAlongExhaustion G Λ ⟨p.2.1, p.2.2, p.1⟩ i n) := by
+  unfold susceptibilityAlongExhaustion
+  by_cases hi : i ∈ Λ.volume n
+  · simp only [hi, dif_pos]
+    exact susceptibilityΛ_differentiable_joint G (Λ.volume n) ⟨i, hi⟩
+  · simp only [hi, dif_neg, not_false_iff]
+    exact differentiable_const _
+
+end Ambient
+end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -43,6 +43,7 @@ import IsingModel.AmbientLattice.SpecialCases.JointAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.JointAnalyticityPartitionFreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.JointRegularity
 import IsingModel.AmbientLattice.SpecialCases.JointRegularityAt
+import IsingModel.AmbientLattice.SpecialCases.JointRegularityDifferentiable
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentities


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 3 ambient joint `_differentiable_joint*` wrappers from `IsingModel/AmbientLattice/SpecialCases/JointRegularity.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/JointRegularityDifferentiable.lean`.

Planned moves:
* `correlationAlongExhaustion_differentiable_joint_gen`
* `magnetizationAlongExhaustion_differentiable_joint`
* `susceptibilityAlongExhaustion_differentiable_joint_gen`

All 3 are self-contained thin pass-throughs to the corresponding `_differentiable_joint*` ambient lemmas via `unfold` + `by_cases`. The new child takes the parent's imports but does not import the parent. The parent re-imports the new child for transitive visibility — the existing `JointRegularityAt` sibling and Concrete consumers see the symbols via the parent's re-import chain.

Parent retains 3 `_continuous_joint*` wrappers (correlation, magnetization, susceptibility).

Pure refactor — no mathematical change.