### PR TITLE
refactor: split ambient HighTemperature tanh wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperature.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperature.lean
@@ -1,6 +1,7 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
 import IsingModel.AmbientLattice.SpecialCases.HighTemperatureVdSandwichFE
+import IsingModel.AmbientLattice.SpecialCases.HighTemperatureTanh
 
 /-!
 # High-temperature convergence wrappers along an exhaustion
@@ -61,52 +62,18 @@ theorem polymerFreeEnergyAlongExhaustion_hasSum_via_log_of_pow_lt_two
   polymerFreeEnergy_Λ_hasSum_via_log_of_pow_lt_two
     G (Λ.volume n) ht h_pow
 
-/-- **Along-exhaustion: high-temperature sandwich for
-`polymerFreeEnergy` (tanh form)** (§18.5 along-ex wrap of the tanh
-sandwich). -/
-theorem polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ)
-    (h_pow : (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card < 2) :
-    0 ≤ IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) ∧
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) ≤
-      ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n))).erase ∅,
-        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card ∧
-    (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n))).erase ∅,
-        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ≤
-      (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 ∧
-    (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 < 1 ∧
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) < Real.log 2 :=
-  polymerFreeEnergy_Λ_tanh_high_temp_sandwich G (Λ.volume n) hβJ h_pow
+/-! ## Moved: 4 tanh sandwich / `HasSum` wrappers
 
-/-- **Along-exhaustion: log Taylor expansion for `polymerFreeEnergy`
-(tanh form)** (§18.5 along-ex wrap). -/
-theorem
-polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ)
-    (h_pow : (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card < 2) :
-    HasSum (fun k : ℕ =>
-        (-1 : ℝ) ^ k *
-          (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ^ (k + 1) /
-          (k + 1))
-      (IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J))) :=
-  polymerFreeEnergy_Λ_tanh_hasSum_via_log_of_pow_lt_two
-    G (Λ.volume n) hβJ h_pow
+The four along-exhaustion `tanh` wrappers
+(`polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich`,
+`polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two`,
+`polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich_ferromagnetic`,
+`polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic`)
+now live in
+`IsingModel.AmbientLattice.SpecialCases.HighTemperatureTanh`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 /-! ## Moved: 4 vdPolymerFamilies_sum sandwich + 2 strict freeEnergy wrappers
 
@@ -117,55 +84,6 @@ strict free-energy bounds now live in
 The legacy import path is preserved by re-exporting the new child
 from this parent module and from `Legacy.lean`.
 -/
-
-/-- **Along-exhaustion: high-temperature sandwich for
-`polymerFreeEnergy` (ferromagnetic tanh form)** (§18.5 ferromagnetic
-along-ex wrap). -/
-theorem
-polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich_ferromagnetic
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (n : ℕ)
-    (h_pow : (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card < 2) :
-    0 ≤ IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) ∧
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) ≤
-      ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n))).erase ∅,
-        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card ∧
-    (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n))).erase ∅,
-        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ≤
-      (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 ∧
-    (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 < 1 ∧
-    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J)) < Real.log 2 :=
-  polymerFreeEnergy_Λ_tanh_high_temp_sandwich_ferromagnetic
-    G (Λ.volume n) hJ hβ h_pow
-
-/-- **Along-exhaustion: log Taylor expansion for `polymerFreeEnergy`
-(ferromagnetic tanh form)** (§18.5 ferromagnetic along-ex wrap). -/
-theorem
-polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (n : ℕ)
-    (h_pow : (1 + Real.tanh (β * J)) ^
-        (inducedGraph G (Λ.volume n)).edgeFinset.card < 2) :
-    HasSum (fun k : ℕ =>
-        (-1 : ℝ) ^ k *
-          (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n))).erase ∅,
-            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ^ (k + 1) /
-          (k + 1))
-      (IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
-        (Real.tanh (β * J))) :=
-  polymerFreeEnergy_Λ_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic
-    G (Λ.volume n) hJ hβ h_pow
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureTanh.lean
@@ -1,0 +1,123 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# High-temperature tanh sandwich / `HasSum` wrappers along an exhaustion
+
+Narrow child module for the four §18.5 along-exhaustion
+high-temperature `tanh` wrappers extracted from
+`HighTemperature.lean`:
+
+* `polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich`
+* `polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two`
+* `polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich_ferromagnetic`
+* `polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic`
+
+Each wrapper is a thin pass-through to the corresponding
+`polymerFreeEnergy_Λ_tanh_*` ambient lemma. Theorem names are
+unchanged from the former `HighTemperature` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-exhaustion: high-temperature sandwich for
+`polymerFreeEnergy` (tanh form)** (§18.5 along-ex wrap of the tanh
+sandwich). -/
+theorem polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ)
+    (h_pow : (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card < 2) :
+    0 ≤ IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) ∧
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) ≤
+      ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n))).erase ∅,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card ∧
+    (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n))).erase ∅,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ≤
+      (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 ∧
+    (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 < 1 ∧
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) < Real.log 2 :=
+  polymerFreeEnergy_Λ_tanh_high_temp_sandwich G (Λ.volume n) hβJ h_pow
+
+/-- **Along-exhaustion: log Taylor expansion for `polymerFreeEnergy`
+(tanh form)** (§18.5 along-ex wrap). -/
+theorem
+polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ)
+    (h_pow : (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card < 2) :
+    HasSum (fun k : ℕ =>
+        (-1 : ℝ) ^ k *
+          (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ^ (k + 1) /
+          (k + 1))
+      (IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J))) :=
+  polymerFreeEnergy_Λ_tanh_hasSum_via_log_of_pow_lt_two
+    G (Λ.volume n) hβJ h_pow
+
+/-- **Along-exhaustion: high-temperature sandwich for
+`polymerFreeEnergy` (ferromagnetic tanh form)** (§18.5 ferromagnetic
+along-ex wrap). -/
+theorem
+polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich_ferromagnetic
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (n : ℕ)
+    (h_pow : (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card < 2) :
+    0 ≤ IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) ∧
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) ≤
+      ∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n))).erase ∅,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card ∧
+    (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n))).erase ∅,
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ≤
+      (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 ∧
+    (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card - 1 < 1 ∧
+    IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J)) < Real.log 2 :=
+  polymerFreeEnergy_Λ_tanh_high_temp_sandwich_ferromagnetic
+    G (Λ.volume n) hJ hβ h_pow
+
+/-- **Along-exhaustion: log Taylor expansion for `polymerFreeEnergy`
+(ferromagnetic tanh form)** (§18.5 ferromagnetic along-ex wrap). -/
+theorem
+polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β) (n : ℕ)
+    (h_pow : (1 + Real.tanh (β * J)) ^
+        (inducedGraph G (Λ.volume n)).edgeFinset.card < 2) :
+    HasSum (fun k : ℕ =>
+        (-1 : ℝ) ^ k *
+          (∑ Γ ∈ (IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n))).erase ∅,
+            ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ^ (k + 1) /
+          (k + 1))
+      (IsingModel.polymerFreeEnergy (inducedGraph G (Λ.volume n))
+        (Real.tanh (β * J))) :=
+  polymerFreeEnergy_Λ_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic
+    G (Λ.volume n) hJ hβ h_pow
+
+end Ambient
+end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -6,6 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZero
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityOnNhd
 import IsingModel.AmbientLattice.SpecialCases.HighTemperature
+import IsingModel.AmbientLattice.SpecialCases.HighTemperatureTanh
 import IsingModel.AmbientLattice.SpecialCases.HighTemperatureVdSandwichFE
 import IsingModel.AmbientLattice.SpecialCases.HighTemperatureBounds
 import IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansion


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2524) by extracting the four §18.5 along-exhaustion `tanh`
sandwich and `HasSum` wrappers from
`HighTemperature.lean` into a new narrow child module
`HighTemperatureTanh.lean`:

- `polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich`
- `polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two`
- `polymerFreeEnergyAlongExhaustion_tanh_high_temp_sandwich_ferromagnetic`
- `polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic`

Each wrapper is a thin pass-through to the corresponding
`polymerFreeEnergy_Λ_tanh_*` ambient lemma; theorem statements,
implicit/explicit parameter signatures, and proofs are byte-identical
to the previous declarations. Theorem names are unchanged so all
downstream consumers continue to resolve via the new child.

The parent `HighTemperature.lean` re-imports the new child to preserve
the legacy import path, and the umbrella `Legacy.lean` is updated to
import the new child. After the split `HighTemperature.lean` retains
only the two non-tanh
`polymerFreeEnergyAlongExhaustion_high_temp_sandwich` and
`polymerFreeEnergyAlongExhaustion_hasSum_via_log_of_pow_lt_two`
wrappers (parameter `t : ℝ`), making the file a clean two-theorem
parent organized around the underlying `t` form.

## Test plan

- [x] `lake build` — succeeded (3576 jobs)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)