### PR TITLE
refactor: split ambient MayerVdIff tanh wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -116,6 +116,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentityEdgeless
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
+import IsingModel.AmbientLattice.SpecialCases.MayerVdIffTanh
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityDifferentiable
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdIff.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdIff.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerVdIffTanh
 
 /-!
 # Mayer vd iff characterization wrappers along an exhaustion
@@ -44,31 +45,15 @@ theorem vdPolymerFamilies_sumAlongExhaustion_gt_one_iff_eps_pos
             ∏ P ∈ Γ, t ^ P.card :=
   vdPolymerFamilies_sum_Λ_gt_one_iff_eps_pos G (Λ.volume n) ht
 
-/-- **Along-ex: vdSum_tanh > 1 ↔ 0 < tanh ∧ allPolymers ≠ ∅**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_gt_one_iff
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) :
-    1 < (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ↔
-      0 < Real.tanh (β * J) ∧
-        (IsingModel.allPolymers
-          (inducedGraph G (Λ.volume n))).Nonempty :=
-  vdPolymerFamilies_sum_Λ_tanh_gt_one_iff G (Λ.volume n) hβJ
+/-! ## Moved: 2 vd tanh iff wrappers
 
-/-- **Along-ex: vdSum_tanh = 1 ↔ tanh = 0 ∨ allPolymers = ∅**. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_tanh_eq_one_iff
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) :
-    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-            (inducedGraph G (Λ.volume n)),
-        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) = 1 ↔
-      Real.tanh (β * J) = 0 ∨
-        IsingModel.allPolymers
-          (inducedGraph G (Λ.volume n)) = ∅ :=
-  vdPolymerFamilies_sum_Λ_tanh_eq_one_iff G (Λ.volume n) hβJ
+The two `vdPolymerFamilies_sumAlongExhaustion_tanh_*_iff`
+characterization wrappers (`_tanh_gt_one_iff`, `_tanh_eq_one_iff`)
+now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerVdIffTanh`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from the umbrella.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdIffTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdIffTanh.lean
@@ -1,0 +1,55 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer vd `tanh` iff characterization wrappers along an exhaustion
+
+Narrow child module for the two along-exhaustion
+`vdPolymerFamilies_sumAlongExhaustion_tanh_*_iff` characterization
+wrappers extracted from `MayerVdIff.lean`:
+
+* `vdPolymerFamilies_sumAlongExhaustion_tanh_gt_one_iff`
+* `vdPolymerFamilies_sumAlongExhaustion_tanh_eq_one_iff`
+
+Each wrapper is a thin pass-through to the corresponding ambient
+`vdPolymerFamilies_sum_Λ_tanh_*_iff` lemma characterizing the
+`> 1` / `= 1` cases of the vd sum at the tanh argument by joint
+behaviour of `tanh(βJ)` and `allPolymers`. Theorem names are
+unchanged from the former `MayerVdIff` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: vdSum_tanh > 1 ↔ 0 < tanh ∧ allPolymers ≠ ∅**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_gt_one_iff
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) :
+    1 < (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) ↔
+      0 < Real.tanh (β * J) ∧
+        (IsingModel.allPolymers
+          (inducedGraph G (Λ.volume n))).Nonempty :=
+  vdPolymerFamilies_sum_Λ_tanh_gt_one_iff G (Λ.volume n) hβJ
+
+/-- **Along-ex: vdSum_tanh = 1 ↔ tanh = 0 ∨ allPolymers = ∅**. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_tanh_eq_one_iff
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) :
+    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+            (inducedGraph G (Λ.volume n)),
+        ∏ P ∈ Γ, (Real.tanh (β * J)) ^ P.card) = 1 ↔
+      Real.tanh (β * J) = 0 ∨
+        IsingModel.allPolymers
+          (inducedGraph G (Λ.volume n)) = ∅ :=
+  vdPolymerFamilies_sum_Λ_tanh_eq_one_iff G (Λ.volume n) hβJ
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2583) by extracting the two along-exhaustion
`vdPolymerFamilies_sumAlongExhaustion_tanh_*_iff` characterization
wrappers from `MayerVdIff.lean` into a new narrow child module
`MayerVdIffTanh.lean`:

- `vdPolymerFamilies_sumAlongExhaustion_tanh_gt_one_iff`
- `vdPolymerFamilies_sumAlongExhaustion_tanh_eq_one_iff`

Each wrapper is a thin pass-through to the corresponding ambient
`vdPolymerFamilies_sum_Λ_tanh_*_iff` lemma characterizing the
`> 1` / `= 1` cases of the vd sum at the tanh argument by joint
behaviour of `tanh(βJ)` and `allPolymers`. Theorem statements,
parameter signatures, and proofs are byte-identical to the previous
declarations. Theorem names are unchanged so all downstream consumers
continue to resolve via the new child.

The parent re-imports the new child to preserve the legacy import
path, and the umbrella `SpecialCases.lean` is updated to import
the new child. After the split the parent retains only the two
non-tanh `_eq_one_iff_eps_eq_zero` / `_gt_one_iff_eps_pos` wrappers,
making it a coherent single-purpose module organized around the
general `t` / `ε` iff characterizations.

## Test plan

- [x] `lake build` — succeeded (3631 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)