### PR TITLE
refactor: split ambient MayerTrivialCasesIdentity edgeless wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/Legacy.lean
@@ -85,6 +85,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFE
 import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFEIff
 import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentity
+import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentityEdgeless
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentityEdgeless
 
 /-!
 # Mayer identity edge-case wrappers along an exhaustion
@@ -61,34 +62,16 @@ theorem mayer_identity_of_trivial_AlongExhaustion
         (Real.tanh (β * J)) :=
   mayer_identity_of_trivial_Λ G (Λ.volume n) h N
 
-/-- **Along-ex: Mayer identity for edgeless induced graphs**. -/
-theorem mayer_identity_of_edgeFinset_empty_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ)
-    (h_empty : (inducedGraph G (Λ.volume n)).edgeFinset = ∅)
-    (t : ℝ) (N : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) t =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N t :=
-  mayer_identity_of_edgeFinset_empty_Λ G (Λ.volume n) h_empty t N
+/-! ## Moved: 2 edgeless Mayer identity wrappers
 
-/-- **Along-ex: Mayer identity for edgeless induced graphs (tanh
-form)**. -/
-theorem mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (n : ℕ)
-    (h_empty : (inducedGraph G (Λ.volume n)).edgeFinset = ∅)
-    (β J : ℝ) (N : ℕ) :
-    IsingModel.polymerFreeEnergy
-        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh (β * J)) :=
-  mayer_identity_of_edgeFinset_empty_tanh_Λ
-    G (Λ.volume n) h_empty β J N
+The two along-ex edgeless Mayer identity wrappers
+(`mayer_identity_of_edgeFinset_empty_AlongExhaustion`,
+`mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion`) now
+live in
+`IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentityEdgeless`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from `Legacy.lean`.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentityEdgeless.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentityEdgeless.lean
@@ -1,0 +1,55 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer identity edgeless wrappers along an exhaustion
+
+Narrow child module for the two §18.5 along-exhaustion Mayer
+identity wrappers for edgeless induced graphs extracted from
+`MayerTrivialCasesIdentity.lean`:
+
+* `mayer_identity_of_edgeFinset_empty_AlongExhaustion`
+* `mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion`
+
+Each wrapper is a thin pass-through to the corresponding
+`mayer_identity_of_edgeFinset_empty_*_Λ` ambient lemma. Theorem
+names are unchanged from the former `MayerTrivialCases`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: Mayer identity for edgeless induced graphs**. -/
+theorem mayer_identity_of_edgeFinset_empty_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ)
+    (h_empty : (inducedGraph G (Λ.volume n)).edgeFinset = ∅)
+    (t : ℝ) (N : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) t =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N t :=
+  mayer_identity_of_edgeFinset_empty_Λ G (Λ.volume n) h_empty t N
+
+/-- **Along-ex: Mayer identity for edgeless induced graphs (tanh
+form)**. -/
+theorem mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (n : ℕ)
+    (h_empty : (inducedGraph G (Λ.volume n)).edgeFinset = ∅)
+    (β J : ℝ) (N : ℕ) :
+    IsingModel.polymerFreeEnergy
+        (inducedGraph G (Λ.volume n)) (Real.tanh (β * J)) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh (β * J)) :=
+  mayer_identity_of_edgeFinset_empty_tanh_Λ
+    G (Λ.volume n) h_empty β J N
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2548) by extracting the two §18.5 along-exhaustion Mayer
identity wrappers for edgeless induced graphs from
`MayerTrivialCasesIdentity.lean` into a new narrow child module
`MayerTrivialCasesIdentityEdgeless.lean`:

- `mayer_identity_of_edgeFinset_empty_AlongExhaustion`
- `mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion`

Each wrapper is a thin pass-through to the corresponding
`mayer_identity_of_edgeFinset_empty_*_Λ` ambient lemma. Theorem
statements, parameter signatures, and proofs are byte-identical to
the previous declarations. Theorem names are unchanged so all
downstream consumers continue to resolve via the new child.

The parent re-imports the new child to preserve the legacy import
path, and the umbrella `Legacy.lean` is updated to import the new
child. After the split the parent retains only the three no-polymer
/ trivial wrappers (`_of_no_polymers_*`, `_of_trivial_*`), making
it a coherent single-purpose module organized around the
no-polymer / trivial case family.

## Test plan

- [x] `lake build` — succeeded (3600 jobs)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)