### PR TITLE
refactor: split ambient MayerVdBoundsGeneric sandwich wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -116,6 +116,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentity
 import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentityEdgeless
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric
+import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGenericSandwich
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 import IsingModel.AmbientLattice.SpecialCases.MayerVdIffTanh
 import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGeneric.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGeneric.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGenericSandwich
 
 /-!
 # Mayer vd generic-t bound wrappers along an exhaustion
@@ -21,26 +22,16 @@ variable {V : Type*} [DecidableEq V]
 
 /-! ### §18.5 vdPolymerFamilies_sum generic-t bounds along-ex -/
 
-/-- **Along-ex: 1 ≤ vdSum** under `0 ≤ t`. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_ge_one_of_nonneg
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
-    1 ≤ ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card :=
-  vdPolymerFamilies_sum_Λ_ge_one_of_nonneg G (Λ.volume n) ht
+/-! ## Moved: 2 sandwich bound wrappers
 
-/-- **Along-ex: vdSum ≤ (1+t)^|E|** under `0 ≤ t`. -/
-theorem vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
-    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
-              (inducedGraph G (Λ.volume n)),
-          ∏ P ∈ Γ, t ^ P.card)
-      ≤ (1 + t) ^ (inducedGraph G (Λ.volume n)).edgeFinset.card :=
-  vdPolymerFamilies_sum_Λ_le_one_plus_pow_of_nonneg G (Λ.volume n) ht
+The two sandwich bound wrappers
+(`vdPolymerFamilies_sumAlongExhaustion_ge_one_of_nonneg`,
+`vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg`)
+now live in
+`IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGenericSandwich`.
+The legacy import path is preserved by re-exporting the new child
+from this parent module and from the umbrella.
+-/
 
 /-- **Along-ex: 0 < vdSum** under `0 ≤ t`. -/
 theorem vdPolymerFamilies_sumAlongExhaustion_pos_of_nonneg

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGenericSandwich.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGenericSandwich.lean
@@ -1,0 +1,50 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Mayer vd generic-t sandwich bound wrappers along an exhaustion
+
+Narrow child module for the two §18.5 along-exhaustion
+`vdPolymerFamilies_sumAlongExhaustion` sandwich bound wrappers
+extracted from `MayerVdBoundsGeneric.lean`:
+
+* `vdPolymerFamilies_sumAlongExhaustion_ge_one_of_nonneg`
+* `vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg`
+
+Each wrapper is a thin pass-through to the corresponding
+`vdPolymerFamilies_sum_Λ_*` ambient lemma giving the `1 ≤ vdSum`
+lower bound and `vdSum ≤ (1+t)^|E|` upper bound under `0 ≤ t`.
+Theorem names are unchanged from the former `MayerVdBounds`
+declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+open Finset Real
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: 1 ≤ vdSum** under `0 ≤ t`. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_ge_one_of_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    1 ≤ ∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card :=
+  vdPolymerFamilies_sum_Λ_ge_one_of_nonneg G (Λ.volume n) ht
+
+/-- **Along-ex: vdSum ≤ (1+t)^|E|** under `0 ≤ t`. -/
+theorem vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    (∑ Γ ∈ IsingModel.vdCompatiblePolymerFamilies
+              (inducedGraph G (Λ.volume n)),
+          ∏ P ∈ Γ, t ^ P.card)
+      ≤ (1 + t) ^ (inducedGraph G (Λ.volume n)).edgeFinset.card :=
+  vdPolymerFamilies_sum_Λ_le_one_plus_pow_of_nonneg G (Λ.volume n) ht
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2585) by extracting the two §18.5 along-exhaustion
`vdPolymerFamilies_sumAlongExhaustion` sandwich bound wrappers from
`MayerVdBoundsGeneric.lean` into a new narrow child module
`MayerVdBoundsGenericSandwich.lean`:

- `vdPolymerFamilies_sumAlongExhaustion_ge_one_of_nonneg`
- `vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg`

Each wrapper is a thin pass-through to the corresponding
`vdPolymerFamilies_sum_Λ_*` ambient lemma giving the `1 ≤ vdSum`
lower bound and `vdSum ≤ (1+t)^|E|` upper bound under `0 ≤ t`.
Theorem statements, parameter signatures, and proofs are
byte-identical to the previous declarations. Theorem names are
unchanged so all downstream consumers continue to resolve via the
new child.

The parent re-imports the new child to preserve the legacy import
path, and the umbrella `SpecialCases.lean` is updated to import the
new child. After the split the parent retains only the strict
`_pos_of_nonneg` positivity wrapper and the `_eq_one_add`
decomposition, making it a coherent single-purpose module organized
around the strict-positivity and decomposition family.

## Test plan

- [x] `lake build` — succeeded (3633 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)