### PR TITLE
refactor: split ambient FreeEnergyTrivialSlices Infinite wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean
@@ -1,6 +1,7 @@
 import IsingModel.AmbientLattice.SpontaneousMono
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyHSymmetry
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlicesInfinite
 
 /-!
 # Non-analytic free-energy special cases

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlices.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlices.lean
@@ -38,33 +38,6 @@ theorem freeEnergyAlongExhaustion_beta_zero
       (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2
   exact IsingModel.freeEnergy_beta_zero _ J h (Finset.Nonempty.fintype_card_coe_pos hne)
 
-/-- **Infinite-volume β=0 closed form**:
-under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2`
-for any `J, h, G, Λ`.
-
-The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n` is constantly
-`log 2` by `freeEnergyAlongExhaustion_beta_zero`, so its `limsup` on
-`atTop` is `log 2` by `Filter.limsup_const`.
-
-Sanity check: the β = 0 slice of the §4.6 Prop 4.6.1 infinite-volume
-free energy is trivially the maximum-entropy value.
-
-A weakened version requiring only `∀ᶠ n in atTop, (Λ.volume n).Nonempty`
-is provided as `freeEnergyInfinite_beta_zero_of_eventually_nonempty`
-in `AmbientLatticeSum.lean`. -/
-theorem freeEnergyInfinite_beta_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J h : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
-    freeEnergyInfinite G Λ (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2 := by
-  unfold freeEnergyInfinite
-  have hconst : freeEnergyAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ)
-      = fun _ : ℕ => Real.log 2 := by
-    funext n
-    exact freeEnergyAlongExhaustion_beta_zero G Λ J h n (hne n)
-  rw [hconst]
-  exact Filter.limsup_const (Real.log 2)
-
 /-- **Along-exhaustion J=h=0 closed form**:
 for nonempty `Λ.volume n` and any ambient graph `G, Λ` and any `β`,
 `freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n = log 2`.
@@ -82,33 +55,14 @@ theorem freeEnergyAlongExhaustion_zero_params
       (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2
   exact IsingModel.freeEnergy_zero_params _ β (Finset.Nonempty.fintype_card_coe_pos hne)
 
-/-- **Infinite-volume J=h=0 closed form**:
-under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2`
-for any `β, G, Λ`.
+/-! ## Moved: `freeEnergyInfinite_*` trivial-slice wrappers
 
-The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n` is constantly
-`log 2` by `freeEnergyAlongExhaustion_zero_params`, so its `limsup` on
-`atTop` is `log 2` by `Filter.limsup_const`.
-
-Companion to `freeEnergyInfinite_beta_zero`: both give the
-maximum-entropy value `log 2` from orthogonal degeneracies
-(β=0 vs. H ≡ 0).
-
-A weakened version requiring only `∀ᶠ n in atTop, (Λ.volume n).Nonempty`
-is provided as `freeEnergyInfinite_zero_params_of_eventually_nonempty`
-in `AmbientLatticeSum.lean`. -/
-theorem freeEnergyInfinite_zero_params
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
-    freeEnergyInfinite G Λ (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2 := by
-  unfold freeEnergyInfinite
-  have hconst : freeEnergyAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ)
-      = fun _ : ℕ => Real.log 2 := by
-    funext n
-    exact freeEnergyAlongExhaustion_zero_params G Λ β n (hne n)
-  rw [hconst]
-  exact Filter.limsup_const (Real.log 2)
+The two `freeEnergyInfinite_*` trivial-slice closed-form
+wrappers (`_beta_zero`, `_zero_params`) now live in
+`IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlicesInfinite`.
+The legacy import path is preserved by re-exporting the new child
+from `Legacy.lean`.
+-/
 
 /-- **Along-exhaustion J=0 graph-independence**:
 `freeEnergyAlongExhaustion G Λ ⟨0, h, β⟩ n

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlicesInfinite.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlicesInfinite.lean
@@ -1,0 +1,79 @@
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices
+
+/-!
+# Infinite-volume free-energy trivial-slice closed forms
+
+Narrow child module for the two infinite-volume `freeEnergyInfinite_*`
+trivial-parameter-slice closed-form wrappers extracted from
+`FreeEnergyTrivialSlices.lean`. Each wrapper unfolds
+`freeEnergyInfinite` to a constant sequence (using the
+corresponding `freeEnergyAlongExhaustion_*` parent theorem) and
+applies `Filter.limsup_const`. Theorem names are unchanged from
+the former `FreeEnergyTrivialSlices` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+open scoped symmDiff
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Infinite-volume β=0 closed form**:
+under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨J, h, 0⟩ = log 2`
+for any `J, h, G, Λ`.
+
+The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨J, h, 0⟩ n` is constantly
+`log 2` by `freeEnergyAlongExhaustion_beta_zero`, so its `limsup` on
+`atTop` is `log 2` by `Filter.limsup_const`.
+
+Sanity check: the β = 0 slice of the §4.6 Prop 4.6.1 infinite-volume
+free energy is trivially the maximum-entropy value.
+
+A weakened version requiring only `∀ᶠ n in atTop, (Λ.volume n).Nonempty`
+is provided as `freeEnergyInfinite_beta_zero_of_eventually_nonempty`
+in `AmbientLatticeSum.lean`. -/
+theorem freeEnergyInfinite_beta_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J h : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite G Λ (⟨J, h, 0⟩ : IsingParams ℝ) = Real.log 2 := by
+  unfold freeEnergyInfinite
+  have hconst : freeEnergyAlongExhaustion G Λ (⟨J, h, 0⟩ : IsingParams ℝ)
+      = fun _ : ℕ => Real.log 2 := by
+    funext n
+    exact freeEnergyAlongExhaustion_beta_zero G Λ J h n (hne n)
+  rw [hconst]
+  exact Filter.limsup_const (Real.log 2)
+
+/-- **Infinite-volume J=h=0 closed form**:
+under `∀ n, (Λ.volume n).Nonempty`, `freeEnergyInfinite G Λ ⟨0, 0, β⟩ = log 2`
+for any `β, G, Λ`.
+
+The sequence `n ↦ freeEnergyAlongExhaustion G Λ ⟨0, 0, β⟩ n` is constantly
+`log 2` by `freeEnergyAlongExhaustion_zero_params`, so its `limsup` on
+`atTop` is `log 2` by `Filter.limsup_const`.
+
+Companion to `freeEnergyInfinite_beta_zero`: both give the
+maximum-entropy value `log 2` from orthogonal degeneracies
+(β=0 vs. H ≡ 0).
+
+A weakened version requiring only `∀ᶠ n in atTop, (Λ.volume n).Nonempty`
+is provided as `freeEnergyInfinite_zero_params_of_eventually_nonempty`
+in `AmbientLatticeSum.lean`. -/
+theorem freeEnergyInfinite_zero_params
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (hne : ∀ n, (Λ.volume n).Nonempty) :
+    freeEnergyInfinite G Λ (⟨0, 0, β⟩ : IsingParams ℝ) = Real.log 2 := by
+  unfold freeEnergyInfinite
+  have hconst : freeEnergyAlongExhaustion G Λ (⟨0, 0, β⟩ : IsingParams ℝ)
+      = fun _ : ℕ => Real.log 2 := by
+    funext n
+    exact freeEnergyAlongExhaustion_zero_params G Λ β n (hne n)
+  rw [hconst]
+  exact Filter.limsup_const (Real.log 2)
+
+end Ambient
+end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -1,6 +1,7 @@
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyHSymmetry
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlicesInfinite
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZero
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityOnNhd


### PR DESCRIPTION
Wrapper-split refactor (WIP — opening PR early per workflow): extract 2 ambient `freeEnergyInfinite_*` trivial-slice closed forms from `IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlices.lean` into a new child module `IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlicesInfinite.lean`.

Planned moves:
* `freeEnergyInfinite_beta_zero`
* `freeEnergyInfinite_zero_params`

Each `_Infinite_*` theorem unfolds `freeEnergyInfinite` to a constant sequence (using the corresponding `freeEnergyAlongExhaustion_*` parent theorem) and applies `Filter.limsup_const`. The new child imports the parent (for the AlongExhaustion siblings); the parent does NOT re-import the child to avoid a cycle. `Legacy.lean` adds the new child import so downstream consumers continue to see the symbols via the legacy re-export.

Parent retains 4 `freeEnergyAlongExhaustion_*` trivial-slice wrappers
(`_beta_zero`, `_zero_params`, `_eq_bot_at_J_zero`, `_J_zero`).

Pure refactor — no mathematical change.