### PR TITLE
refactor: split ambient MayerEpsilonPositivity vdSum wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -57,6 +57,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCases
 import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCasesTwo
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonInfrastructure
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivity
+import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivityVdSum
 import IsingModel.AmbientLattice.SpecialCases.MayerFilterConnected
 import IsingModel.AmbientLattice.SpecialCases.MayerRecurrenceHasSum
 import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivity

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEpsilonPositivity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEpsilonPositivity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivityVdSum
 
 /-!
 # Mayer epsilon positivity wrappers along an exhaustion
@@ -17,60 +18,15 @@ variable {V : Type*} [DecidableEq V]
 /-! ### §18.5 ε(t) / polymerFreeEnergy positivity-iff along-ex
 wraps -/
 
-/-- **Along-ex: 0 < ε(t) ↔ 0 < t ∧ allPolymers ≠ ∅** under `0 ≤ t`. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_minus_one_pos_iff
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
-    0 < (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, t ^ P.card) ↔
-      0 < t ∧
-        (IsingModel.allPolymers
-          (inducedGraph G (Λ.volume n))).Nonempty :=
-  vdPolymerFamilies_sum_Λ_minus_one_pos_iff G (Λ.volume n) ht
+/-! ## Moved: `vdPolymerFamilies_sum_minus_one_*_iff` wrappers
 
-/-- **Along-ex: ε(t) = 0 ↔ t = 0 ∨ allPolymers = ∅**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_minus_one_eq_zero_iff
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
-    (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-          ∏ P ∈ Γ, t ^ P.card) = 0 ↔
-      t = 0 ∨
-        IsingModel.allPolymers
-          (inducedGraph G (Λ.volume n)) = ∅ :=
-  vdPolymerFamilies_sum_Λ_minus_one_eq_zero_iff G (Λ.volume n) ht
-
-/-- **Along-ex: 0 < ε(tanh) ↔ 0 < tanh ∧ allPolymers ≠ ∅**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_pos_iff
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) :
-    0 < (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ↔
-      0 < Real.tanh (β * J) ∧
-        (IsingModel.allPolymers
-          (inducedGraph G (Λ.volume n))).Nonempty :=
-  vdPolymerFamilies_sum_Λ_minus_one_tanh_pos_iff G (Λ.volume n) hβJ
-
-/-- **Along-ex: ε(tanh) = 0 ↔ tanh = 0 ∨ allPolymers = ∅**. -/
-theorem
-vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_eq_zero_iff
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) :
-    (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-          ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) = 0 ↔
-      Real.tanh (β * J) = 0 ∨
-        IsingModel.allPolymers
-          (inducedGraph G (Λ.volume n)) = ∅ :=
-  vdPolymerFamilies_sum_Λ_minus_one_tanh_eq_zero_iff
-    G (Λ.volume n) hβJ
+The four `vdPolymerFamilies_sumAlongExhaustion_minus_one_*_iff`
+positivity / zero iff wrappers (general `t` and tanh-form) now
+live in
+`IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivityVdSum`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-- **Along-ex: 0 < polymerFreeEnergy(tanh) ↔ 0 < tanh ∧
 allPolymers ≠ ∅**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEpsilonPositivityVdSum.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEpsilonPositivityVdSum.lean
@@ -1,0 +1,77 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# `vdPolymerFamilies_sum` ε(t) positivity-iff wrappers along an exhaustion
+
+Narrow child module for the four §18.5 along-exhaustion
+`vdPolymerFamilies_sumAlongExhaustion_minus_one_*_iff`
+positivity / zero iff wrappers (general `t` and tanh-form). Each
+wrapper is a thin pass-through to the corresponding
+`vdPolymerFamilies_sum_Λ_minus_one_*_iff` ambient lemma. Theorem
+names are unchanged from the former `MayerEpsilonPositivity`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: 0 < ε(t) ↔ 0 < t ∧ allPolymers ≠ ∅** under `0 ≤ t`. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_minus_one_pos_iff
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    0 < (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, t ^ P.card) ↔
+      0 < t ∧
+        (IsingModel.allPolymers
+          (inducedGraph G (Λ.volume n))).Nonempty :=
+  vdPolymerFamilies_sum_Λ_minus_one_pos_iff G (Λ.volume n) ht
+
+/-- **Along-ex: ε(t) = 0 ↔ t = 0 ∨ allPolymers = ∅**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_minus_one_eq_zero_iff
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+          ∏ P ∈ Γ, t ^ P.card) = 0 ↔
+      t = 0 ∨
+        IsingModel.allPolymers
+          (inducedGraph G (Λ.volume n)) = ∅ :=
+  vdPolymerFamilies_sum_Λ_minus_one_eq_zero_iff G (Λ.volume n) ht
+
+/-- **Along-ex: 0 < ε(tanh) ↔ 0 < tanh ∧ allPolymers ≠ ∅**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_pos_iff
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) :
+    0 < (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ↔
+      0 < Real.tanh (β * J) ∧
+        (IsingModel.allPolymers
+          (inducedGraph G (Λ.volume n))).Nonempty :=
+  vdPolymerFamilies_sum_Λ_minus_one_tanh_pos_iff G (Λ.volume n) hβJ
+
+/-- **Along-ex: ε(tanh) = 0 ↔ tanh = 0 ∨ allPolymers = ∅**. -/
+theorem
+vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_eq_zero_iff
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) :
+    (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+          ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) = 0 ↔
+      Real.tanh (β * J) = 0 ∨
+        IsingModel.allPolymers
+          (inducedGraph G (Λ.volume n)) = ∅ :=
+  vdPolymerFamilies_sum_Λ_minus_one_tanh_eq_zero_iff
+    G (Λ.volume n) hβJ
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 4 ambient `vdPolymerFamilies_sumAlongExhaustion_minus_one_*_iff` wrappers from `IsingModel/AmbientLattice/SpecialCases/MayerEpsilonPositivity.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/MayerEpsilonPositivityVdSum.lean`.

Planned moves:
* `vdPolymerFamilies_sumAlongExhaustion_minus_one_pos_iff`
* `vdPolymerFamilies_sumAlongExhaustion_minus_one_eq_zero_iff`
* `vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_pos_iff`
* `vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_eq_zero_iff`

All 4 are self-contained thin pass-throughs to `vdPolymerFamilies_sum_Λ_minus_one_*_iff` ambient lemmas. The new child takes the parent's imports but does not import the parent. The parent re-imports the new child for transitive visibility — no per-consumer updates needed.

Parent retains 2 `polymerFreeEnergyAlongExhaustion_tanh_*_iff` wrappers
(`_pos_iff`, `_eq_zero_iff`).

Pure refactor — no mathematical change.