### PR TITLE
refactor: split ambient MayerFilterConnected zero/one wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -90,6 +90,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivityVdSum
 import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCases
 import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCasesTwo
 import IsingModel.AmbientLattice.SpecialCases.MayerFilterConnected
+import IsingModel.AmbientLattice.SpecialCases.MayerFilterConnectedBase
 import IsingModel.AmbientLattice.SpecialCases.MayerRecurrenceHasSum
 import IsingModel.AmbientLattice.SpecialCases.MayerRecurrenceHasSumLog
 import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivity

--- a/IsingModel/AmbientLattice/SpecialCases/MayerFilterConnected.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerFilterConnected.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerFilterConnectedBase
 
 /-!
 # Mayer filter-connected wrappers along an exhaustion
@@ -34,35 +35,14 @@ theorem vdPolymerFamilies_sumAlongExhaustion_minus_one_pow
         ∏ i : Fin k, ∏ P ∈ ω i, t ^ P.card :=
   vdPolymerFamilies_sum_Λ_minus_one_pow G (Λ.volume n) t k
 
-/-- **Along-ex: mayerExpansionTerm filter-connected at k=0 = ∅**. -/
-theorem mayerExpansionTermAlongExhaustion_filter_connected_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (t : ℝ) (n : ℕ) :
-    (Fintype.piFinset
-        (fun _ : Fin 0 =>
-          IsingModel.allPolymers
-            (inducedGraph G (Λ.volume n)))).filter
-        (fun ω =>
-          (IsingModel.polymerSeqIncompatibilityGraph ω).Connected) = ∅ :=
-  mayerExpansionTerm_Λ_filter_connected_zero G (Λ.volume n) t
+/-! ## Moved: 2 filter_connected base-case wrappers
 
-/-- **Along-ex: mayerExpansionTerm filter-connected at k=1 = full
-piFinset**. -/
-theorem mayerExpansionTermAlongExhaustion_filter_connected_one
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
-    (Fintype.piFinset
-        (fun _ : Fin 1 =>
-          IsingModel.allPolymers
-            (inducedGraph G (Λ.volume n)))).filter
-        (fun ω =>
-          (IsingModel.polymerSeqIncompatibilityGraph ω).Connected) =
-      Fintype.piFinset
-        (fun _ : Fin 1 =>
-          IsingModel.allPolymers
-            (inducedGraph G (Λ.volume n))) :=
-  mayerExpansionTerm_Λ_filter_connected_one G (Λ.volume n)
+The two `mayerExpansionTermAlongExhaustion_filter_connected_{zero,one}`
+base-case wrappers now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerFilterConnectedBase`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from the umbrella.
+-/
 
 /-- **Along-ex: filter-connected = filter-incompatible at k=2**. -/
 theorem mayerExpansionTermAlongExhaustion_two_filter_connected_eq_incompat

--- a/IsingModel/AmbientLattice/SpecialCases/MayerFilterConnectedBase.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerFilterConnectedBase.lean
@@ -1,0 +1,59 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer filter-connected base-case wrappers along an exhaustion
+
+Narrow child module for the two §18.5 along-exhaustion
+`mayerExpansionTermAlongExhaustion_filter_connected_{zero,one}`
+base-case wrappers extracted from `MayerFilterConnected.lean`:
+
+* `mayerExpansionTermAlongExhaustion_filter_connected_zero`
+* `mayerExpansionTermAlongExhaustion_filter_connected_one`
+
+Each wrapper is a thin pass-through to the corresponding ambient
+`mayerExpansionTerm_Λ_filter_connected_{zero,one}` lemma stating
+that the filter-connected piFinset is empty at `k = 0` and the
+entire piFinset at `k = 1`. Theorem names are unchanged from the
+former `MayerFilterConnected` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: mayerExpansionTerm filter-connected at k=0 = ∅**. -/
+theorem mayerExpansionTermAlongExhaustion_filter_connected_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (t : ℝ) (n : ℕ) :
+    (Fintype.piFinset
+        (fun _ : Fin 0 =>
+          IsingModel.allPolymers
+            (inducedGraph G (Λ.volume n)))).filter
+        (fun ω =>
+          (IsingModel.polymerSeqIncompatibilityGraph ω).Connected) = ∅ :=
+  mayerExpansionTerm_Λ_filter_connected_zero G (Λ.volume n) t
+
+/-- **Along-ex: mayerExpansionTerm filter-connected at k=1 = full
+piFinset**. -/
+theorem mayerExpansionTermAlongExhaustion_filter_connected_one
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet] (n : ℕ) :
+    (Fintype.piFinset
+        (fun _ : Fin 1 =>
+          IsingModel.allPolymers
+            (inducedGraph G (Λ.volume n)))).filter
+        (fun ω =>
+          (IsingModel.polymerSeqIncompatibilityGraph ω).Connected) =
+      Fintype.piFinset
+        (fun _ : Fin 1 =>
+          IsingModel.allPolymers
+            (inducedGraph G (Λ.volume n))) :=
+  mayerExpansionTerm_Λ_filter_connected_one G (Λ.volume n)
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2565) by extracting the two §18.5 along-exhaustion
`mayerExpansionTermAlongExhaustion_filter_connected_{zero,one}`
base-case wrappers from `MayerFilterConnected.lean` into a new narrow
child module `MayerFilterConnectedBase.lean`:

- `mayerExpansionTermAlongExhaustion_filter_connected_zero`
- `mayerExpansionTermAlongExhaustion_filter_connected_one`

Each wrapper is a thin pass-through to the corresponding ambient
`mayerExpansionTerm_Λ_filter_connected_{zero,one}` lemma stating
that the filter-connected piFinset is empty at `k = 0` and the
entire piFinset at `k = 1`. Theorem statements, parameter
signatures, and proofs are byte-identical to the previous
declarations. Theorem names are unchanged so all downstream consumers
continue to resolve via the new child.

The parent re-imports the new child to preserve the legacy import
path, and the umbrella `SpecialCases.lean` is updated to import the
new child. After the split the parent retains only the two non-base
wrappers (`vdPolymerFamilies_sumAlongExhaustion_minus_one_pow`,
`mayerExpansionTermAlongExhaustion_two_filter_connected_eq_incompat`),
making it a coherent module organized around the `k ≥ 2`
filter-connected manipulations and the ε(t)^n identity.

## Test plan

- [x] `lake build` — succeeded (3613 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)