### PR TITLE
refactor: split ambient VdPolymerFamiliesAnalyticity tanh wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -157,6 +157,7 @@ import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityA
 import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityDifferentiable
 import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLog
+import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityTanh
 
 /-!
 # Ambient-lattice special cases umbrella

--- a/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticity.lean
@@ -1,6 +1,7 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
 import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLog
+import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityTanh
 
 /-!
 # Polymer-family analyticity wrappers along an exhaustion
@@ -29,29 +30,15 @@ theorem vdPolymerFamilies_sumAlongExhaustion_analyticAt
           ∏ P ∈ Γ, s ^ P.card) t :=
   vdPolymerFamilies_sum_Λ_analyticAt G (Λ.volume n) t
 
-/-! ### `vdPolymerFamilies_sum` tanh β/J analyticity along an exhaustion -/
+/-! ## Moved: 2 tanh analyticity wrappers
 
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) AnalyticAt in β**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun β' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) β :=
-  vdPolymerFamilies_sum_Λ_tanh_analyticAt_beta G (Λ.volume n) J β
-
-/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) AnalyticAt in J**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β J : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun J' : ℝ =>
-        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) J :=
-  vdPolymerFamilies_sum_Λ_tanh_analyticAt_J G (Λ.volume n) β J
+The two along-ex tanh-composition analyticity wrappers
+(`vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta`,
+`vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J`) now live in
+`IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityTanh`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from the umbrella.
+-/
 
 /-! ## Moved: log_vdPolymerFamilies_sumAlongExhaustion analyticity wrappers
 

--- a/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityTanh.lean
@@ -1,0 +1,48 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Polymer-family `tanh ∘ (·)` analyticity wrappers along an exhaustion
+
+Narrow child module for the two along-exhaustion
+`vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_{beta,J}`
+wrappers extracted from `VdPolymerFamiliesAnalyticity.lean`:
+
+* `vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta`
+* `vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J`
+
+Each wrapper is a thin pass-through to the corresponding ambient
+`vdPolymerFamilies_sum_Λ_tanh_analyticAt_*` lemma. Theorem names
+are unchanged from the former `VdPolymerFamiliesAnalyticity`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (·*J) AnalyticAt in β**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun β' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card) β :=
+  vdPolymerFamilies_sum_Λ_tanh_analyticAt_beta G (Λ.volume n) J β
+
+/-- **Along-ex: vdPolymerFamilies_sum ∘ tanh ∘ (β*·) AnalyticAt in J**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β J : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun J' : ℝ =>
+        ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card) J :=
+  vdPolymerFamilies_sum_Λ_tanh_analyticAt_J G (Λ.volume n) β J
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2567) by extracting the two along-exhaustion
`vdPolymerFamilies_sum ∘ tanh ∘ (·)` analyticity wrappers from
`VdPolymerFamiliesAnalyticity.lean` into a new narrow child module
`VdPolymerFamiliesAnalyticityTanh.lean`:

- `vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta`
- `vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J`

Each wrapper is a thin pass-through to the corresponding ambient
`vdPolymerFamilies_sum_Λ_tanh_analyticAt_*` lemma. Theorem
statements, parameter signatures, and proofs are byte-identical to
the previous declarations. Theorem names are unchanged so all
downstream consumers continue to resolve via the new child.

The parent re-imports the new child to preserve the legacy import
path, and the umbrella `SpecialCases.lean` is updated to import the
new child. After the split the parent retains only the two direct
`vdPolymerFamilies_sumAlongExhaustion_analyticAt` and
`vdPolymerFamilies_sumAlongExhaustion_minus_one_analyticAt`
wrappers, making it a coherent single-purpose module organized
around the underlying `s ↦ ∑ Γ, ∏ P, s^|P|` analyticity.

## Test plan

- [x] `lake build` — succeeded (3615 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)