### PR TITLE
refactor: split ambient VdPolymerFamiliesAnalyticityLog tanh wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -171,6 +171,7 @@ import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityA
 import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityDifferentiable
 import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLog
+import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLogTanh
 import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityTanh
 
 /-!

--- a/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityLog.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityLog.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLogTanh
 
 /-!
 # Ambient log_vdPolymerFamilies_sumAlongExhaustion analyticity wrappers
@@ -48,31 +49,14 @@ theorem log_vdPolymerFamilies_sumAlongExhaustion_analyticOnNhd_Ici_zero
   log_vdPolymerFamilies_sum_Λ_analyticOnNhd_Ici_zero
     G (Λ.volume n)
 
-/-- **Along-ex: log_vdPolymerFamilies_sum ∘ tanh AnalyticAt in β under
-`0 ≤ β·J`**. -/
-theorem log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β : ℝ) (hβJ : 0 ≤ β * J) (n : ℕ) :
-    AnalyticAt ℝ (fun β' : ℝ =>
-        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card)) β :=
-  log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_beta
-    G (Λ.volume n) J β hβJ
+/-! ## Moved: 2 log_vdPolymerFamilies_sum tanh wrappers
 
-/-- **Along-ex: log_vdPolymerFamilies_sum ∘ tanh AnalyticAt in J under
-`0 ≤ β·J`**. -/
-theorem log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β J : ℝ) (hβJ : 0 ≤ β * J) (n : ℕ) :
-    AnalyticAt ℝ (fun J' : ℝ =>
-        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card)) J :=
-  log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_J
-    G (Λ.volume n) β J hβJ
+The two `log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_*`
+wrappers (`_tanh_analyticAt_beta`, `_tanh_analyticAt_J`) now live in
+`IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLogTanh`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from the umbrella.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityLogTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityLogTanh.lean
@@ -1,0 +1,52 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Ambient log_vdPolymerFamilies_sumAlongExhaustion `tanh` analyticity wrappers
+
+Narrow child module for the two ambient
+`log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_*` wrappers
+extracted from `VdPolymerFamiliesAnalyticityLog.lean`:
+
+* `log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta`
+* `log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J`
+
+Each result is a thin pass-through of the corresponding Λ-level
+`log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_*` lemma. Theorem
+names are unchanged from the former `VdPolymerFamiliesAnalyticity`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: log_vdPolymerFamilies_sum ∘ tanh AnalyticAt in β under
+`0 ≤ β·J`**. -/
+theorem log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β : ℝ) (hβJ : 0 ≤ β * J) (n : ℕ) :
+    AnalyticAt ℝ (fun β' : ℝ =>
+        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β' * J) ^ P.card)) β :=
+  log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_beta
+    G (Λ.volume n) J β hβJ
+
+/-- **Along-ex: log_vdPolymerFamilies_sum ∘ tanh AnalyticAt in J under
+`0 ≤ β·J`**. -/
+theorem log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β J : ℝ) (hβJ : 0 ≤ β * J) (n : ℕ) :
+    AnalyticAt ℝ (fun J' : ℝ =>
+        Real.log (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, Real.tanh (β * J') ^ P.card)) J :=
+  log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_J
+    G (Λ.volume n) β J hβJ
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2582) by extracting the two ambient
`log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_*` wrappers
from `VdPolymerFamiliesAnalyticityLog.lean` into a new narrow child
module `VdPolymerFamiliesAnalyticityLogTanh.lean`:

- `log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta`
- `log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J`

Each result is a thin pass-through of the corresponding Λ-level
`log_vdPolymerFamilies_sum_Λ_tanh_analyticAt_*` lemma. Theorem
statements, parameter signatures, and proofs are byte-identical to
the previous declarations. Theorem names are unchanged so all
downstream consumers continue to resolve via the new child.

The parent re-imports the new child to preserve the legacy import
path, and the umbrella `SpecialCases.lean` is updated to import the
new child. After the split the parent retains only the two direct
`s ↦ log (∑ Γ, ∏ P, s^|P|)` analyticity wrappers (`_analyticAt`,
`_analyticOnNhd_Ici_zero`), making it a coherent single-purpose
module organized around the underlying `log` composition analyticity.

## Test plan

- [x] `lake build` — succeeded (3630 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)