### PR TITLE
refactor: split ambient MayerEdgeCases trivial-slice wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -82,6 +82,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentitiesVdSum
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCases
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPFE
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPolymerFreeEnergy
+import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesTrivial
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonInfrastructure
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonInfrastructureVdSum
 import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivity

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCases.lean
@@ -2,6 +2,7 @@ import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPFE
 import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPolymerFreeEnergy
+import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesTrivial
 
 /-!
 # Mayer edge-case wrappers along an exhaustion
@@ -43,31 +44,14 @@ theorem mayer_identity_at_betaJ_zero_AlongExhaustion
         (Real.tanh (β * J)) :=
   mayer_identity_at_betaJ_zero_Λ G (Λ.volume n) hβJ N
 
-/-- **Along-ex: Mayer identity at `β = 0`**. -/
-theorem mayer_identity_at_beta_zero_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J : ℝ) (N : ℕ) (n : ℕ) :
-    Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-                (inducedGraph G (Λ.volume n)),
-              ∏ P ∈ Γ, Real.tanh ((0 : ℝ) * J) ^ P.card) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh ((0 : ℝ) * J)) :=
-  mayer_identity_at_beta_zero_Λ G (Λ.volume n) J N
+/-! ## Moved: 2 trivial-slice Mayer identity wrappers
 
-/-- **Along-ex: Mayer identity at `J = 0`**. -/
-theorem mayer_identity_at_J_zero_AlongExhaustion
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (N : ℕ) (n : ℕ) :
-    Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-                (inducedGraph G (Λ.volume n)),
-              ∏ P ∈ Γ, Real.tanh (β * (0 : ℝ)) ^ P.card) =
-      IsingModel.mayerPartialSum
-        (inducedGraph G (Λ.volume n)) N
-        (Real.tanh (β * (0 : ℝ))) :=
-  mayer_identity_at_J_zero_Λ G (Λ.volume n) β N
+The two along-ex `mayer_identity_at_*_zero_AlongExhaustion` trivial-slice
+wrappers (`_beta_zero`, `_J_zero`) now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesTrivial`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from the umbrella.
+-/
 
 /-! ## Moved: polymerFreeEnergyAlongExhaustion eq mayerPartialSum wrappers
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCasesTrivial.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCasesTrivial.lean
@@ -1,0 +1,51 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer trivial-slice edge-case wrappers along an exhaustion
+
+Narrow child module for the two §18.5 along-exhaustion Mayer
+identity wrappers at the trivial parameter slices
+`β = 0` and `J = 0` extracted from `MayerEdgeCases.lean`:
+
+* `mayer_identity_at_beta_zero_AlongExhaustion`
+* `mayer_identity_at_J_zero_AlongExhaustion`
+
+Each wrapper is a thin pass-through to the corresponding
+`mayer_identity_at_*_zero_Λ` ambient lemma. Theorem names are
+unchanged from the former `MayerEdgeCases` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: Mayer identity at `β = 0`**. -/
+theorem mayer_identity_at_beta_zero_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J : ℝ) (N : ℕ) (n : ℕ) :
+    Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+                (inducedGraph G (Λ.volume n)),
+              ∏ P ∈ Γ, Real.tanh ((0 : ℝ) * J) ^ P.card) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh ((0 : ℝ) * J)) :=
+  mayer_identity_at_beta_zero_Λ G (Λ.volume n) J N
+
+/-- **Along-ex: Mayer identity at `J = 0`**. -/
+theorem mayer_identity_at_J_zero_AlongExhaustion
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (N : ℕ) (n : ℕ) :
+    Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+                (inducedGraph G (Λ.volume n)),
+              ∏ P ∈ Γ, Real.tanh (β * (0 : ℝ)) ^ P.card) =
+      IsingModel.mayerPartialSum
+        (inducedGraph G (Λ.volume n)) N
+        (Real.tanh (β * (0 : ℝ))) :=
+  mayer_identity_at_J_zero_Λ G (Λ.volume n) β N
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2564) by extracting the two §18.5 along-exhaustion Mayer
identity wrappers at the trivial parameter slices `β = 0` and `J = 0`
from `MayerEdgeCases.lean` into a new narrow child module
`MayerEdgeCasesTrivial.lean`:

- `mayer_identity_at_beta_zero_AlongExhaustion`
- `mayer_identity_at_J_zero_AlongExhaustion`

Each wrapper is a thin pass-through to the corresponding
`mayer_identity_at_*_zero_Λ` ambient lemma. Theorem statements,
parameter signatures, and proofs are byte-identical to the previous
declarations. Theorem names are unchanged so all downstream consumers
continue to resolve via the new child.

The parent re-imports the new child to preserve the legacy import
path, and the umbrella `SpecialCases.lean` is updated to import the
new child. After the split the parent retains only the two base
wrappers (`mayer_identity_at_zero_AlongExhaustion`,
`mayer_identity_at_betaJ_zero_AlongExhaustion`), making it a
coherent single-purpose module organized around the base Mayer
identity at zero / β·J = 0.

## Test plan

- [x] `lake build` — succeeded (3612 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)