### PR TITLE
refactor: split ambient MayerVdRegularity Differentiable wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -68,6 +68,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityDifferentiable
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanhExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityDifferentiable
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer
 
@@ -29,16 +30,6 @@ theorem mayerPartialSumAlongExhaustion_continuous
           (inducedGraph G (Λ.volume n)) N t) :=
   mayerPartialSum_Λ_continuous G (Λ.volume n) N
 
-/-- **Along-ex: `mayerPartialSum` is `Differentiable ℝ`**. -/
-theorem mayerPartialSumAlongExhaustion_differentiable
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (n : ℕ) :
-    Differentiable ℝ (fun t : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N t) :=
-  mayerPartialSum_Λ_differentiable G (Λ.volume n) N
-
 /-- **Along-ex: `mayerPartialSum` is `ContinuousOn`**. -/
 theorem mayerPartialSumAlongExhaustion_continuousOn
     (G : SimpleGraph V) (Λ : Exhaustion V)
@@ -48,16 +39,6 @@ theorem mayerPartialSumAlongExhaustion_continuousOn
         IsingModel.mayerPartialSum
           (inducedGraph G (Λ.volume n)) N t) s :=
   mayerPartialSum_Λ_continuousOn G (Λ.volume n) N s
-
-/-- **Along-ex: `mayerPartialSum` is `DifferentiableOn ℝ`**. -/
-theorem mayerPartialSumAlongExhaustion_differentiableOn
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (n : ℕ) (s : Set ℝ) :
-    DifferentiableOn ℝ (fun t : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N t) s :=
-  mayerPartialSum_Λ_differentiableOn G (Λ.volume n) N s
 
 /-! ### §18.6 mayerExpansionTerm regularity along-ex wraps -/
 
@@ -71,15 +52,15 @@ theorem mayerExpansionTermAlongExhaustion_continuous
           (inducedGraph G (Λ.volume n)) k t) :=
   mayerExpansionTerm_Λ_continuous G (Λ.volume n) k
 
-/-- **Along-ex: `mayerExpansionTerm` is `Differentiable ℝ`**. -/
-theorem mayerExpansionTermAlongExhaustion_differentiable
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (k : ℕ) (n : ℕ) :
-    Differentiable ℝ (fun t : ℝ =>
-        IsingModel.mayerExpansionTerm
-          (inducedGraph G (Λ.volume n)) k t) :=
-  mayerExpansionTerm_Λ_differentiable G (Λ.volume n) k
+/-! ### Moved: `mayerPartialSum` / `mayerExpansionTerm` Differentiable wraps
+
+The three `mayer*AlongExhaustion_differentiable*` wrappers
+(`mayerPartialSum_differentiable`, `_differentiableOn`,
+`mayerExpansionTerm_differentiable`) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityDifferentiable`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-! ### Moved: `mayerPartialSum` / `mayerExpansionTerm` tanh along-ex wraps
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityDifferentiable.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityDifferentiable.lean
@@ -1,0 +1,51 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer `Differentiable` along-ex wrappers
+
+Narrow child module for the three §18.6 along-exhaustion
+`mayerPartialSum` / `mayerExpansionTerm` `Differentiable` /
+`DifferentiableOn` wrappers. Each wrapper is a thin pass-through
+to the corresponding `mayer*_Λ_differentiable*` ambient lemma.
+Theorem names are unchanged from the former `MayerVdRegularity`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: `mayerPartialSum` is `Differentiable ℝ`**. -/
+theorem mayerPartialSumAlongExhaustion_differentiable
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (n : ℕ) :
+    Differentiable ℝ (fun t : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N t) :=
+  mayerPartialSum_Λ_differentiable G (Λ.volume n) N
+
+/-- **Along-ex: `mayerPartialSum` is `DifferentiableOn ℝ`**. -/
+theorem mayerPartialSumAlongExhaustion_differentiableOn
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (n : ℕ) (s : Set ℝ) :
+    DifferentiableOn ℝ (fun t : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N t) s :=
+  mayerPartialSum_Λ_differentiableOn G (Λ.volume n) N s
+
+/-- **Along-ex: `mayerExpansionTerm` is `Differentiable ℝ`**. -/
+theorem mayerExpansionTermAlongExhaustion_differentiable
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (k : ℕ) (n : ℕ) :
+    Differentiable ℝ (fun t : ℝ =>
+        IsingModel.mayerExpansionTerm
+          (inducedGraph G (Λ.volume n)) k t) :=
+  mayerExpansionTerm_Λ_differentiable G (Λ.volume n) k
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 3 ambient `mayer*AlongExhaustion_differentiable*` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityDifferentiable.lean`.

Planned moves:
* `mayerPartialSumAlongExhaustion_differentiable`
* `mayerPartialSumAlongExhaustion_differentiableOn`
* `mayerExpansionTermAlongExhaustion_differentiable`

All 3 are self-contained thin pass-throughs to `mayer*_Λ_differentiable*` ambient lemmas. The new child takes the parent's imports but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 3 `mayer*AlongExhaustion_continuous*` wrappers
(`mayerPartialSum_continuous`, `_continuousOn`,
`mayerExpansionTerm_continuous`).

Pure refactor — no mathematical change.