### PR TITLE
refactor: split ambient MayerAnalyticity tanh wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -46,6 +46,7 @@ import IsingModel.AmbientLattice.SpecialCases.JointRegularityAt
 import IsingModel.AmbientLattice.SpecialCases.JointRegularityDifferentiable
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm
+import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityTanh
 import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentities
 import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentitiesExpansionTerm
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCases

--- a/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticity.lean
@@ -1,6 +1,7 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
 import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTerm
+import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityTanh
 
 /-!
 # Mayer analyticity wrappers along an exhaustion
@@ -44,53 +45,15 @@ now live in `MayerAnalyticityExpansionTerm.lean`. They are re-imported
 here so downstream consumers continue to see the symbols. -/
 
 
-/-! ### `mayerPartialSum` tanh β/J analyticity along an exhaustion -/
+/-! ## Moved: mayerPartialSumAlongExhaustion tanh analyticity wrappers
 
-/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (·*J) AnalyticAt in β**. -/
-theorem mayerPartialSumAlongExhaustion_tanh_analyticAt_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (J β : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun β' : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N
-          (Real.tanh (β' * J))) β :=
-  mayerPartialSum_Λ_tanh_analyticAt_beta G (Λ.volume n) N J β
-
-/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (β*·) AnalyticAt in J**. -/
-theorem mayerPartialSumAlongExhaustion_tanh_analyticAt_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (β J : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun J' : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N
-          (Real.tanh (β * J'))) J :=
-  mayerPartialSum_Λ_tanh_analyticAt_J G (Λ.volume n) N β J
-
-/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (·*J) AnalyticOnNhd in β
-over `Set.univ`**. -/
-theorem mayerPartialSumAlongExhaustion_tanh_analyticOnNhd_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (J : ℝ) (n : ℕ) :
-    AnalyticOnNhd ℝ (fun β' : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N
-          (Real.tanh (β' * J))) Set.univ :=
-  mayerPartialSum_Λ_tanh_analyticOnNhd_beta G (Λ.volume n) N J
-
-/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (β*·) AnalyticOnNhd in J
-over `Set.univ`**. -/
-theorem mayerPartialSumAlongExhaustion_tanh_analyticOnNhd_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (N : ℕ) (β : ℝ) (n : ℕ) :
-    AnalyticOnNhd ℝ (fun J' : ℝ =>
-        IsingModel.mayerPartialSum
-          (inducedGraph G (Λ.volume n)) N
-          (Real.tanh (β * J'))) Set.univ :=
-  mayerPartialSum_Λ_tanh_analyticOnNhd_J G (Λ.volume n) N β
+The four `mayerPartialSumAlongExhaustion_tanh_analytic*` wrappers
+(`_analyticAt_beta`, `_analyticAt_J`, `_analyticOnNhd_beta`,
+`_analyticOnNhd_J`) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityTanh`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-! ## Moved: mayerExpansionTermAlongExhaustion tanh analyticity wrappers
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityTanh.lean
@@ -1,0 +1,69 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# `mayerPartialSum` tanh analyticity wrappers along an exhaustion
+
+Narrow child module for the four §18.6 along-exhaustion
+`mayerPartialSum` tanh-composed analyticity wrappers (`AnalyticAt`
+in `β` and `J`, `AnalyticOnNhd ℝ _ Set.univ` in `β` and `J`).
+Each wrapper is a thin pass-through to the corresponding
+`mayerPartialSum_Λ_tanh_analytic*` ambient lemma. Theorem names
+are unchanged from the former `MayerAnalyticity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### `mayerPartialSum` tanh β/J analyticity along an exhaustion -/
+
+/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (·*J) AnalyticAt in β**. -/
+theorem mayerPartialSumAlongExhaustion_tanh_analyticAt_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (J β : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun β' : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N
+          (Real.tanh (β' * J))) β :=
+  mayerPartialSum_Λ_tanh_analyticAt_beta G (Λ.volume n) N J β
+
+/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (β*·) AnalyticAt in J**. -/
+theorem mayerPartialSumAlongExhaustion_tanh_analyticAt_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (β J : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun J' : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N
+          (Real.tanh (β * J'))) J :=
+  mayerPartialSum_Λ_tanh_analyticAt_J G (Λ.volume n) N β J
+
+/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (·*J) AnalyticOnNhd in β
+over `Set.univ`**. -/
+theorem mayerPartialSumAlongExhaustion_tanh_analyticOnNhd_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (J : ℝ) (n : ℕ) :
+    AnalyticOnNhd ℝ (fun β' : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N
+          (Real.tanh (β' * J))) Set.univ :=
+  mayerPartialSum_Λ_tanh_analyticOnNhd_beta G (Λ.volume n) N J
+
+/-- **Along-ex: mayerPartialSum ∘ tanh ∘ (β*·) AnalyticOnNhd in J
+over `Set.univ`**. -/
+theorem mayerPartialSumAlongExhaustion_tanh_analyticOnNhd_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (N : ℕ) (β : ℝ) (n : ℕ) :
+    AnalyticOnNhd ℝ (fun J' : ℝ =>
+        IsingModel.mayerPartialSum
+          (inducedGraph G (Λ.volume n)) N
+          (Real.tanh (β * J'))) Set.univ :=
+  mayerPartialSum_Λ_tanh_analyticOnNhd_J G (Λ.volume n) N β
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 4 ambient `mayerPartialSumAlongExhaustion_tanh_analytic*` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerAnalyticity.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityTanh.lean`.

Planned moves:
* `mayerPartialSumAlongExhaustion_tanh_analyticAt_beta`
* `mayerPartialSumAlongExhaustion_tanh_analyticAt_J`
* `mayerPartialSumAlongExhaustion_tanh_analyticOnNhd_beta`
* `mayerPartialSumAlongExhaustion_tanh_analyticOnNhd_J`

All 4 are self-contained thin pass-throughs to `mayerPartialSum_Λ_tanh_analytic*` ambient lemmas. The new child takes the parent's imports but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 2 base wrappers
(`mayerPartialSumAlongExhaustion_analyticAt`,
`mayerPartialSumAlongExhaustion_analyticOnNhd`).

Pure refactor — no mathematical change.