### PR TITLE
refactor: purge stale Legacy / legacy doc-comment references

### DIFF
--- a/IsingModel/AmbientLattice/Analyticity.lean
+++ b/IsingModel/AmbientLattice/Analyticity.lean
@@ -42,7 +42,7 @@ The 10 Λ-level joint analyticity wrappers (partitionFunctionΛ +
 freeEnergyΛ + correlationΛ AnalyticAt / AnalyticOnNhd / Continuous /
 Differentiable joint) now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaJoint`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -53,7 +53,7 @@ The 14 magnetizationΛ + susceptibilityΛ + correlationΛ
 continuousAt/differentiableAt/analyticAt/analyticOnNhd joint wrappers
 now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaMagSuscep`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -62,7 +62,7 @@ The legacy import path is preserved by re-importing the new child.
 The 6 partitionFunctionΛ per-direction Continuous / Differentiable
 wrappers at general h now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaPerDirection`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## §18.4-§18.5 polymerFreeEnergy / vdSum / ε wrappers (now split)
@@ -79,7 +79,7 @@ have been refactored out into narrow child modules
 `AnalyticityLambdaMayerPfeEdgeBounds`,
 `AnalyticityLambdaMayerRecurrenceEpsilon`,
 `AnalyticityLambdaEpsilonIff`, ...) re-imported at the top of this
-file, so the legacy import path is preserved while the per-PR
+file, so the earlier import path is preserved while the per-PR
 narrow Moved doc blocks below list the exact destinations. -/
 
 /-! ## Moved: polymerFreeEnergy_Λ basic wrappers
@@ -87,7 +87,7 @@ narrow Moved doc blocks below list the exact destinations. -/
 The 16 §18.4 polymerFreeEnergy_Λ / vdPolymerFamilies_sum_Λ / mayer*_Λ
 basic wrappers now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaPolymer`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -98,7 +98,7 @@ The 10 §18.4 / §18.5 polymerFreeEnergy_Λ high_temp_sandwich, tanh
 sandwich, hasSum_via_log, and vdPolymerFamilies_sum_Λ sandwich wrappers
 (with ferromagnetic variants) now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaSandwich`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -108,7 +108,7 @@ The 10 Λ-layer freeEnergyΛ correction + polymerFreeEnergy_Λ
 continuous/differentiable + tanh analyticAt/analyticOnNhd wrappers
 now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaRegularity`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -117,7 +117,7 @@ The legacy import path is preserved by re-importing the new child.
 The 12 Λ-layer polymerFreeEnergy_Λ nonneg / bounds / monotone / eq_zero
 / tanh sandwich / tanh double bound wrappers now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaPolymerBounds`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -127,7 +127,7 @@ The 23 §18.6 mayerPartialSum_Λ + mayerExpansionTerm_Λ
 continuous/differentiable/analyticAt/analyticOnNhd wrappers (raw and
 tanh-composed variants) now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaMayer`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: vdPolymerFamilies_sum + log_vdPolymerFamilies_sum wrappers
@@ -136,7 +136,7 @@ The 14 §18.5-18.6 vdPolymerFamilies_sum_Λ + log_vdPolymerFamilies_sum_Λ
 continuous / differentiable / analyticAt / hasDerivAt wrappers
 (raw and tanh-composed variants) now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaVdPolymer`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: §18.5 Mayer identity edge-case wrappers
@@ -147,7 +147,7 @@ mayerPartialSum edge-case wrappers (parameter slices `t = 0`, `β·J =
 polymerFreeEnergy bounds; no-polymer / trivial / edgeless induced
 graphs) now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaMayerIdentity`. The
-legacy import path is preserved by re-importing the new child.
+earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: §18.5 basic identities + bounds + iff wrappers
@@ -157,7 +157,7 @@ identities, tanh iff characterizations, the bound family
 (`le_two_pow`, `le_one_plus_tanh_pow`, `one_le_vdPolymerFamilies_sum_Λ`),
 and generic-`t` bounds + `_eq_one_add` decomposition now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaBasicIdentities`. The
-legacy import path is preserved by re-importing the new child.
+earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: §18.5 Mayer expansion + polymerFreeEnergy bound wrappers
@@ -170,7 +170,7 @@ analyticAt + analyticOnNhd_Ici_zero + sandwich_of_nonneg, and
 polymerFreeEnergy tanh-bound + ferromagnetic + hasDerivAt +
 `_eq_log_one_add_eps` now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaMayerPfeEdgeBounds`. The
-legacy import path is preserved by re-importing the new child.
+earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: §18.5 Mayer recurrence + ε infrastructure wrappers
@@ -185,7 +185,7 @@ The 12 §18.5 Λ-layer wrappers covering Mayer recurrence
 continuous, analyticAt, lt_one_eventually}`, and
 `allPolymers_Λ_eq_empty_of_edgeFinset_empty` now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaMayerRecurrenceEpsilon`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: §18.5 ε(t) positivity-iff + strict-mono wrappers
@@ -199,7 +199,7 @@ eq_zero_iff}`) and strict-mono / strict-pos under polymers ≠ ∅
 `_tanh_gt_one_of_tanh_pos`, `_minus_one_tanh_pos_of_tanh_pos`,
 `_strictMonoOn_Ioi_zero`, both for `polymerFreeEnergy_Λ` and
 `vdPolymerFamilies_sum_Λ`) now live in
-`IsingModel.AmbientLattice.AnalyticityLambdaEpsilonIff`. The legacy
+`IsingModel.AmbientLattice.AnalyticityLambdaEpsilonIff`. The earlier
 import path is preserved by re-importing the new child.
 -/
 
@@ -213,7 +213,7 @@ lt_pow_sub_one_of_eps_pos, lt_eps_of_eps_pos}_ferro` and
 `vdPolymerFamilies_sum_Λ_tanh_{gt_one_iff, eq_one_iff}_ferro`
 (under `0 ≤ β`, `0 ≤ J`) now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaTanhFerroIff`. The
-legacy import path is preserved by re-importing the new child.
+earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -230,7 +230,7 @@ and pow_at_zero, non-tanh `polymerFreeEnergy_Λ` sharpening,
 `polymerFreeEnergy_Λ_tanh_{le_eps, le_pow_sub_one, lt_log_two}`)
 now live in
 `IsingModel.AmbientLattice.AnalyticityLambdaPfeSharpening`. The
-legacy import path is preserved by re-importing the new child.
+earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -239,7 +239,7 @@ legacy import path is preserved by re-importing the new child.
 The 23 §18.6 Λ-layer wrappers covering partitionFunctionΛ regularity
 at `h = 0`, freeEnergyΛ per-direction analyticity, and
 partitionFunction joint + general-h analyticity now live in
-`IsingModel.AmbientLattice.AnalyticityLambdaSection186`. The legacy
+`IsingModel.AmbientLattice.AnalyticityLambdaSection186`. The earlier
 import path is preserved by re-importing the new child.
 -/
 
@@ -251,7 +251,7 @@ The 11 Λ-layer wrappers covering §18.4-§18.6 capstones
 decomposition, freeEnergy = log 2 at β·J = 0,
 mayerPartialSum_one_at_one) and §18.5 Mayer filter-connected /
 ε^n / mayerPartialSum_analyticOnNhd now live in
-`IsingModel.AmbientLattice.AnalyticityLambdaCapstones`. The legacy
+`IsingModel.AmbientLattice.AnalyticityLambdaCapstones`. The earlier
 import path is preserved by re-importing the new child.
 -/
 

--- a/IsingModel/AmbientLattice/MagnetizationInfinite.lean
+++ b/IsingModel/AmbientLattice/MagnetizationInfinite.lean
@@ -261,7 +261,7 @@ theorem magnetizationInfinite_monotone_beta
 The 10 Λ-level h-symmetry, odd-vanish at h=0, J_zero, and tanh-power
 lower-bound wrappers now live in
 `IsingModel.AmbientLattice.MagnetizationInfiniteLambdaHSymmetry`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -270,7 +270,7 @@ The legacy import path is preserved by re-importing the new child.
 The 9 alongExhaustion / correlationInfinite h-symmetry wrappers now
 live in
 `IsingModel.AmbientLattice.MagnetizationInfiniteExhaustionHSymmetry`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -279,7 +279,7 @@ The legacy import path is preserved by re-importing the new child.
 The infinite-volume susceptibility definition `susceptibilityInfinite`
 and 4 of its properties now live in
 `IsingModel.AmbientLattice.MagnetizationInfiniteSusceptibility`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 The h-symmetry bound `abs_magnetizationInfinite_le_magnetizationInfinite_abs_h`
 remains here because it directly references `magnetizationInfinite`.
 -/
@@ -431,7 +431,7 @@ theorem magnetizationInfinite_eq_zero_of_exists_stage_not_mem
 
 The 8 h_zero / J_zero / zero_params / tanh_pow wrappers now live in
 `IsingModel.AmbientLattice.MagnetizationInfiniteHZeroJZero`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 The closely related `magnetizationInfinite_ge_tanh` stays here because
 it references `magnetizationInfinite` directly.
 -/
@@ -453,7 +453,7 @@ theorem magnetizationInfinite_ge_tanh
 
 The 9 empty / beta_zero_vanish / zero_params_vanish wrappers now live in
 `IsingModel.AmbientLattice.MagnetizationInfiniteEmptyTrivial`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -462,7 +462,7 @@ The legacy import path is preserved by re-importing the new child.
 The 7 magnetizationΛ / magnetizationAlongExhaustion trivial-slice
 wrappers now live in
 `IsingModel.AmbientLattice.MagnetizationInfiniteMagTrivial`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-- **β=0 infinite-volume magnetization vanishes**: at infinite
@@ -526,7 +526,7 @@ theorem magnetizationInfinite_zero_at_h_zero
 The 7 susceptibilityInfinite J = 0 closed form + trivial-slice +
 regularity-at-J=0 wrappers now live in
 `IsingModel.AmbientLattice.MagnetizationInfiniteSusceptibilityRegularity`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-- **`magnetizationInfinite` ContinuousOn h on Ici 0 at J = 0** (Step 266):

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergy.lean
@@ -11,7 +11,7 @@ This module contains the special-case free-energy APIs that do not depend on
 the analytic cluster-expansion stack: bounded edge density, trivial parameter
 slices, basic `h`-symmetry, and uniform exhaustion bounds.
 
-It is split from the legacy `AmbientLattice.SpecialCases` body so modules such
+It is split from the original `AmbientLattice.SpecialCases` body so modules such
 as `AmbientLatticeSum` can use these free-energy facts without importing
 `AmbientLattice.Analyticity`.
 -/
@@ -85,8 +85,8 @@ The six trivial-parameter-slice closed forms
 `freeEnergyAlongExhaustion_eq_bot_at_J_zero`,
 `freeEnergyAlongExhaustion_J_zero`) now live in
 `IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlices`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: 2 sharper high-temperature free-energy upper bounds
@@ -97,8 +97,8 @@ high-temperature upper bound wrappers
 `freeEnergyAlongExhaustion_high_temp_h_zero_upper_bound_exp_uniform`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.FreeEnergyHighTempExp`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: `h`-symmetry / `|h|`-monotonicity wrappers
@@ -106,8 +106,8 @@ from this parent module and from `Legacy.lean`.
 The three `freeEnergyAlongExhaustion_{neg_h, eq_abs_h, monotone_abs_h}`
 wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.FreeEnergyHSymmetry`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **BddAbove for `freeEnergyAlongExhaustion` under bounded edge density**:

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticity.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityOnNhd
 
 This module contains general-graph `AnalyticAt` and `AnalyticOnNhd` APIs
 for per-stage `freeEnergyAlongExhaustion` in the `β`, `J`, and `h`
-directions. It is split out of the legacy ambient special-cases module so
+directions. It is split out of the original ambient special-cases module so
 concrete free-energy analyticity wrappers can depend on a narrower child path.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlices.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyTrivialSlices.lean
@@ -61,8 +61,8 @@ theorem freeEnergyAlongExhaustion_zero_params
 The two `freeEnergyInfinite_*` trivial-slice closed-form
 wrappers (`_beta_zero`, `_zero_params`) now live in
 `IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlicesInfinite`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: 2 `_J_zero` wrappers
@@ -71,7 +71,7 @@ The two J = 0 wrappers
 (`freeEnergyAlongExhaustion_eq_bot_at_J_zero`,
 `freeEnergyAlongExhaustion_J_zero`) now live in
 `IsingModel.AmbientLattice.SpecialCases.FreeEnergyTrivialSlicesJZero`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperature.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperature.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.HighTemperatureTanh
 
 Narrow child module for the §18.5 high-temperature sandwich, convergence-radius
 `HasSum`, polymer-family sandwich, and strict free-energy correction wrappers
-along an exhaustion. The theorem names are the same as the former legacy
+along an exhaustion. The theorem names are the same as the former
 declarations, but callers can now avoid importing the monolithic special-cases
 module.
 -/
@@ -71,8 +71,8 @@ The four along-exhaustion `tanh` wrappers
 `polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureTanh`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: 4 vdPolymerFamilies_sum sandwich + 2 strict freeEnergy wrappers
@@ -81,8 +81,8 @@ The four `vdPolymerFamilies_sumAlongExhaustion_sandwich*` wrappers
 and the two `freeEnergyAlongExhaustion_lt_log_two_plus_high_temp_correction*`
 strict free-energy bounds now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureVdSandwichFE`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBounds.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBounds.lean
@@ -30,8 +30,8 @@ import IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelation
 
 Narrow child module for the §18.3-§18.4 high-temperature expansion,
 lower/upper bound, sandwich, correlation, and deviation wrappers along an
-exhaustion. The theorem names are the same as the former legacy declarations,
-but callers can now avoid importing the monolithic special-cases legacy module.
+exhaustion. The theorem names are the same as the former declarations,
+but callers can now avoid importing the monolithic special-cases original module.
 -/
 
 namespace IsingModel
@@ -53,7 +53,7 @@ complete-summary wrappers (20 theorems for
 forms, plus the `one_le_sum_pow_tanh_even_subgraph_alongExhaustion` helper)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansion`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -66,7 +66,7 @@ sandwich / complete-summary wrappers (16 theorems for
 `log_partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_*_exp`
 with ferromagnetic variants) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpSharper`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: alongExhaustion f/Z/log Z deviation / continuity wrappers
@@ -82,7 +82,7 @@ with the 4 `freeEnergyAlongExhaustion_*_continuity_*` wrappers
 (`_at_J_zero`, `_at_beta_zero`, `_bundle`, `_bundle_ferromagnetic`)
 subsequently narrowed in PR #2024 into
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationContinuity`.
-The legacy import path is preserved by re-importing both children.
+The earlier import path is preserved by re-importing both children.
 -/
 
 /-! ## Moved: alongExhaustion Z/f/log Z ratio sandwich/ratio bound wrappers
@@ -98,7 +98,7 @@ deviation_pos / pow_two_lt) wrappers now live in
 (narrowed in PR #1995). The 7 `triple_ratio_*` wrappers (sandwich +
 bound bundles, J = 0 / β = 0 / ferromagnetic variants) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsTripleRatio`
-(narrowed in PR #1994). The legacy import path is preserved by
+(narrowed in PR #1994). The earlier import path is preserved by
 re-importing all three children.
 -/
 
@@ -146,7 +146,7 @@ The 15 ambient alongExhaustion §18.3-§18.4 correlation basic /
 bundle wrappers (`correlationAlongExhaustion_high_temp_h_zero_at_*`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelationBasic`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 
@@ -158,7 +158,7 @@ decay capstone wrappers (pair correlation `tanh_pow_dist` /
 `pos_of_edge` / `ge_tanh_div_two_pow_edges`, with ferromagnetic
 variants) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDecayCapstones`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 
@@ -170,8 +170,8 @@ The two umbrella-residue correlation wrappers
 `correlationAlongExhaustion_high_temp_h_zero_at_singleton_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelation`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsCorrelationBasic.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsCorrelationBasic.lean
@@ -77,8 +77,8 @@ theorem correlationAlongExhaustion_high_temp_h_zero_at_empty_A
 The six `correlationAlongExhaustion_high_temp_h_zero_at_pair_*`
 wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelationBasicPair`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: correlation singleton + pair-singleton bundle wrappers
@@ -92,8 +92,8 @@ variants (`_at_pair_singleton_bundle`,
 `_at_pair_singleton_trivial_slices_bundle`,
 `_at_pair_singleton_bundle_ferromagnetic`) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelationBasicSingletonBundle`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean` and the umbrella `HighTemperatureBounds.lean`.
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `HighTemperatureBounds.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsCorrelationBasicPair.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsCorrelationBasicPair.lean
@@ -44,7 +44,7 @@ The two base pair wrappers
 `correlationAlongExhaustion_high_temp_h_zero_at_pair_nonneg`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelationBasicPairBase`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 
@@ -81,8 +81,8 @@ The two trivial-parameter-slice vanishing identities
 `correlationAlongExhaustion_high_temp_h_zero_at_pair_beta_zero`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelationBasicPairTrivial`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsCorrelationBasicSingleton.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsCorrelationBasicSingleton.lean
@@ -33,7 +33,7 @@ The two trivial-parameter-slice singleton vanishing wrappers
 `correlationAlongExhaustion_high_temp_h_zero_at_singleton_beta_zero`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelationBasicSingletonTrivial`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsCorrelationBasicSingletonBundle.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsCorrelationBasicSingletonBundle.lean
@@ -32,8 +32,8 @@ The four `correlationAlongExhaustion_high_temp_h_zero_at_singleton*`
 wrappers (`_J_zero`, `_beta_zero`, `_at_singleton`, `_eq_zero_le_one`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsCorrelationBasicSingleton`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex pair+singleton bundle at h=0**. -/
@@ -84,7 +84,7 @@ The two derived bundle wrappers
 now live in
 `IsingModel.AmbientLattice.SpecialCases.`
 `HighTemperatureBoundsCorrelationBasicSingletonBundleDerived`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDecayCapstones.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDecayCapstones.lean
@@ -38,7 +38,7 @@ This parent re-imports the new child below so the remaining
 ferromagnetic wrappers (`_tanh_pow_dist_ferromagnetic`,
 `_exp_rate_dist_ferromagnetic`) continue to see them, and
 downstream consumers see all symbols via the parent and
-`Legacy.lean`.
+the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex §18.7 ferromagnetic capstone**: under `0 ≤ J, 0 < β`,
@@ -79,8 +79,8 @@ The three §18.3 / §18.7 edge-pair correlation capstone wrappers
 `correlationAlongExhaustion_high_temp_h_zero_at_pair_pos_of_edge_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDecayCapstonesEdge`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDecayCapstonesDist.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDecayCapstonesDist.lean
@@ -84,8 +84,8 @@ The three alpha-rate capstones (`_exp_alpha_dist`,
 `_exp_alpha_dist_of_le_highTempExpRate`, `_exp_alpha_dist_ferro`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDecayCapstonesAlpha`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDeviation.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDeviation.lean
@@ -48,7 +48,7 @@ The 4 ambient alongExhaustion `freeEnergyAlongExhaustion_high_temp_h_zero_contin
 wrappers (`_at_J_zero`, `_at_beta_zero`, `_bundle`,
 `_bundle_ferromagnetic`) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationContinuity`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 
@@ -94,8 +94,8 @@ The three `*_deviation_*_ferromagnetic` wrappers
 `log_partitionFunctionAlongExhaustion_..._deviation_sandwich_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationFerro`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean` and the umbrella `HighTemperatureBounds.lean`.
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `HighTemperatureBounds.lean`.
 -/
 
 /-! ## Moved: strict-deviation wrappers
@@ -106,7 +106,7 @@ The 10 ambient alongExhaustion strict-deviation wrappers covering
 `_strict_deviation_bundle` (with ferromagnetic variants) now live
 in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationStrict`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDeviationContinuity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDeviationContinuity.lean
@@ -34,8 +34,8 @@ parameter slices
 `freeEnergyAlongExhaustion_high_temp_h_zero_continuity_at_beta_zero`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationContinuityTrivial`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex f continuity bundle at stage `n`**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDeviationStrict.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDeviationStrict.lean
@@ -61,7 +61,7 @@ The two Z and log Z strict-deviation wrappers
 `log_partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_deviation_pos`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationStrictZ`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 
@@ -73,8 +73,8 @@ The four ferromagnetic strict-deviation wrappers
 and the two strict-deviation bundles (`_strict_deviation_bundle`,
 `_strict_deviation_bundle_ferromagnetic`) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationStrictFerro`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean` and the umbrella `HighTemperatureBounds.lean`.
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `HighTemperatureBounds.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDeviationStrictFerro.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsDeviationStrictFerro.lean
@@ -53,8 +53,8 @@ The two `Z + log Z + f` strict-deviation bundle wrappers
 `partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_strict_deviation_bundle_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationStrictFerroBundle`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: 2 ferromagnetic Z / log Z strict-deviation wrappers
@@ -64,7 +64,7 @@ The two ferromagnetic Z / log Z strict-deviation wrappers
 `log_partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_deviation_pos_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsDeviationStrictFerroZ`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpSharper.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpSharper.lean
@@ -65,7 +65,7 @@ The 5 ambient alongExhaustion sharper-exp `_sandwich_exp` wrappers
 `freeEnergyAlongExhaustion_*_sandwich_exp`, plus ferromagnetic
 variants for Z and f) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpSharperSandwich`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 
@@ -76,8 +76,8 @@ The three `*AlongExhaustion_high_temp_*_h_zero_upper_bound_exp_ferromagnetic`
 wrappers (for `partitionFunction`, `log_partitionFunction`,
 `freeEnergy`) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpSharperFerro`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean` and the umbrella `HighTemperatureBounds.lean`.
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `HighTemperatureBounds.lean`.
 -/
 
 /-! ## Moved: complete_summary_exp wrappers
@@ -87,7 +87,7 @@ The 6 ambient alongExhaustion `complete_summary_exp` wrappers
 `log_partitionFunctionAlongExhaustion` with ferromagnetic variants)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpSharperComplete`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpSharperComplete.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpSharperComplete.lean
@@ -109,8 +109,8 @@ The three ferromagnetic `complete_summary_exp_ferromagnetic`
 wrappers (for `partitionFunction`, `log_partitionFunction`,
 `freeEnergy`) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpSharperCompleteFerro`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean` and the umbrella `HighTemperatureBounds.lean`.
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `HighTemperatureBounds.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpSharperSandwich.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpSharperSandwich.lean
@@ -87,8 +87,8 @@ The two ferromagnetic sharper-exp sandwich wrappers
 `freeEnergyAlongExhaustion_high_temp_h_zero_sandwich_exp_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpSharperSandwichFerro`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansion.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansion.lean
@@ -36,7 +36,7 @@ upper-bound, closed-form, and lower_le_upper consistency wrappers
 `freeEnergyAlongExhaustion_high_temp_h_zero_upper_bound`,
 `freeEnergyAlongExhaustion_high_temp_h_zero_lower_bound`) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansionLowerUpper`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 
@@ -47,7 +47,7 @@ The 4 ambient alongExhaustion `_high_temp_expansion_h_zero` /
 `one_le_sum_pow_tanh_even_subgraph_alongExhaustion` wrappers now
 live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansionVariants`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 
@@ -61,7 +61,7 @@ complete-summary wrappers (`*_closed_at_J_zero`,
 `*_sandwich`, `*_complete_summary`, freeEnergy
 complete_summary) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansionClosedForms`.
-The legacy import path is preserved by re-importing the new child
+The earlier import path is preserved by re-importing the new child
 via the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansionClosed.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansionClosed.lean
@@ -83,8 +83,8 @@ The two ambient alongExhaustion correlation wrappers
 `correlationAlongExhaustion_high_temp_expansion_h_zero_closed`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansionClosedCorrelation`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansionClosedForms.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansionClosedForms.lean
@@ -36,8 +36,8 @@ The five `partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_closed*`
 and `correlationAlongExhaustion_high_temp_*_h_zero_{nonneg,closed}`
 wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansionClosed`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-exhaustion Z high-temp sandwich (FV (3.45))**: under

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansionLowerUpper.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansionLowerUpper.lean
@@ -73,8 +73,8 @@ The two `lower ≤ upper` bound consistency wrappers
 `freeEnergyAlongExhaustion_high_temp_h_zero_lower_le_upper`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansionLowerUpperConsistency`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-exhaustion partition function high-temperature lower bound**:

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansionVariants.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsExpansionVariants.lean
@@ -49,7 +49,7 @@ The two general-h `partitionFunctionAlongExhaustion_high_temp_expansion*`
 wrappers (`_high_temp_expansion`, `_high_temp_expansion_subset_form`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsExpansionVariantsGeneralH`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioBounds.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioBounds.lean
@@ -36,8 +36,8 @@ The two slice-singleton wrappers
 `partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_ratio_sandwich_beta_zero`
 [β = 0 trivial slice]) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioBoundsSingletons`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex Z ratio sandwich bundle at stage `n`**. -/
@@ -106,8 +106,8 @@ The six ambient alongExhaustion `partitionFunctionAlongExhaustion`
 `β = 0` and ferromagnetic counterparts — and the two
 `ratio_bound_bundle` wrappers, general and ferromagnetic) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioBoundsBound`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean` and the umbrella `HighTemperatureBounds.lean`.
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `HighTemperatureBounds.lean`.
 -/
 
 /-! ## Moved: log Z + freeEnergy ratio wrappers
@@ -116,15 +116,15 @@ The 17 ambient alongExhaustion `log_partitionFunction` and
 `freeEnergy` ratio_sandwich / ratio_bound (+ deviation_pos /
 pow_two_lt) wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioLogFe`.
-The umbrella `HighTemperatureBounds.lean` and `Legacy.lean` re-import
-the new child so the legacy import paths and theorem names remain
+The umbrella `HighTemperatureBounds.lean` re-imports
+the new child so the import paths and theorem names remain
 unchanged.
 
 The 7 ambient alongExhaustion `triple_ratio_sandwich_bundle` and
 `triple_ratio_bound_bundle` wrappers (J = 0 / β = 0 trivial slices,
 ferromagnetic variants) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsTripleRatio`
-(narrowed in PR #1994). The legacy import path is preserved by
+(narrowed in PR #1994). The earlier import path is preserved by
 re-exporting both children from the umbrella module that aggregates
 them.
 -/

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioBoundsBound.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioBoundsBound.lean
@@ -28,8 +28,8 @@ The four `partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_ratio_boun
 non-bundle wrappers (`J = 0`, `β = 0`, plus their ferromagnetic
 counterparts) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioBoundsBoundOnly`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex Z ratio upper bound bundle at stage `n`**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioLogFe.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioLogFe.lean
@@ -88,8 +88,8 @@ ferromagnetic — and the four `ratio_bound` variants: `J = 0`,
 `β = 0`, `ratio_bound_bundle`, and
 `ratio_bound_bundle_ferromagnetic`) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioLogFeLogBound`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean`, the umbrella `HighTemperatureBounds.lean`, and
+The earlier import path is preserved by re-exporting the new child
+from the umbrellas `HighTemperatureBounds.lean` /
 this parent module (which now re-imports the new child below).
 -/
 
@@ -111,8 +111,8 @@ The six ambient alongExhaustion `freeEnergyAlongExhaustion`
 `β = 0` and ferromagnetic counterparts — and the two
 `ratio_bound_bundle` wrappers, general and ferromagnetic) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioLogFeFreeEnergyBound`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean`, the umbrella `HighTemperatureBounds.lean`, and
+The earlier import path is preserved by re-exporting the new child
+from the umbrellas `HighTemperatureBounds.lean` /
 this parent module (which now re-imports the new child below).
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioLogFeFreeEnergyBound.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioLogFeFreeEnergyBound.lean
@@ -64,8 +64,8 @@ The four `freeEnergyAlongExhaustion_high_temp_h_zero_ratio_bound*`
 non-bundle wrappers (`J = 0`, `β = 0`, plus their ferromagnetic
 counterparts) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioLogFeFreeEnergyBoundOnly`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioLogFeLogBound.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioLogFeLogBound.lean
@@ -99,8 +99,8 @@ The four
 wrappers (`J = 0`, `β = 0`, `_bundle`, `_bundle_ferromagnetic`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioLogFeLogBoundOnly`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioLogFeLogBoundOnly.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsRatioLogFeLogBoundOnly.lean
@@ -29,7 +29,7 @@ The two slice-singleton wrappers
 `log_partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_ratio_bound_beta_zero`
 [β = 0 trivial slice]) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsRatioLogFeLogBoundOnlySingletons`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsTripleRatio.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureBoundsTripleRatio.lean
@@ -120,8 +120,8 @@ wrappers
 `partitionFunctionAlongExhaustion_h_zero_triple_ratio_sandwich_bundle_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsTripleRatioFerro`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: triple_ratio_bound_bundle wrappers
@@ -129,8 +129,8 @@ from this parent module and from `Legacy.lean`.
 The three `partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_triple_ratio_bound_bundle*`
 wrappers (general, `_beta_zero`, ferromagnetic) now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureBoundsTripleRatioBoundBundle`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureCapstones.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureCapstones.lean
@@ -11,9 +11,9 @@ along an exhaustion: the two `freeEnergyAlongExhaustion =
 log 2 + cosh-correction + polymer correction` decompositions
 (general and ferromagnetic), the `freeEnergyAlongExhaustion = log 2`
 identity at `β · J = 0`, and the `mayerPartialSum_one_at_one`
-identity. Theorem names are the same as the former legacy
+identity. Theorem names are the same as the former
 declarations, but callers can now avoid importing the monolithic
-special-cases legacy module.
+special-cases original module.
 -/
 
 namespace IsingModel
@@ -34,8 +34,8 @@ closed-form wrappers
 `partitionFunctionAlongExhaustion_high_temp_expansion_h_zero_closed_evenSubgraphs`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureCapstonesPartition`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: 2 freeEnergy decomposition wrappers
@@ -45,7 +45,7 @@ The two §18.6 free-energy decomposition wrappers
 `freeEnergyAlongExhaustion_eq_polymerFreeEnergy_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureCapstonesFreeEnergy`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureTanh.lean
@@ -78,7 +78,7 @@ The two §18.5 along-ex ferromagnetic tanh wrappers
 `polymerFreeEnergyAlongExhaustion_tanh_hasSum_via_log_of_pow_lt_two_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureTanhFerro`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/HighTemperatureVdSandwichFE.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/HighTemperatureVdSandwichFE.lean
@@ -58,7 +58,7 @@ The two ferromagnetic VD polymer-family sum sandwich wrappers
 `vdPolymerFamilies_sumAlongExhaustion_sandwich_sharp_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureVdSandwichFEFerro`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 
@@ -69,8 +69,8 @@ The two strict free-energy upper bound wrappers
 `freeEnergyAlongExhaustion_lt_log_two_plus_high_temp_correction_ferromagnetic`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.HighTemperatureVdSandwichFreeEnergy`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/InfiniteVolume.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/InfiniteVolume.lean
@@ -4,7 +4,7 @@ import IsingModel.AmbientLattice.TruncatedFunctions
 # Infinite-volume special-case aliases
 
 This module contains lightweight ambient special-case APIs that depend only on
-the infinite-volume truncated-correlation layer. Keeping them outside the legacy
+the infinite-volume truncated-correlation layer. Keeping them outside the original
 special-cases body lets concrete correlation modules use these aliases without
 importing the analytic or cluster-expansion stack.
 -/

--- a/IsingModel/AmbientLattice/SpecialCases/JointAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointAnalyticity.lean
@@ -9,7 +9,7 @@ import IsingModel.AmbientLattice.SpecialCases.JointAnalyticitySusceptibility
 
 Narrow child module for general-graph `AnalyticAt` / `AnalyticOnNhd` wrappers
 in the joint `(β, J, h)` parameters. This keeps callers that only need these
-along-exhaustion forwarders out of the monolithic legacy special-cases module.
+along-exhaustion forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -50,8 +50,8 @@ joint-`(β, J, h)` analyticity wrappers
 (`magnetizationAlongExhaustion_analyticAt_joint`,
 `magnetizationAlongExhaustion_analyticOnNhd_joint`) now live in
 `IsingModel.AmbientLattice.SpecialCases.JointAnalyticityMagnetization`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: 2 susceptibilityAlongExhaustion joint analyticity wrappers
@@ -61,8 +61,8 @@ joint-`(β, J, h)` analyticity wrappers
 (`susceptibilityAlongExhaustion_analyticAt_joint_gen`,
 `susceptibilityAlongExhaustion_analyticOnNhd_joint_gen`) now live in
 `IsingModel.AmbientLattice.SpecialCases.JointAnalyticitySusceptibility`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: partitionFunction + freeEnergy joint analyticity wrappers

--- a/IsingModel/AmbientLattice/SpecialCases/JointRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointRegularity.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.JointRegularityDifferentiable
 
 This module contains general-graph joint `Continuous`, `Differentiable`,
 `ContinuousAt`, and `DifferentiableAt` APIs for along-exhaustion correlation,
-magnetization, and susceptibility. It is split out of the legacy ambient
+magnetization, and susceptibility. It is split out of the original ambient
 special-cases module so concrete joint wrappers can depend on a narrower child
 path.
 -/
@@ -67,8 +67,8 @@ theorem susceptibilityAlongExhaustion_continuous_joint_gen
 The three joint `_differentiable_joint*` wrappers (correlation,
 magnetization, susceptibility) now live in
 `IsingModel.AmbientLattice.SpecialCases.JointRegularityDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: joint ContinuousAt / DifferentiableAt along-ex wrappers
@@ -76,8 +76,8 @@ from this parent module and from `Legacy.lean`.
 The six joint `_continuousAt_joint*` / `_differentiableAt_joint*`
 wrappers for correlation, magnetization, and susceptibility now live
 in `IsingModel.AmbientLattice.SpecialCases.JointRegularityAt`. The
-legacy import path is preserved by re-exporting the new child from
-`Legacy.lean` and from each downstream consumer that previously
+earlier import path is preserved by re-exporting the new child from
+the umbrella `SpecialCases.lean` and from each downstream consumer that previously
 imported only this parent.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/JointRegularityAt.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/JointRegularityAt.lean
@@ -34,8 +34,8 @@ The three `DifferentiableAt ℝ` joint wrappers
 `susceptibilityAlongExhaustion_differentiableAt_joint_gen`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.JointRegularityAtDifferentiableAt`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: magnetization jointly ContinuousAt** (general G). -/

--- a/IsingModel/AmbientLattice/SpecialCases/MagnetizationConvergence.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MagnetizationConvergence.lean
@@ -5,9 +5,9 @@ import IsingModel.AmbientLattice.Exhaustion
 # Magnetization convergence wrappers along an exhaustion
 
 Narrow child module for finite-stage magnetization convergence wrappers along
-an exhaustion. The theorem names are the same as the former legacy
+an exhaustion. The theorem names are the same as the former
 declarations, but callers can now avoid importing the monolithic special-cases
-legacy module.
+original module.
 -/
 
 namespace IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/MagnetizationRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MagnetizationRegularity.lean
@@ -7,8 +7,8 @@ import IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularityDifferentia
 
 Narrow child module for finite-stage magnetization `Continuous` and
 `Differentiable` wrappers along an exhaustion. The theorem names are the same
-as the former legacy declarations, but callers can now avoid importing the
-monolithic special-cases legacy module.
+as the former declarations, but callers can now avoid importing the
+monolithic special-cases original module.
 -/
 
 namespace IsingModel
@@ -71,8 +71,8 @@ theorem magnetizationAlongExhaustion_continuous_beta
 The three `magnetizationAlongExhaustion_differentiable_*` wrappers
 (`_field`, `_J`, `_beta`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularityDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ### Moved: ContinuousAt / DifferentiableAt along-ex wrappers
@@ -80,8 +80,8 @@ from this parent module and from `Legacy.lean`.
 The six `magnetizationAlongExhaustion_{continuousAt,differentiableAt}_{beta,field,J}`
 pointwise wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularityAt`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MagnetizationRegularityAt.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MagnetizationRegularityAt.lean
@@ -37,8 +37,8 @@ The three `DifferentiableAt ℝ` pointwise wrappers
 `magnetizationAlongExhaustion_differentiableAt_field`,
 `magnetizationAlongExhaustion_differentiableAt_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularityAtDifferentiableAt`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: magnetization ContinuousAt h**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticity.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityTanh
 
 Narrow child module for along-exhaustion `mayerPartialSum` and
 `mayerExpansionTerm` analytic wrappers. This keeps callers that only need
-these analytic forwarders out of the monolithic legacy special-cases module.
+these analytic forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -51,8 +51,8 @@ The four `mayerPartialSumAlongExhaustion_tanh_analytic*` wrappers
 (`_analyticAt_beta`, `_analyticAt_J`, `_analyticOnNhd_beta`,
 `_analyticOnNhd_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityTanh`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: mayerExpansionTermAlongExhaustion tanh analyticity wrappers

--- a/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityExpansionTerm.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityExpansionTerm.lean
@@ -53,7 +53,7 @@ The two `mayerExpansionTermAlongExhaustion_tanh_analyticAt_*`
 wrappers (`_tanh_analyticAt_beta`, `_tanh_analyticAt_J`) now live
 in
 `IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityExpansionTermTanh`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerAnalyticityTanh.lean
@@ -48,7 +48,7 @@ The two `mayerPartialSumAlongExhaustion_tanh_analyticOnNhd_*`
 wrappers (`_tanh_analyticOnNhd_beta`, `_tanh_analyticOnNhd_J`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.MayerAnalyticityTanhOnNhd`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerBasicIdentities.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerBasicIdentities.lean
@@ -9,7 +9,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentitiesVdSum
 Narrow child module for along-exhaustion at-zero and at-one identities for
 `vdPolymerFamilies_sum`, `mayerPartialSum`, and `mayerExpansionTerm`. This
 keeps callers that only need these basic forwarders out of the monolithic
-legacy special-cases module.
+original special-cases module.
 -/
 
 namespace IsingModel
@@ -26,8 +26,8 @@ variable {V : Type*} [DecidableEq V]
 The two along-ex `vdPolymerFamilies_sumAlongExhaustion` evaluation
 identities (`_at_zero`, `_at_one`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentitiesVdSum`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: mayerPartialSum at N = 0 = 0**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCases.lean
@@ -9,7 +9,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesTrivial
 
 Narrow child module for along-exhaustion Mayer identity edge cases and
 `polymerFreeEnergy = mayerPartialSum` wrappers. This keeps callers that only
-need these forwarders out of the monolithic legacy special-cases module.
+need these forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -49,7 +49,7 @@ theorem mayer_identity_at_betaJ_zero_AlongExhaustion
 The two along-ex `mayer_identity_at_*_zero_AlongExhaustion` trivial-slice
 wrappers (`_beta_zero`, `_J_zero`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesTrivial`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 
@@ -68,8 +68,8 @@ The three
 `mayer_identity_at_*_polymer_free_energy_AlongExhaustion`
 wrappers (`_J_zero`, `_beta_zero`, `_either_zero`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPFE`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCasesPolymerFreeEnergy.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEdgeCasesPolymerFreeEnergy.lean
@@ -58,7 +58,7 @@ The two trivial-slice wrappers
 `polymerFreeEnergyAlongExhaustion_eq_mayerPartialSum_at_J_zero`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerEdgeCasesPolymerFreeEnergyTrivial`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEpsilonInfrastructure.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEpsilonInfrastructure.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonInfrastructureVdSum
 Narrow child module for the first Mayer-term sign wrappers
 (`mayerExpansionTerm` at `n = 1`, `n = 2`) and the edgeless
 `allPolymers` wrapper along an exhaustion. This keeps callers that
-only need these forwarders out of the monolithic legacy special-cases
+only need these forwarders out of the monolithic original special-cases
 module.
 -/
 
@@ -44,8 +44,8 @@ The three `vdPolymerFamilies_sumAlongExhaustion_minus_one_*` ε(t)
 infrastructure wrappers (`_at_zero`, `_continuous`,
 `_lt_one_eventually`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerEpsilonInfrastructureVdSum`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: allPolymers = ∅ on edgeless induced graphs**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/MayerEpsilonPositivity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerEpsilonPositivity.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivityVdSum
 
 Narrow child module for along-exhaustion `ε(t)` and `polymerFreeEnergy`
 positivity/zero iff wrappers. This keeps callers that only need these
-forwarders out of the monolithic legacy special-cases module.
+forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -24,8 +24,8 @@ The four `vdPolymerFamilies_sumAlongExhaustion_minus_one_*_iff`
 positivity / zero iff wrappers (general `t` and tanh-form) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivityVdSum`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: 0 < polymerFreeEnergy(tanh) ↔ 0 < tanh ∧

--- a/IsingModel/AmbientLattice/SpecialCases/MayerExpansionEdgeCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerExpansionEdgeCases.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCasesTwo
 
 Narrow child module for along-exhaustion Mayer expansion `n = 2`, no-polymer,
 edgeless, and absolute-bound wrappers. This keeps callers that only need these
-forwarders out of the monolithic legacy special-cases module.
+forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -24,8 +24,8 @@ variable {V : Type*} [DecidableEq V]
 The three `mayer*AlongExhaustion_two*` wrappers (`_two`,
 `_two_filter`, `mayerPartialSumAlongExhaustion_two`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCasesTwo`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: mayerPartialSum = 0 on no-polymer graphs**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/MayerFilterConnected.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerFilterConnected.lean
@@ -7,8 +7,8 @@ import IsingModel.AmbientLattice.SpecialCases.MayerFilterConnectedBase
 
 Narrow child module for the §18.5 Mayer filter-connected and epsilon-power
 wrappers along an exhaustion. The theorem names are the same as the former
-legacy declarations, but callers can now avoid importing the monolithic
-special-cases legacy module.
+former declarations, but callers can now avoid importing the monolithic
+special-cases original module.
 -/
 
 namespace IsingModel
@@ -40,7 +40,7 @@ theorem vdPolymerFamilies_sumAlongExhaustion_minus_one_pow
 The two `mayerExpansionTermAlongExhaustion_filter_connected_{zero,one}`
 base-case wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerFilterConnectedBase`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerRecurrenceHasSum.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerRecurrenceHasSum.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerRecurrenceHasSumLog
 Narrow child module for along-exhaustion Mayer recurrence wrappers,
 `polymerFreeEnergy` log-series `HasSum` wrappers, and the
 `vdPolymerFamilies_sum - 1` tendsto-zero wrapper. This keeps callers that only
-need these forwarders out of the monolithic legacy special-cases module.
+need these forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -49,8 +49,8 @@ The two along-ex polymer free-energy log-series `HasSum` wrappers
 `polymerFreeEnergyAlongExhaustion_hasSum_via_log_eventually`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.MayerRecurrenceHasSumLog`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: ε(t) → 0 as t → 0**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivity.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSum
 
 Narrow child module for along-exhaustion strict-monotonicity and strict
 positivity wrappers under `allPolymers` nonempty hypotheses. This keeps callers
-that only need these forwarders out of the monolithic legacy special-cases
+that only need these forwarders out of the monolithic original special-cases
 module.
 -/
 
@@ -24,8 +24,8 @@ wraps -/
 The seven `vdPolymerFamilies_sumAlongExhaustion_*_of_polymers_nonempty`
 wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSum`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: 0 < pFE under `0 < t` and polymers exist**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivityVdSum.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivityVdSum.lean
@@ -58,8 +58,8 @@ The four pointwise wrappers
 `_tanh_gt_one_of_tanh_pos_of_polymers_nonempty`,
 `_minus_one_tanh_pos_of_tanh_pos_of_polymers_nonempty`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSumPointwise`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: vdSum is `StrictMonoOn (Set.Ioi 0)`**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivityVdSumPointwise.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerStrictPositivityVdSumPointwise.lean
@@ -54,7 +54,7 @@ The two along-ex tanh-positivity wrappers
 `vdPolymerFamilies_sumAlongExhaustion_minus_one_tanh_pos_of_tanh_pos_of_polymers_nonempty`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivityVdSumPointwiseTanh`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIff.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIff.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFE
 
 Narrow child module for along-exhaustion ferromagnetic tanh iff wrappers for
 `polymerFreeEnergy` and `vdPolymerFamilies_sum`. This keeps callers that only
-need these forwarders out of the monolithic legacy special-cases module.
+need these forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -23,8 +23,8 @@ along-ex wraps -/
 The seven `polymerFreeEnergyAlongExhaustion_tanh_*_ferro` wrappers
 now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFE`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: 1 < vdSum(tanh) ↔ 0 < tanh ∧ allPolymers ≠ ∅**

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIffPFE.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIffPFE.lean
@@ -22,8 +22,8 @@ variable {V : Type*} [DecidableEq V]
 The five `polymerFreeEnergyAlongExhaustion_tanh_*_iff_*_ferro`
 wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFEIff`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: pFE(tanh) < (1+tanh)^|E| - 1** under ε(tanh) > 0

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIffPFEIff.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTanhFerromagneticIffPFEIff.lean
@@ -68,8 +68,8 @@ wrappers in the `allPolymers` form
 `polymerFreeEnergyAlongExhaustion_tanh_eq_zero_iff_ferro`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIffPFEIffAllPolymers`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCases.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentity
 Narrow child module for along-exhaustion `mayerPartialSum 0 ≤ polymerFreeEnergy`
 comparisons and Mayer identity wrappers for no-polymer, trivial, and edgeless
 cases. This keeps callers that only need these forwarders out of the
-monolithic legacy special-cases module.
+monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -62,8 +62,8 @@ mayerPartialSum_zero_AlongExhaustion_tanh_le_polymerFreeEnergy_ferromagnetic
 
 The five `mayer_identity_of_*_AlongExhaustion` wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentity`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerTrivialCasesIdentity.lean
@@ -69,8 +69,8 @@ The two along-ex edgeless Mayer identity wrappers
 `mayer_identity_of_edgeFinset_empty_tanh_AlongExhaustion`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.MayerTrivialCasesIdentityEdgeless`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdBounds.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdBounds.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric
 
 Narrow child module for along-exhaustion `vdPolymerFamilies_sum` bound
 wrappers. This keeps callers that only need these forwarders out of the
-monolithic legacy special-cases module.
+monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -58,8 +58,8 @@ The four `vdPolymerFamilies_sumAlongExhaustion_*` generic-`t`
 wrappers (`_ge_one_of_nonneg`, `_le_one_plus_pow_of_nonneg`,
 `_pos_of_nonneg`, `_eq_one_add`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGeneric`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGeneric.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdBoundsGeneric.lean
@@ -29,7 +29,7 @@ The two sandwich bound wrappers
 `vdPolymerFamilies_sumAlongExhaustion_le_one_plus_pow_of_nonneg`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdBoundsGenericSandwich`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdIff.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdIff.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdIffTanh
 
 Narrow child module for along-exhaustion iff characterizations of
 `vdPolymerFamilies_sum`. This keeps callers that only need the equivalence
-wrappers out of the monolithic legacy special-cases module.
+wrappers out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -51,7 +51,7 @@ The two `vdPolymerFamilies_sumAlongExhaustion_tanh_*_iff`
 characterization wrappers (`_tanh_gt_one_iff`, `_tanh_eq_one_iff`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdIffTanh`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularity.lean
@@ -10,7 +10,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer
 Narrow child module for along-exhaustion `mayerPartialSum`,
 `mayerExpansionTerm`, and `vdPolymerFamilies_sum` regularity and tanh
 wrappers. This keeps callers that only need these forwarders out of the
-monolithic legacy special-cases module.
+monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -58,8 +58,8 @@ The three `mayer*AlongExhaustion_differentiable*` wrappers
 (`mayerPartialSum_differentiable`, `_differentiableOn`,
 `mayerExpansionTerm_differentiable`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ### Moved: `mayerPartialSum` / `mayerExpansionTerm` tanh along-ex wraps
@@ -68,8 +68,8 @@ The eight `mayerPartialSumAlongExhaustion_tanh_*` and
 `mayerExpansionTermAlongExhaustion_tanh_*` continuity /
 differentiability wrappers (in `β` and `J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanh`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ### §18.6 vdPolymerFamilies_sum regularity in t along-ex wraps -/
@@ -81,8 +81,8 @@ The seven `vdPolymerFamilies_sumAlongExhaustion_*` wrappers
 tanh-composed `_continuous_{beta,J}` / `_differentiable_{beta,J}`
 variants) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymer`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanh.lean
@@ -49,7 +49,7 @@ The two `mayerPartialSumAlongExhaustion_tanh_differentiable_*`
 wrappers (`_tanh_differentiable_beta`, `_tanh_differentiable_J`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanhDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 
@@ -58,8 +58,8 @@ from this parent module and from the umbrella.
 The four `mayerExpansionTermAlongExhaustion_tanh_*` continuity /
 differentiability wrappers (in `β` and `J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanhExpansionTerm`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanhExpansionTerm.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityTanhExpansionTerm.lean
@@ -48,7 +48,7 @@ The two `mayerExpansionTermAlongExhaustion_tanh_differentiable_*`
 wrappers (`_tanh_differentiable_beta`, `_tanh_differentiable_J`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityTanhExpansionTermDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymer.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymer.lean
@@ -61,8 +61,8 @@ The four `vdPolymerFamilies_sumAlongExhaustion_tanh_*` wrappers
 (`_continuous_beta`, `_continuous_J`, `_differentiable_beta`,
 `_differentiable_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymerTanh`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymerTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/MayerVdRegularityVdPolymerTanh.lean
@@ -48,7 +48,7 @@ The two `vdPolymerFamilies_sumAlongExhaustion_tanh_differentiable_*`
 wrappers (`_tanh_differentiable_beta`, `_tanh_differentiable_J`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.MayerVdRegularityVdPolymerTanhDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularity.lean
@@ -10,7 +10,7 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyPointwiseRegula
 
 This module contains general-graph `ContinuousAt` and `DifferentiableAt` APIs
 for per-parameter and joint `partitionFunctionAlongExhaustion` /
-`freeEnergyAlongExhaustion` regularity. It is split out of the legacy ambient
+`freeEnergyAlongExhaustion` regularity. It is split out of the original ambient
 special-cases module so concrete partition/free-energy pointwise wrappers can
 depend on a narrower child path.
 -/
@@ -64,7 +64,7 @@ The two `partitionFunctionAlongExhaustion_*_joint` joint pointwise
 wrappers (`_continuousAt_joint`, `_differentiableAt_joint`) now live
 in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyPointwiseRegularityJoint`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularityFE.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularityFE.lean
@@ -38,8 +38,8 @@ variable {V : Type*} [DecidableEq V]
 The six `freeEnergyAlongExhaustion_{continuousAt,differentiableAt}_{beta,field,J}`
 non-joint pointwise wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyPointwiseRegularityFENonJoint`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **freeEnergyAlongExhaustion jointly ContinuousAt**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularityFENonJoint.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularityFENonJoint.lean
@@ -40,8 +40,8 @@ The three `DifferentiableAt ℝ` non-joint pointwise wrappers
 `freeEnergyAlongExhaustion_differentiableAt_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.`
 `PartitionFreeEnergyPointwiseRegularityFENonJointDifferentiableAt`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **freeEnergyAlongExhaustion ContinuousAt h**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularityHZero.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularityHZero.lean
@@ -54,8 +54,8 @@ The two `DifferentiableAt ℝ` pointwise h = 0 wrappers
 live in
 `IsingModel.AmbientLattice.SpecialCases.`
 `PartitionFreeEnergyPointwiseRegularityHZeroDifferentiableAt`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularityPartitionGeneralH.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyPointwiseRegularityPartitionGeneralH.lean
@@ -54,8 +54,8 @@ The two `DifferentiableAt ℝ` pointwise general-h wrappers
 now live in
 `IsingModel.AmbientLattice.SpecialCases.`
 `PartitionFreeEnergyPointwiseRegularityPartitionGeneralHDifferentiableAt`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyRegularity.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyRegularityDiffe
 
 This module contains general-graph `Continuous` and `Differentiable` APIs for
 per-stage `partitionFunctionAlongExhaustion` and `freeEnergyAlongExhaustion`.
-It is split out of the legacy ambient special-cases module so concrete
+It is split out of the original ambient special-cases module so concrete
 partition/free-energy wrappers can depend on a narrower child path.
 -/
 
@@ -44,8 +44,8 @@ The three `Differentiable ℝ` wrappers
 `partitionFunctionAlongExhaustion_differentiable_J_general_h`,
 `partitionFunctionAlongExhaustion_differentiable_h`) now live in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyRegularityDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: partitionFunction Continuous in `h`**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyRegularityFE.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFreeEnergyRegularityFE.lean
@@ -41,8 +41,8 @@ The four `Differentiable ℝ` wrappers
 `freeEnergyAlongExhaustion_differentiable_field`,
 `freeEnergyAlongExhaustion_differentiable_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyRegularityFEDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: freeEnergy Continuous in β** (general h). -/

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionClosedForms.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionClosedForms.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionClosedFormsPartit
 # Partition-function closed forms along an exhaustion
 
 Narrow child module for finite-stage partition-function closed forms along an
-exhaustion. The theorem names are the same as the former legacy declarations,
-but callers can now avoid importing the monolithic special-cases legacy module.
+exhaustion. The theorem names are the same as the former declarations,
+but callers can now avoid importing the monolithic special-cases original module.
 -/
 
 namespace IsingModel
@@ -22,8 +22,8 @@ variable {V : Type*} [DecidableEq V]
 The three `partitionFunctionAlongExhaustion_*` closed-form wrappers
 (`_beta_zero`, `_zero_params`, `_J_zero`) now live in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFunctionClosedFormsPartition`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## β = 0 closed form for `log_partitionFunctionAlongExhaustion` -/

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionGeneralAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionGeneralAnalyticity.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticit
 
 This module contains general-graph joint `Continuous` / `Differentiable` APIs
 and general-h `AnalyticAt` APIs for per-stage
-`partitionFunctionAlongExhaustion`. It is split out of the legacy ambient
+`partitionFunctionAlongExhaustion`. It is split out of the original ambient
 special-cases module so concrete partition-function wrappers can depend on a
 narrower child path.
 -/
@@ -46,8 +46,8 @@ The three pointwise `AnalyticAt` wrappers
 `partitionFunctionAlongExhaustion_analyticAt_J_general_h`,
 `partitionFunctionAlongExhaustion_analyticAt_h`) now live in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticityAnalyticAt`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionRegularity.lean
@@ -9,7 +9,7 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionRegularityDiffere
 This module contains general-graph `Continuous`, `Differentiable`,
 `AnalyticAt`, and `AnalyticOnNhd` APIs for per-stage
 `partitionFunctionAlongExhaustion` at zero external field. It is split out of
-the legacy ambient special-cases module so concrete partition-function
+the original ambient special-cases module so concrete partition-function
 regularity wrappers can depend on a narrower child path.
 -/
 
@@ -46,7 +46,7 @@ The two `Differentiable ℝ` wrappers
 `partitionFunctionAlongExhaustion_differentiable_J_h_zero`) now live
 in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFunctionRegularityDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionRegularityAnalytic.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionRegularityAnalytic.lean
@@ -50,7 +50,7 @@ The two `AnalyticOnNhd ℝ _ Set.univ` wrappers
 `partitionFunctionAlongExhaustion_analyticOnNhd_J_h_zero`) now live
 in
 `IsingModel.AmbientLattice.SpecialCases.PartitionFunctionRegularityAnalyticOnNhd`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionSymmetry.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PartitionFunctionSymmetry.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.Exhaustion
 
 Narrow child module for finite-stage partition-function h-symmetry and
 absolute-field wrappers along an exhaustion. The theorem names are the same as
-the former legacy declarations, but callers can now avoid importing the
-monolithic special-cases legacy module.
+the former declarations, but callers can now avoid importing the
+monolithic special-cases original module.
 -/
 
 namespace IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyAnalyticity.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyAnalyticityTanh
 
 Narrow child module for along-exhaustion `polymerFreeEnergy` direct
 `s ↦ polymerFreeEnergy (·) s` analytic wrappers. This keeps callers
-that only need these analytic forwarders out of the monolithic legacy
+that only need these analytic forwarders out of the monolithic
 special-cases module.
 -/
 
@@ -25,8 +25,8 @@ The four §18.6 `polymerFreeEnergy ∘ tanh ∘ (·)` analytic wrappers
 `polymerFreeEnergyAlongExhaustion_tanh_analyticOnNhd_J_Ici_zero`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyAnalyticityTanh`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: polymerFreeEnergy is `AnalyticAt ℝ` for `t ≥ 0`**. -/

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyBasic.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyBasic.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.Exhaustion
 
 Narrow child module for along-exhaustion `polymerFreeEnergy` at-zero, at-one,
 and nonnegative sandwich wrappers. This keeps callers that only need these
-forwarders out of the monolithic legacy special-cases module.
+forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyBounds.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyBounds.lean
@@ -10,7 +10,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyBoundsEdgeCases
 
 Narrow child module for along-exhaustion `polymerFreeEnergy` regularity,
 bounds, comparison, and edge-case wrappers. This keeps callers that only need
-these forwarders out of the monolithic legacy special-cases module.
+these forwarders out of the monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -54,8 +54,8 @@ The two §18.5 along-ex boundary-case vanishing wrappers
 `polymerFreeEnergyAlongExhaustion_eq_zero_of_edgeFinset_empty`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyBoundsEdgeCases`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: `polymerFreeEnergy` preserves order on `[0, ∞)`**

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyBoundsRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyBoundsRegularity.lean
@@ -57,7 +57,7 @@ The two `_On_Ici_zero` regularity wrappers
 `polymerFreeEnergyAlongExhaustion_differentiableOn_Ici_zero`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyBoundsRegularityOn`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyBoundsTanh.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyBoundsTanh.lean
@@ -45,7 +45,7 @@ The two `polymerFreeEnergyAlongExhaustion_*_log_two_*` upper bound
 wrappers (`_le_card_log_two_of_le_one`, `_tanh_le_card_log_two`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyBoundsTanhLogTwo`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyEpsilonSharpening.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyEpsilonSharpening.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyEpsilonSharpening
 
 Narrow child module for along-exhaustion `ε(t)` (`vdPolymerFamilies_sum`
 minus one) nonnegativity and zero-power identities. This keeps callers
-that only need these forwarders out of the monolithic legacy
+that only need these forwarders out of the monolithic
 special-cases module.
 -/
 
@@ -51,8 +51,8 @@ The four §18.5 `polymerFreeEnergy_*_iff_eps_*` and
 `polymerFreeEnergyAlongExhaustion_lt_pow_sub_one_of_eps_pos`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyEpsilonSharpeningPFE`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyHighTemperatureBounds.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyHighTemperatureBounds.lean
@@ -7,8 +7,8 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyHighTemperatureBo
 
 Narrow child module for the §18.5 `vdPolymerFamilies_sum` sandwich,
 `MonotoneOn`, and `ε(t)` bound wrappers along an exhaustion. The
-theorem names are the same as the former legacy declarations, but
-callers can now avoid importing the monolithic special-cases legacy
+theorem names are the same as the former declarations, but
+callers can now avoid importing the monolithic special-cases
 module.
 -/
 
@@ -62,8 +62,8 @@ The three §18.5 `polymerFreeEnergy_tanh_*` wrappers
 `polymerFreeEnergyAlongExhaustion_tanh_lt_log_two_of_pow_lt_two`)
 now live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyHighTemperatureBoundsTanh`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyTanhBounds.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyTanhBounds.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyTanhBoundsFerro
 Narrow child module for along-exhaustion `polymerFreeEnergy` general
 tanh bound, the `log(1 + eps)` decomposition, and the `HasDerivAt`
 wrapper. This keeps callers that only need these forwarders out of the
-monolithic legacy special-cases module.
+monolithic original special-cases module.
 -/
 
 namespace IsingModel
@@ -39,8 +39,8 @@ The three §18.5 ferromagnetic bound wrappers
 `polymerFreeEnergyAlongExhaustion_tanh_le_card_log_two_ferro`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyTanhBoundsFerro`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: polymerFreeEnergy = log(1 + ε(t))** decomposition. -/

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyTanhSharpening.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyTanhSharpening.lean
@@ -9,7 +9,7 @@ an exhaustion
 
 Narrow child module for along-exhaustion polymer free-energy
 `tanh sharpening + β/J strict-mono` wrappers. This keeps callers that
-only need these forwarders out of the monolithic legacy special-cases
+only need these forwarders out of the monolithic original special-cases
 module.
 -/
 
@@ -28,8 +28,8 @@ along-ex wraps -/
 The five `polymerFreeEnergyAlongExhaustion_tanh_*` iff /
 `_of_eps_pos` wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyTanhSharpeningIff`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: pFE(tanh(β₁·J)) < pFE(tanh(β₂·J))** under `J > 0`,
@@ -69,7 +69,7 @@ polymerFreeEnergyAlongExhaustion_tanh_lt_of_lt_in_J_of_polymers_nonempty
 The two along-ex `polymerFreeEnergyAlongExhaustion_tanh_strictMonoOn_*`
 wrappers (`_strictMonoOn_beta`, `_strictMonoOn_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyTanhSharpeningStrictMono`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyTanhSharpeningIff.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/PolymerFreeEnergyTanhSharpeningIff.lean
@@ -66,8 +66,8 @@ The two along-ex `polymerFreeEnergyAlongExhaustion_tanh_*_of_eps_pos`
 wrappers (`_lt_eps_of_eps_pos`, `_lt_pow_sub_one_of_eps_pos`) now
 live in
 `IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyTanhSharpeningIffEpsPos`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 end Ambient

--- a/IsingModel/AmbientLattice/SpecialCases/SusceptibilityConvergence.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/SusceptibilityConvergence.lean
@@ -6,9 +6,9 @@ import IsingModel.AmbientLattice.MagnetizationAlongExhaustion
 # Susceptibility convergence wrappers along an exhaustion
 
 Narrow child module for finite-stage susceptibility convergence wrappers along
-an exhaustion. The theorem names are the same as the former legacy
+an exhaustion. The theorem names are the same as the former
 declarations, but callers can now avoid importing the monolithic special-cases
-legacy module.
+original module.
 -/
 
 namespace IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/SusceptibilityPointwiseRegularity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/SusceptibilityPointwiseRegularity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityD
 
 This module contains general-graph `Continuous`, `Differentiable`,
 `ContinuousAt`, and `DifferentiableAt` APIs for per-parameter
-`susceptibilityAlongExhaustion` regularity. It is split out of the legacy
+`susceptibilityAlongExhaustion` regularity. It is split out of the original
 ambient special-cases module so concrete susceptibility pointwise wrappers can
 depend on a narrower child path.
 -/
@@ -68,8 +68,8 @@ theorem susceptibilityAlongExhaustion_continuous_J_gen
 The three `susceptibilityAlongExhaustion_differentiable_*_gen`
 wrappers (`_beta`, `_field`, `_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityDifferentiable`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-! ## Moved: ContinuousAt / DifferentiableAt along-ex susceptibility wrappers
@@ -77,8 +77,8 @@ from this parent module and from `Legacy.lean`.
 The six `susceptibilityAlongExhaustion_{continuousAt,differentiableAt}_{beta,field,J}_gen`
 pointwise wrappers now live in
 `IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityAt`.
-The legacy import path is preserved by re-exporting the new child
-from `Legacy.lean` and from each downstream consumer that previously
+The earlier import path is preserved by re-exporting the new child
+from the umbrella `SpecialCases.lean` and from each downstream consumer that previously
 imported only this parent.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/SusceptibilityPointwiseRegularityAt.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/SusceptibilityPointwiseRegularityAt.lean
@@ -35,8 +35,8 @@ The three `DifferentiableAt ℝ` pointwise wrappers
 `susceptibilityAlongExhaustion_differentiableAt_J_gen`) now live in
 `IsingModel.AmbientLattice.SpecialCases.`
 `SusceptibilityPointwiseRegularityAtDifferentiableAt`.
-The legacy import path is preserved by re-exporting the new child
-from this parent module and from `Legacy.lean`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
 -/
 
 /-- **Along-ex: susceptibility ContinuousAt h** (general G). -/

--- a/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticity.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityTanh
 
 Narrow child module for along-exhaustion `vdPolymerFamilies_sum`,
 `log_vdPolymerFamilies_sum`, and epsilon analyticity wrappers. This keeps
-callers that only need these analytic forwarders out of the monolithic legacy
+callers that only need these analytic forwarders out of the monolithic
 special-cases module.
 -/
 
@@ -36,7 +36,7 @@ The two along-ex tanh-composition analyticity wrappers
 (`vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_beta`,
 `vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityTanh`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityLog.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/VdPolymerFamiliesAnalyticityLog.lean
@@ -54,7 +54,7 @@ theorem log_vdPolymerFamilies_sumAlongExhaustion_analyticOnNhd_Ici_zero
 The two `log_vdPolymerFamilies_sumAlongExhaustion_tanh_analyticAt_*`
 wrappers (`_tanh_analyticAt_beta`, `_tanh_analyticAt_J`) now live in
 `IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticityLogTanh`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from this parent module and from the umbrella.
 -/
 

--- a/IsingModel/AmbientLatticeSum.lean
+++ b/IsingModel/AmbientLatticeSum.lean
@@ -200,7 +200,7 @@ variable {V : Type*} [DecidableEq V]
 
 The 13 basic freeEnergyΛ / freeEnergyAlongExhaustion wrappers now live in
 `IsingModel.AmbientLatticeSumFreeEnergy`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -210,7 +210,7 @@ The legacy import path is preserved by re-importing the new child.
 The 12 partitionFunction / log_partitionFunction ferromagnetic lower-bound
 wrappers now live in
 `IsingModel.AmbientLatticeSumGeFerromagnetic`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -774,7 +774,7 @@ theorem freeEnergyAlongExhaustion_tendsto_of_disjointTowerHypotheses
 The 14 log_partitionFunctionΛ / log_partitionFunctionAlongExhaustion
 trivial-slice + monotonicity wrappers now live in
 `IsingModel.AmbientLatticeSumLogZ`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-- **Closed form for `log (partitionFunctionΛ G Λ ⟨0, 0, β⟩)`**:
@@ -1497,7 +1497,7 @@ theorem freeEnergyInfinite_monotone_ambient_subgraph
 
 The 6 freeEnergyInfinite h-symmetry + monotonicity wrappers now live in
 `IsingModel.AmbientLatticeSumFInfHSymMono`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-- **`log Z` tends to `∞` along any exhaustion of an infinite ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Base.lean
@@ -45,7 +45,7 @@ The 2 `@[simp]` ℤ^d `freeEnergyAlongExhaustion_latticeGraph_apply` and
 `partitionFunctionAlongExhaustion_latticeGraph_apply` wrappers now live
 alongside the Λ-layer apply unfoldings in
 `IsingModel.Concrete.LatticeGraphCorrelation.BaseApply`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -67,7 +67,7 @@ The 4 ℤ^d wrappers
 `_le_correlationInfinite_of_other`, `_le_correlationInfinite`,
 and `_nonneg` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongExBounds`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -87,7 +87,7 @@ and
 `correlationAlongExhaustion_latticeGraph_{beta_zero_vanish,zero_params_vanish}`
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.BaseVanish`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -97,7 +97,7 @@ The 3 ℤ^d `partitionFunctionΛ_latticeGraph_apply`,
 `correlationΛ_latticeGraph_apply`, and `freeEnergyΛ_latticeGraph_apply`
 wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.BaseApply`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -108,7 +108,7 @@ The 4 ℤ^d
 and `spontaneousCorrelation_latticeGraph_monotone_ambient_subgraph`
 wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.BaseMonotoneAmbientSubgraph`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -120,7 +120,7 @@ The 9 ℤ^d `spontaneousCorrelation_latticeGraph_*` wrappers
 plus the `spontaneousMagnetization_latticeGraph_monotone_ambient_subgraph`
 companion now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.BaseSpontaneousCorrelation`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: magnetization sq_le_one + correlation J=0 / ge_tanh wrappers
@@ -131,7 +131,7 @@ The 8 ℤ^d wrappers
 `correlation{Λ,Infinite}_latticeGraph_ge_tanh_pow_card`, and
 `magnetization{Λ,Infinite}_latticeGraph_ge_tanh` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.BaseBoundsTanh`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -143,7 +143,7 @@ The 7 ℤ^d wrappers
 `correlationAlongExhaustion_latticeGraph_{empty,of_subset,of_not_subset,cubicExhaustion_monotone}`
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.BaseCorrelationAlongEx`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Complex.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Complex.lean
@@ -50,7 +50,7 @@ The 12 concrete per-direction `analyticAt` / `analyticOn` wrappers
 for `partitionFunction*` / `freeEnergy*` in `h`, `J`, `β` (plus joint
 analyticity) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexAnalyticityBasic`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -61,7 +61,7 @@ The 22 concrete real-complex compatibility, Lee-Yang-domain
 non-vanishing, and related restriction wrappers on `latticeGraph d`
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexRealCompat`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -79,7 +79,7 @@ The 15 concrete continuity, `AnalyticOnNhd`/`AnalyticOn`, and
 norm-bound wrappers for `partitionFunctionComplex` / `freeEnergyComplex`
 on `latticeGraph d` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexContinuityNorm`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -96,7 +96,7 @@ the finite-volume GJ §4.6 Thm 4.6.2 branch-form ingredients at ℤ^d. -/
 The 11 concrete log Z / freeEnergyComplex local-branch construction
 wrappers on `latticeGraph d` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranches`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -112,7 +112,7 @@ ball restatements from `IsingModel/ComplexAnalyticity.lean`. -/
 The 15 concrete slitPlane-locus continuity / analyticOn / differentiableOn
 wrappers and log-branch-on-ball wrappers on `latticeGraph d` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexSlitPlane`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: leeYang inclusions + real-axis restriction wrappers
@@ -120,7 +120,7 @@ The legacy import path is preserved by re-importing the new child.
 The 16 concrete leeYangSubdomain ⊆ slitPlane locus inclusions and
 real-axis restriction identities now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexRestrictions`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: analyticBranch + entire wrappers
@@ -132,7 +132,7 @@ The 12 concrete `leeYangDomain_subset_branch_locus`,
 `continuousAt/differentiableAt_freeEnergyComplex_at_real_joint`, and
 `partitionFunctionComplex_entire_*` wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexBranchEntire`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -145,7 +145,7 @@ The final 10 concrete `isingEdgePoly` evaluations,
 `norm_partitionFunctionComplex_eq_partitionFunction_at_real` wrappers
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.ComplexIsingPoly`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/CorrelationDecay.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/CorrelationDecay.lean
@@ -6,8 +6,8 @@ import IsingModel.Lattice
 # Lightweight concrete lattice correlation-decay wrappers
 
 This module exposes concrete `latticeGraph d` cluster-decay and
-high-temperature correlation-decay wrappers without importing the legacy
-monolithic `LatticeGraphCorrelation.Legacy` implementation. It keeps
+high-temperature correlation-decay wrappers without importing the original
+monolithic special-cases module. It keeps
 incremental checks for thin correlation-decay API additions away from the
 heavy ambient analyticity and cluster-expansion import chain.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/CorrelationExhaustionLimits.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/CorrelationExhaustionLimits.lean
@@ -7,8 +7,8 @@ import IsingModel.AmbientLattice.MagnetizationAlongExhaustion
 
 Narrow child module for concrete `latticeGraph` along-exhaustion correlation
 monotonicity, boundedness, eventuality, and infinite-volume limit wrappers. The
-theorem names are the same as the former legacy declarations, but callers can
-now avoid importing the monolithic concrete legacy module.
+theorem names are the same as the former declarations, but callers can
+now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/CorrelationSymmetry.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/CorrelationSymmetry.lean
@@ -9,8 +9,8 @@ import IsingModel.AmbientLattice.MagnetizationInfinite
 Narrow child module for concrete `latticeGraph` correlation, magnetization, and
 susceptibility h-symmetry / absolute-field wrappers, including finite-volume,
 along-exhaustion, and infinite-volume forms. The theorem names are the same as
-the former legacy declarations, but callers can now avoid importing the
-monolithic concrete legacy module.
+the former declarations, but callers can now avoid importing the
+monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/CubicPseudoMassNamedRateCubicCorrMem.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/CubicPseudoMassNamedRateCubicCorrMem.lean
@@ -139,7 +139,7 @@ cubic-correlation comparisons (`*_of_cubic_pseudoMassG_le_corr`,
 `cubicNamedRate_decay_mem_Ioc_of_pos_le_high_temp_rate`,
 `cubicNamedRate_decay_mem_Ioc_of_corr_mem_le_high_temp_rate`) now live
 in `IsingModel.Concrete.LatticeGraphCorrelation.CubicPseudoMassNamedRateCorr`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/EnergyClosedForms.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/EnergyClosedForms.lean
@@ -8,8 +8,8 @@ import IsingModel.FreeEnergy
 Narrow child module for concrete `latticeGraph` finite-volume Hamiltonian
 closed-form wrappers, direct finite-volume energy / partition / free-energy
 bounds, and base spin-product helper wrappers. The theorem names are the same
-as the former legacy declarations, but callers can now avoid importing the
-monolithic concrete legacy module.
+as the former declarations, but callers can now avoid importing the
+monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumeBasics.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumeBasics.lean
@@ -8,8 +8,8 @@ import IsingModel.FreeEnergy
 
 Narrow child module for concrete `latticeGraph` finite-volume graph, spin
 algebra, bottom-graph, and Hamiltonian symmetry wrappers. The theorem names are
-the same as the former legacy declarations, but callers can now avoid importing
-the monolithic concrete legacy module.
+the same as the former declarations, but callers can now avoid importing
+the monolithic concrete module.
 -/
 
 open scoped symmDiff

--- a/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumeCorrelationInequalities.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumeCorrelationInequalities.lean
@@ -7,8 +7,8 @@ import IsingModel.Inequalities.GHS
 
 Narrow child module for concrete `latticeGraph` finite-volume correlation and
 truncated-correlation inequality, symmetry, and trivial-slice wrappers. The
-theorem names are the same as the former legacy declarations, but callers can
-now avoid importing the monolithic concrete legacy module.
+theorem names are the same as the former declarations, but callers can
+now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumeCorrelationMonotonicity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumeCorrelationMonotonicity.lean
@@ -7,8 +7,8 @@ import IsingModel.InfiniteVolume
 
 Narrow child module for direct concrete `latticeGraph` finite-volume HNC,
 Gibbs-expectation, and correlation monotonicity/convergence wrappers. The
-theorem names are the same as the former legacy declarations, but callers can
-now avoid importing the monolithic concrete legacy module.
+theorem names are the same as the former declarations, but callers can
+now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumeEnergyBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumeEnergyBounds.lean
@@ -7,8 +7,8 @@ import IsingModel.FreeEnergy
 
 Narrow child module for direct concrete `latticeGraph` finite-volume
 Boltzmann-weight, Hamiltonian, partition-function, and free-energy bound
-wrappers. The theorem names are the same as the former legacy declarations, but
-callers can now avoid importing the monolithic concrete legacy module.
+wrappers. The theorem names are the same as the former declarations, but
+callers can now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumePartition.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumePartition.lean
@@ -7,8 +7,8 @@ import IsingModel.FreeEnergy
 
 Narrow child module for direct concrete `latticeGraph` finite-volume
 `partitionFunction` monotonicity, trivial-slice, and h-symmetry wrappers. The
-theorem names are the same as the former legacy declarations, but callers can
-now avoid importing the monolithic concrete legacy module.
+theorem names are the same as the former declarations, but callers can
+now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumePartitionBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/FiniteVolumePartitionBounds.lean
@@ -7,8 +7,8 @@ import IsingModel.FreeEnergy
 
 Narrow child module for direct concrete `latticeGraph` finite-volume
 `partitionFunction` absolute-field, positivity, and ferromagnetic lower-bound
-wrappers. The theorem names are the same as the former legacy declarations, but
-callers can now avoid importing the monolithic concrete legacy module.
+wrappers. The theorem names are the same as the former declarations, but
+callers can now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/FreeEnergyAnalyticity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/FreeEnergyAnalyticity.lean
@@ -6,9 +6,9 @@ import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity
 
 This module contains `latticeGraph` wrappers for per-direction free-energy
 `AnalyticAt` and `AnalyticOnNhd` APIs at the finite-volume and
-along-exhaustion layers. It is split out of the legacy concrete correlation
+along-exhaustion layers. It is split out of the original concrete correlation
 module so downstream users can import the free-energy analyticity surface
-without pulling the whole legacy module.
+without pulling the whole original module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/FreeEnergySpecialCases.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/FreeEnergySpecialCases.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
 
 Narrow child module for concrete `latticeGraph` free-energy closed forms,
 monotonicity wrappers, h-symmetry, and bottom-graph comparison wrappers. The
-theorem names are the same as the former legacy declarations, but callers can
-now avoid importing the monolithic concrete legacy module.
+theorem names are the same as the former declarations, but callers can
+now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel
@@ -72,7 +72,7 @@ The 16 ℤ^d finite-volume `freeEnergy_*_latticeGraph` wrappers
 `ge_log_two_of_ferromagnetic`, `nonneg_of_ferromagnetic`, `bot`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.FreeEnergySpecialCasesFiniteVol`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -83,7 +83,7 @@ The 12 ℤ^d `freeEnergyΛ_latticeGraph_*` wrappers
 `zero_params`, `neg_h`, `eq_abs_h`, `monotone_abs_h`, `monotone_J`,
 `monotone_h`, `monotone_beta`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.FreeEnergySpecialCasesLambda`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d `freeEnergyAlongExhaustion` special-case wrappers
@@ -94,7 +94,7 @@ The 12 ℤ^d `freeEnergyAlongExhaustion_latticeGraph_*` wrappers
 `monotone_abs_h`, `beta_zero`, `zero_params`, `J_zero`, plus
 `cubicExhaustion_{beta_zero,zero_params,J_zero}`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.FreeEnergySpecialCasesAlongEx`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 end Ambient
 end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperature.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperature.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.HighTemperature
 Narrow child module for the §18.5 high-temperature sandwich,
 convergence-radius `HasSum`, polymer-family sandwich, and strict free-energy
 correction wrappers on `latticeGraph d`. The theorem names are the same as the
-former legacy declarations, but callers can now import this child module
+former declarations, but callers can now import this child module
 directly.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBounds.lean
@@ -40,7 +40,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsFreeEner
 
 Narrow child module for the §18.3-§18.4 high-temperature expansion,
 lower/upper bound, sandwich, correlation, and deviation wrappers on
-`latticeGraph d`. The theorem names are the same as the former legacy
+`latticeGraph d`. The theorem names are the same as the former
 declarations, but callers can now import this child module directly.
 -/
 
@@ -62,7 +62,7 @@ Sandwich and downstream wrappers continue to live in this module
 in PR #1935; deviation / continuity wrappers were further moved to
 `HighTemperatureBoundsDeviation` in PR #1936; ratio_sandwich / ratio_bound
 wrappers were further moved to `HighTemperatureBoundsRatioBounds` in
-PR #1937). The legacy import path is preserved by re-importing the new
+PR #1937). The earlier import path is preserved by re-importing the new
 child.
 -/
 
@@ -123,7 +123,7 @@ wrappers at `h = 0` (pair nonneg, pair `≤ 1`, singleton / pair trivial-slice
 vanishings at `J = 0` and `β = 0`, pair sandwich, singleton / pair
 ferromagnetic, singleton `= 0 ∧ ≤ 1`, pair+singleton bundle) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsCorrelationBasic`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -134,7 +134,7 @@ The 3 ℤ^d
 bundle wrappers (`_bundle_ferromagnetic`, `_complete_summary`,
 `_trivial_slices_bundle`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsPairSingletonBundle`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: §18.7 high-temperature exponential decay capstones
@@ -151,7 +151,7 @@ them; some named-rate / monotone-rate ferromagnetic variants of
 `Concrete/LatticeGraphCorrelation/CorrelationDecay.lean` and are
 intentionally not moved) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsDecayCapstones`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -166,7 +166,7 @@ The 8 ℤ^d Λ-level correlation pair/singleton wrappers
 `_at_pair_pos_of_latticeAdj`, `_at_singleton`, `_odd_card_eq_zero`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsCorrelationPair`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d HT Λ-layer complete_summary wrappers
@@ -176,7 +176,7 @@ The 2 ℤ^d Λ-layer HT complete_summary wrappers
 `freeEnergyΛ_latticeGraph_high_temp_h_zero_complete_summary`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsLambdaCompleteSummary`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -189,7 +189,7 @@ wrappers on `latticeGraph d` at `h = 0` (17 theorems for
 `log_partitionFunctionΛ_latticeGraph_high_temp_expansion_h_zero_*_exp` families,
 with ferromagnetic variants) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsExpSharper`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -202,7 +202,7 @@ for `freeEnergyΛ_latticeGraph`, `partitionFunctionΛ_latticeGraph`, and
 `log_partitionFunctionΛ_latticeGraph`, with ferromagnetic variants) now
 live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsDeviation`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -219,7 +219,7 @@ The 7 `triple_ratio_*` wrappers now live in
 (narrowed in PR #1998), and the 12 `log_partitionFunctionΛ_latticeGraph`
 / `freeEnergyΛ_latticeGraph` ratio wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsRatioLogFe`
-(narrowed in PR #1999). The legacy import path is preserved by
+(narrowed in PR #1999). The earlier import path is preserved by
 re-importing all three children.
 -/
 
@@ -238,7 +238,7 @@ numerator filter helper) now live in
 The two `_of_latticeAdj` along-exhaustion variants were narrowed in
 PR #2074 into
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExCompleteSummary`
-(see the next Moved block). The legacy import path is preserved by
+(see the next Moved block). The earlier import path is preserved by
 re-importing the new child.
 -/
 
@@ -262,7 +262,7 @@ The 4 ℤ^d along-exhaustion HT wrappers
 `partitionFunctionAlongExhaustion_latticeGraph_high_temp_expansion_h_zero_closed_at_beta_zero`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExSubset`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d HT AlongExhaustion complete_summary wrappers
@@ -272,7 +272,7 @@ The 2 ℤ^d along-exhaustion complete_summary wrappers
 `freeEnergyAlongExhaustion_latticeGraph_high_temp_h_zero_complete_summary`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExCompleteSummary`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -287,7 +287,7 @@ sandwich / complete-summary wrappers on `latticeGraph d` at `h = 0`
 `log_partitionFunctionAlongExhaustion_latticeGraph_high_temp_expansion_h_zero_*_exp`
 with ferromagnetic variants) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExhaustionExpSharper`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -306,7 +306,7 @@ variants) live across two narrow children. The four
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExDeviationContinuity`.
 The remaining wrappers still live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExhaustionDeviation`.
-The legacy import path is preserved by re-importing both children.
+The earlier import path is preserved by re-importing both children.
 -/
 
 
@@ -331,7 +331,7 @@ bound bundles, J = 0 / β = 0 / ferromagnetic variants) now live in
 (narrowed in PR #1996); and the 14 `log_partitionFunction` /
 `freeEnergy` ratio wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExhaustionRatioLogFe`
-(narrowed in PR #1997). The legacy import path is preserved by
+(narrowed in PR #1997). The earlier import path is preserved by
 re-importing all five children.
 -/
 
@@ -344,7 +344,7 @@ The 4 ℤ^d along-exhaustion HT wrappers
 `freeEnergyAlongExhaustion_latticeGraph_high_temp_h_zero_lower_bound`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExClosedLower`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -359,7 +359,7 @@ on `cubicExhaustion d` (with the BED constant `c = d`) (10 theorems:
 `continuity_at_J_zero`, `continuity_at_beta_zero`, `continuity_bundle`,
 `deviation_sandwich_exp`, `ratio_bound_bundle`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsFreeEnergyInfinite`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsAlongExhaustionBasic.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsAlongExhaustionBasic.lean
@@ -108,7 +108,7 @@ The 8 ℤ^d along-exhaustion correlation bound wrappers
 `_at_pair_le_one`, `_at_pair_sandwich`, `_at_pair_singleton_bundle`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExBasicCorrelation`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: along-ex pair+singleton bundle wrappers
@@ -157,7 +157,7 @@ wrappers
 `_at_pair_beta_zero`, `_at_singleton_J_zero`, `_at_singleton_beta_zero`,
 `_at_singleton`, `_odd_card_eq_zero`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExBasicTrivial`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsAlongExhaustionExpSharper.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsAlongExhaustionExpSharper.lean
@@ -85,7 +85,7 @@ theorem log_partitionFunctionAlongExhaustion_latticeGraph_high_temp_expansion_h_
 The three ferromagnetic alongExhaustion sharper-exp HT upper-bound
 wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExhaustionExpSharperFerro`.
-The legacy import path is preserved by re-importing the new child. -/
+The earlier import path is preserved by re-importing the new child. -/
 
 
 /-! ## Moved: ℤ^d HT AlongExhaustion sandwich_exp wrappers
@@ -96,7 +96,7 @@ The 4 ℤ^d along-exhaustion sandwich_exp HT wrappers
 `freeEnergyAlongExhaustion_latticeGraph_high_temp_h_zero_sandwich_exp`,
 `_ferromagnetic`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExExpSharperSandwich`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d HT AlongExhaustion complete_summary_exp wrappers
@@ -106,7 +106,7 @@ The 6 ℤ^d along-exhaustion `*_complete_summary_exp` HT wrappers
 `log_partitionFunctionAlongExhaustion_*`; plus 3 `_ferromagnetic`
 variants) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExExpSharperCompleteSummary`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsAlongExhaustionRatioBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsAlongExhaustionRatioBounds.lean
@@ -60,8 +60,8 @@ The 14 ℤ^d alongExhaustion `log_partitionFunction` and `freeEnergy`
 ratio_sandwich / ratio_bound (+ deviation_pos / pow_two_lt) wrappers
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExhaustionRatioLogFe`.
-The umbrella `HighTemperatureBounds.lean` and `Legacy.lean` re-import
-the new child so the legacy import paths and theorem names remain
+The umbrella `HighTemperatureBounds.lean` re-imports
+the new child so the import paths and theorem names remain
 unchanged.
 -/
 
@@ -71,7 +71,7 @@ The 7 ℤ^d alongExhaustion `triple_ratio_sandwich_bundle` and
 `triple_ratio_bound_bundle` wrappers (J = 0 / β = 0 trivial slices,
 ferromagnetic variants) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsAlongExhaustionTripleRatio`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from the umbrella module that aggregates both.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsDeviation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsDeviation.lean
@@ -27,7 +27,7 @@ The 4 ℤ^d Λ-layer `freeEnergyΛ_latticeGraph_high_temp_h_zero_*`
 wrappers (`deviation_bound_exp`, `deviation_bound_exp_ferromagnetic`,
 `continuity_bundle`, `continuity_bundle_ferromagnetic`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsDeviationContinuity`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-- **ℤ^d Λ f deviation sandwich**. -/
@@ -105,7 +105,7 @@ The 8 ℤ^d Λ-layer strict-deviation HT wrappers
 `partitionFunctionΛ_latticeGraph_high_temp_expansion_h_zero_strict_deviation_bundle`,
 `_ferromagnetic`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsDeviationStrict`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsExpSharper.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsExpSharper.lean
@@ -85,7 +85,7 @@ The three ferromagnetic Λ-layer sharper-exp HT upper-bound wrappers
 `freeEnergyΛ_latticeGraph_high_temp_h_zero_upper_bound_exp_ferromagnetic`
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsExpSharperFerro`.
-The legacy import path is preserved by re-importing the new child. -/
+The earlier import path is preserved by re-importing the new child. -/
 
 
 /-! ## Moved: ℤ^d HT Λ-layer sandwich_exp wrappers
@@ -96,7 +96,7 @@ The 4 ℤ^d Λ-layer sandwich_exp HT wrappers
 `freeEnergyΛ_latticeGraph_high_temp_h_zero_sandwich_exp`,
 `_ferromagnetic`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsExpSharperSandwich`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d HT Λ-layer complete_summary_exp wrappers
@@ -105,7 +105,7 @@ The 6 ℤ^d Λ-layer `*_complete_summary_exp` HT wrappers (3 base:
 `partitionFunctionΛ_*`, `freeEnergyΛ_*`, `log_partitionFunctionΛ_*`;
 plus 3 `_ferromagnetic` variants) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsExpSharperCompleteSummary`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsExpansion.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsExpansion.lean
@@ -105,7 +105,7 @@ The 3 ℤ^d
 and `log_partitionFunctionAlongExhaustion_latticeGraph_high_temp_expansion_h_zero_closed`
 closed-form wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsExpansionCorrelationLogZ`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -119,7 +119,7 @@ The 5 ℤ^d HT partition-function / free-energy bound wrappers
 `partitionFunctionΛ_latticeGraph_high_temp_expansion_h_zero_lower_bound`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsExpansionPartitionBounds`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -134,7 +134,7 @@ high-temperature wrappers
 `freeEnergyAlongExhaustion_high_temp_h_zero_upper_bound`,
 `freeEnergyΛ_high_temp_h_zero_lower_bound`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsExpansionFreeEnergy`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsFreeEnergyInfinite.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsFreeEnergyInfinite.lean
@@ -132,7 +132,7 @@ The 2 ℤ^d
 `freeEnergyInfinite_latticeGraph_cubicExhaustion_high_temp_h_zero_deviation_sandwich_exp`
 and `_ratio_bound_bundle` wrappers now live in
 `...HighTemperatureBoundsFreeEnergyInfiniteDeviationAndRatio`.
-The legacy import path is preserved by re-importing the new child. -/
+The earlier import path is preserved by re-importing the new child. -/
 
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsRatioBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureBoundsRatioBounds.lean
@@ -136,8 +136,8 @@ now live in `HighTemperatureBoundsRatioBoundsBound.lean`. -/
 The 12 ℤ^d Λ-direct `log_partitionFunction` and `freeEnergy`
 ratio_sandwich / ratio_bound wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsRatioLogFe`.
-The umbrella `HighTemperatureBounds.lean` and `Legacy.lean` re-import
-the new child so the legacy import paths and theorem names remain
+The umbrella `HighTemperatureBounds.lean` re-imports
+the new child so the import paths and theorem names remain
 unchanged.
 -/
 
@@ -147,7 +147,7 @@ The 7 ℤ^d Λ-direct `triple_ratio_sandwich_bundle` and
 `triple_ratio_bound_bundle` wrappers (J = 0 / β = 0 trivial slices,
 ferromagnetic variants) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.HighTemperatureBoundsTripleRatio`.
-The legacy import path is preserved by re-exporting the new child
+The earlier import path is preserved by re-exporting the new child
 from the umbrella module that aggregates both.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureCapstones.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/HighTemperatureCapstones.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.SpecialCases.HighTemperatureCapstones
 
 Narrow child module for the §18.4-§18.6 high-temperature
 partition-function/free-energy capstone wrappers on the concrete lattice
-graph. The theorem names are the same as the former legacy declarations, but
-callers can now avoid importing the monolithic concrete legacy module.
+graph. The theorem names are the same as the former declarations, but
+callers can now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Inequalities.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Inequalities.lean
@@ -37,11 +37,11 @@ import Mathlib.Analysis.BoundedVariation
 
 This module also imports
 `IsingModel.Concrete.LatticeGraphCorrelation.CorrelationDecay` to preserve the
-legacy `Inequalities` import path for §5.1 conditional and distance-based
+original `Inequalities` import path for §5.1 conditional and distance-based
 cluster-decay wrappers, and
 `IsingModel.Concrete.LatticeGraphCorrelation.PointwiseRegularity` /
 `IsingModel.Concrete.LatticeGraphCorrelation.SusceptibilityPointwiseRegularity`
-to preserve the legacy path for finite-stage correlation and susceptibility
+to preserve the import path for finite-stage correlation and susceptibility
 regularity compatibility names. New code should import the narrower child
 modules directly for those declarations.
 -/
@@ -55,7 +55,7 @@ namespace Ambient
 
 The foundational `HasExponentialDecay` and `latticeMass` API now lives in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassFoundation`. This
-module imports it to preserve the legacy `Inequalities` import path.
+module imports it to preserve the original `Inequalities` import path.
 -/
 
 /-! ## §5.1 / §17.5 high-temperature lattice-mass bounds
@@ -63,7 +63,7 @@ module imports it to preserve the legacy `Inequalities` import path.
 The concrete high-temperature `HasExponentialDecay`, lattice-mass bounds,
 antitonicity, and tanh lower-bound API now lives in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassHighTemperature`. This
-module imports it to preserve the legacy `Inequalities` import path.
+module imports it to preserve the original `Inequalities` import path.
 -/
 
 /-! ## §17.1 / §17.5 pseudo-mass transfer and critical-temperature bridges
@@ -71,7 +71,7 @@ module imports it to preserve the legacy `Inequalities` import path.
 The concrete product-summability, critical inverse temperature, pseudo-mass
 transfer, and below-critical cluster / summability bridge API now lives in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransfer`.
-This module imports it to preserve the legacy `Inequalities` import path.
+This module imports it to preserve the original `Inequalities` import path.
 -/
 
 /-! ## §17.1 d = 0 special case -/
@@ -168,7 +168,7 @@ theorem criticalInverseTemp_eq_top_of_J_zero (d : ℕ) :
 The concrete finite-susceptibility wrapper and Lebowitz derivative bound API
 now lives in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassLebowitzDerivative`.
-This module imports it to preserve the legacy `Inequalities` import path.
+This module imports it to preserve the original `Inequalities` import path.
 -/
 
 /-! ## §17.5 high-temperature Lipschitz and uniform convergence wrappers
@@ -177,7 +177,7 @@ The concrete high-temperature Lipschitz, continuity, uniform convergence,
 a.e. differentiability, locally bounded variation, locally uniform convergence,
 and interior-continuity API now lives in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassHighTempLipschitz`.
-This module imports it to preserve the legacy `Inequalities` import path.
+This module imports it to preserve the original `Inequalities` import path.
 -/
 
 /-! ## §17.5 high-temperature zero-boundary and half-open wrappers
@@ -187,7 +187,7 @@ continuity and uniform convergence wrappers, zero-included Lipschitz bounds,
 half-line a.e. differentiability wrappers, and half-open locally uniform
 convergence API now lives in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassHighTempZeroBoundary`.
-This module imports it to preserve the legacy `Inequalities` import path.
+This module imports it to preserve the original `Inequalities` import path.
 -/
 
 /-! ## §17.5 truncated2Infinite high-temperature wrappers
@@ -197,7 +197,7 @@ Ursell two-point function `truncated2Infinite` at `h = 0` (Step 185--187 in
 the β-direction, Step 239--240 in the J-direction, and Step 241 interior
 `ContinuousAt` wrappers) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassTruncated2HighTemp`.
-This module imports it to preserve the legacy `Inequalities` import path.
+This module imports it to preserve the original `Inequalities` import path.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/JointAnalyticity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/JointAnalyticity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.JointAnalyticity
 
 Narrow child module for ℤ^d `AnalyticAt` / `AnalyticOnNhd` forwarders in the
 joint `(β, J, h)` parameters. The theorem names are the same as the former
-legacy declarations, but callers can now import this child module directly.
+former declarations, but callers can now import this child module directly.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/JointRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/JointRegularity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.JointRegularity
 
 This module contains concrete `latticeGraph` specializations of joint
 `Continuous`, `Differentiable`, `ContinuousAt`, and `DifferentiableAt` APIs for
-correlation, magnetization, and susceptibility. It is split out of the legacy
+correlation, magnetization, and susceptibility. It is split out of the original
 concrete correlation module so downstream users can depend on a narrower child
 path.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/LambdaCorrelationMonotonicity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/LambdaCorrelationMonotonicity.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.MagnetizationAlongExhaustion
 
 Narrow child module for concrete `latticeGraph` Lambda-layer correlation and
 magnetization convergence / monotonicity wrappers. The theorem names are the
-same as the former legacy declarations, but callers can now avoid importing the
-monolithic concrete legacy module.
+same as the former declarations, but callers can now avoid importing the
+monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassHighTempLipschitz.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassHighTempLipschitz.lean
@@ -8,7 +8,7 @@ import Mathlib.Analysis.BoundedVariation
 # High-temperature Lipschitz and uniform convergence wrappers at ℤ^d
 
 This module contains the concrete §17.5 high-temperature Lipschitz layer split
-from the legacy `Inequalities` module: finite-stage β/J Lipschitz helpers,
+from the original `Inequalities` module: finite-stage β/J Lipschitz helpers,
 infinite-volume compact Lipschitz and continuity wrappers, compact uniform
 convergence, a.e. differentiability / locally bounded variation on compact and
 open high-temperature intervals, open-interval continuity, locally uniform

--- a/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassHighTempZeroBoundary.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassHighTempZeroBoundary.lean
@@ -5,7 +5,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassHighTempContinuous
 # High-temperature zero-boundary and half-open wrappers at ℤ^d
 
 This module contains the concrete §17.5 high-temperature zero-boundary layer
-split from the legacy `Inequalities` module: β/J linear bounds at the zero
+split from the original `Inequalities` module: β/J linear bounds at the zero
 boundary, closed-interval continuity and uniform convergence, zero-included
 Lipschitz bounds, half-line a.e. differentiability, and half-open locally
 uniform convergence wrappers.

--- a/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassHighTemperature.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassHighTemperature.lean
@@ -13,7 +13,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.TwoPointCorrelationInfinite
 # High-temperature lattice-mass bounds at ℤ^d
 
 This module contains the concrete high-temperature exponential-decay layer and
-§17.5 lattice-mass bounds split from the legacy `Inequalities` module:
+§17.5 lattice-mass bounds split from the original `Inequalities` module:
 Step 110 high-temperature decay, Step 111 positive/lower mass bounds,
 Step 112 antitonicity, Steps 113--114 tanh lower bounds, and Step 115 upper /
 two-sided mass bounds.

--- a/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassLebowitzDerivative.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassLebowitzDerivative.lean
@@ -8,7 +8,7 @@ import IsingModel.BetaDerivative
 # Finite susceptibility and Lebowitz derivative bounds at ℤ^d
 
 This module contains the concrete §17.1 finite-susceptibility wrapper and
-§17.5 Lebowitz derivative bound layer split from the legacy `Inequalities`
+§17.5 Lebowitz derivative bound layer split from the original `Inequalities`
 module: Step 149 finite susceptibility below the critical inverse temperature,
 Steps 157--166 finite-volume derivative bounds, finite-to-infinite correlation
 comparison, Lebowitz sum bounds, and high-temperature consequences.

--- a/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassPseudoMassTransfer.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassPseudoMassTransfer.lean
@@ -24,7 +24,7 @@ import IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransfer
 # Lattice-mass pseudo-mass transfer bridges at ℤ^d
 
 This module contains the concrete §17.1 / §17.5 bridge layer split from the
-legacy `Inequalities` module: Step 127 product summability bounds, critical
+original `Inequalities` module: Step 127 product summability bounds, critical
 inverse temperature wrappers, high-temperature decay transfer to arbitrary
 exhaustions, pseudo-mass comparison bridges, and below-critical cluster /
 summability consequences.
@@ -41,7 +41,7 @@ namespace Ambient
 The §17.5 Step 127 Lebowitz-exponential product summability bounds and
 §17.1 / §17.5 criticalInverseTemp foundations now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransferSummability`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -50,7 +50,7 @@ The legacy import path is preserved by re-importing the new child.
 The 5 `HasExponentialDecay_*_transfer*` and
 `latticeMass_*_high_temp_exhaustion` wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransferExpDecay`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -59,7 +59,7 @@ The legacy import path is preserved by re-importing the new child.
 The 7 basic §17.5 pseudoMassFromParamsAtPair comparison +
 latticeMass_ge / latticeMass_pos wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransferBasic`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -67,7 +67,7 @@ The legacy import path is preserved by re-importing the new child.
 
 The 6 exhaustion-variant pseudoMassFromParamsAtPair wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransferExhaustion`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -75,7 +75,7 @@ The legacy import path is preserved by re-importing the new child.
 
 The 6 cubic-variant pseudoMassFromParamsAtPair wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransferCubic`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -84,7 +84,7 @@ The legacy import path is preserved by re-importing the new child.
 
 The 6 reference-variant pseudoMassFromParamsAtPair wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransferReference`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -92,7 +92,7 @@ The legacy import path is preserved by re-importing the new child.
 
 The 6 cubic_pseudoMassFromParamsAtPair variant wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransferCubicPseudoMass`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -101,7 +101,7 @@ The legacy import path is preserved by re-importing the new child.
 
 The 13 tanh-power profile + twoPointFunction bridge wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassPseudoMassTransferTanhPowDist`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-- **Cluster property holds below the critical inverse temperature** (GJ §17.1):

--- a/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassTruncated2HighTemp.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/LatticeMassTruncated2HighTemp.lean
@@ -11,7 +11,7 @@ import IsingModel.AmbientLattice.TruncatedFunctions
 
 This module contains the concrete high-temperature regularity wrappers for the
 infinite-volume Ursell two-point function `truncated2Infinite` at `h = 0`,
-split from the legacy `Inequalities` module. Every wrapper reduces to the
+split from the original `Inequalities` module. Every wrapper reduces to the
 corresponding `correlationInfinite {r, s}` statement via
 `truncated2Infinite_h_zero`:
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Magnetization.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Magnetization.lean
@@ -38,7 +38,7 @@ The 9 ℤ^d `magnetization_convergent_{J,h,beta}_latticeGraph`,
 `magnetization_total_convergent_subgraph_latticeGraph` wrappers
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationConvergent`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -47,7 +47,7 @@ The legacy import path is preserved by re-importing the new child.
 The 11 ℤ^d `susceptibility_*_latticeGraph` and
 `eta_nonneg_finite_vol_latticeGraph` wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationSusceptibility`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: site-level magnetization wrappers (GJ §5.3, pp. 77-80)
@@ -59,7 +59,7 @@ The 11 ℤ^d site-level magnetization wrappers
 `magnetization_{zero_at_h_zero,beta_zero,J_zero}_latticeGraph`,
 `magnetization_{monotone_h,monotone_beta}_latticeGraph`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationSiteLevel`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -68,7 +68,7 @@ The legacy import path is preserved by re-importing the new child.
 The 8 ℤ^d `correlation_*_latticeGraph` thin pass-throughs (bounds +
 trivial slices + `correlation_empty`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationCorrelationBasic`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: HNC / GKS / FKG wrappers
@@ -77,7 +77,7 @@ The 12 ℤ^d `hasNonnegCorrelations_*_latticeGraph` /
 `gks_*_latticeGraph` / `boltzmannWeight_*_latticeGraph` /
 `fkg_ising_latticeGraph` wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.MagnetizationGksFkg`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationConvergence.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationConvergence.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.SpecialCases.MagnetizationConvergence
 
 Narrow child module for concrete finite-stage magnetization convergence
 wrappers on the lattice graph. The theorem names are the same as the former
-legacy declarations, but callers can now avoid importing the monolithic
-concrete legacy module.
+former declarations, but callers can now avoid importing the monolithic
+concrete original module.
 -/
 
 namespace IsingModel
@@ -16,7 +16,7 @@ namespace Ambient
 /-! ### magnetization parameter-direction convergent (β/h/J → ∞)
 ℤ^d wraps. Λ-direct versions already exist as
 `magnetizationΛ_latticeGraph_convergent_{beta,h,J}` (in
-`correlationΛ` form) earlier in the legacy module; this section adds the
+`correlationΛ` form) earlier in the original module; this section adds the
 along-exhaustion versions only. -/
 
 /-- **ℤ^d along-ex: magnetization β → ∞ convergence**. -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationPointwiseRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationPointwiseRegularity.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.BetaDerivativeMagnetization
 
 This module contains concrete `latticeGraph` specializations of ambient
 `ContinuousAt` and `DifferentiableAt` APIs for per-parameter
-`magnetizationAlongExhaustion` regularity. It is split out of the legacy
+`magnetizationAlongExhaustion` regularity. It is split out of the original
 concrete correlation module so future magnetization pointwise work can build a
 narrower child path.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MagnetizationRegularity.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.SpecialCases.MagnetizationRegularity
 
 Narrow child module for concrete finite-stage magnetization `Continuous` and
 `Differentiable` wrappers on the lattice graph. The theorem names are the same
-as the former legacy declarations, but callers can now avoid importing the
-monolithic concrete legacy module.
+as the former declarations, but callers can now avoid importing the
+monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerAnalyticity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerAnalyticity.lean
@@ -5,7 +5,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerAnalyticity
 # Concrete Mayer analyticity wrappers for the lattice graph
 
 Narrow child module for ℤ^d `mayerPartialSum` and `mayerExpansionTerm`
-analytic wrappers. The theorem names are the same as the former legacy
+analytic wrappers. The theorem names are the same as the former
 declarations, but callers can now import this child module directly.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerBasicIdentities.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerBasicIdentities.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerBasicIdentities
 Narrow child module for concrete `ℤ^d` at-zero and at-one identities for
 `vdPolymerFamilies_sum`, `mayerPartialSum`, and `mayerExpansionTerm`. This
 keeps callers that only need these wrappers out of the monolithic
-lattice-correlation legacy module.
+lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerEdgeCases.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerEdgeCases.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEdgeCases
 
 Narrow child module for concrete `ℤ^d` Mayer identity edge cases and
 `polymerFreeEnergy = mayerPartialSum` forwarders. This keeps callers that only
-need these wrappers out of the monolithic lattice-correlation legacy module.
+need these wrappers out of the monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerEpsilonInfrastructure.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerEpsilonInfrastructure.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonInfrastructure
 Narrow child module for concrete `ℤ^d` epsilon infrastructure wrappers,
 the first Mayer-term sign wrappers, and the edgeless `allPolymers` wrapper.
 This keeps callers that only need these forwarders out of the monolithic
-lattice-correlation legacy module.
+lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerEpsilonPositivity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerEpsilonPositivity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerEpsilonPositivity
 
 Narrow child module for concrete `ℤ^d` `ε(t)` and `polymerFreeEnergy`
 positivity/zero iff wrappers. This keeps callers that only need these
-forwarders out of the monolithic lattice-correlation legacy module.
+forwarders out of the monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerExpansionEdgeCases.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerExpansionEdgeCases.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerExpansionEdgeCases
 
 Narrow child module for concrete `ℤ^d` Mayer expansion `n = 2`, no-polymer,
 edgeless, and absolute-bound wrappers. This keeps callers that only need these
-forwarders out of the monolithic lattice-correlation legacy module.
+forwarders out of the monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerFilterConnected.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerFilterConnected.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.SpecialCases.MayerFilterConnected
 
 Narrow child module for concrete §18.5 Mayer filter-connected and
 epsilon-power wrappers on the lattice graph. The theorem names are the same
-as the former legacy declarations, but callers can now avoid importing the
-monolithic concrete legacy module.
+as the former declarations, but callers can now avoid importing the
+monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerRecurrenceHasSum.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerRecurrenceHasSum.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerRecurrenceHasSum
 Narrow child module for concrete `ℤ^d` Mayer recurrence wrappers,
 `polymerFreeEnergy` log-series `HasSum` wrappers, and the
 `vdPolymerFamilies_sum - 1` tendsto-zero wrapper. This keeps callers that only
-need these forwarders out of the monolithic lattice-correlation legacy module.
+need these forwarders out of the monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerStrictPositivity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerStrictPositivity.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerStrictPositivity
 Narrow child module for concrete `ℤ^d` strict-monotonicity and strict
 positivity wrappers under `allPolymers` nonempty hypotheses. This keeps callers
 that only need these forwarders out of the monolithic lattice-correlation
-legacy module.
+original module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerTanhFerromagneticIff.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerTanhFerromagneticIff.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTanhFerromagneticIff
 
 Narrow child module for concrete `Z^d` ferromagnetic tanh iff wrappers for
 `polymerFreeEnergy` and `vdPolymerFamilies_sum`. This keeps callers that only
-need these forwarders out of the monolithic lattice-correlation legacy module.
+need these forwarders out of the monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerTrivialCases.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerTrivialCases.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerTrivialCases
 Narrow child module for concrete `ℤ^d` `mayerPartialSum 0 ≤ polymerFreeEnergy`
 comparisons and Mayer identity wrappers for no-polymer, trivial, and edgeless
 cases. This keeps callers that only need these wrappers out of the monolithic
-lattice-correlation legacy module.
+lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerVdBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerVdBounds.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdBounds
 
 Narrow child module for concrete `ℤ^d` `vdPolymerFamilies_sum` bound
 wrappers. This keeps callers that only need these forwarders out of the
-monolithic lattice-correlation legacy module.
+monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerVdIff.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerVdIff.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdIff
 
 Narrow child module for concrete `ℤ^d` iff characterizations of
 `vdPolymerFamilies_sum`. This keeps callers that only need these wrappers out
-of the monolithic lattice-correlation legacy module.
+of the monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/MayerVdRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/MayerVdRegularity.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.MayerVdRegularity
 Narrow child module for concrete `ℤ^d` wrappers around `mayerPartialSum`,
 `mayerExpansionTerm`, and `vdPolymerFamilies_sum` regularity and tanh
 forwarders. This keeps callers that only need these wrappers out of the
-monolithic lattice-correlation legacy module.
+monolithic lattice-correlation module.
 -/
 
 namespace IsingModel
@@ -86,7 +86,7 @@ The 16 ℤ^d `mayerPartialSum_Λ_latticeGraph_tanh_*`,
 `mayerExpansionTermAlongExhaustion_latticeGraph_tanh_*` wrappers
 (continuous/differentiable in β/J) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.MayerVdRegularityTanh`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -97,7 +97,7 @@ The 12 ℤ^d `vdPolymerFamilies_sum_Λ_latticeGraph_*` and
 (Continuous/Differentiable/HasDerivAt in t, plus tanh-variants in
 β/J) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.MayerVdRegularityPolymer`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionExhaustionBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionExhaustionBounds.lean
@@ -6,8 +6,8 @@ import IsingModel.Concrete.LatticeGraphBED
 Narrow child module for concrete `latticeGraph` partition-function
 along-exhaustion volume / parameter monotonicity, positivity, divergence, and
 infinite-volume free-energy positivity wrappers. The theorem names are the same
-as the former legacy declarations, but callers can now avoid importing the
-monolithic concrete legacy module.
+as the former declarations, but callers can now avoid importing the
+monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergyBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergyBounds.lean
@@ -5,7 +5,7 @@ import IsingModel.Concrete.LatticeGraphBED
 
 Thin `ℤ^d` specializations of partition-function and free-energy bounds,
 nonnegativity facts, and infinite-volume bridge statements.  These wrappers keep
-downstream imports away from the legacy concrete correlation module when only
+downstream imports away from the original concrete correlation module when only
 order-theoretic or bound facts are needed.
 -/
 
@@ -72,7 +72,7 @@ identity / nonneg wrappers (`eq_inv_card_mul_log`,
 `eq_inv_Λcard_mul_log`, `nonneg_of_ferromagnetic`, `eq_log_div_card`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyBoundsFeAlongExId`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -84,7 +84,7 @@ bound wrappers (`ge_one`, `ge_one_general`, `ge_two_pow_card`,
 `ge_two_cosh_pow_card`, `nonneg_general`, `nonneg`,
 `ge_card_mul_log_two`, `ge_card_mul_log_two_cosh`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyBoundsAlongEx`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -95,7 +95,7 @@ The 6 ℤ^d `freeEnergyInfinite_latticeGraph_*` bridge wrappers
 `cubicExhaustion_of_eventually_const`, `le_uniform_upper_bound`,
 `cubicExhaustion_le_uniform_upper_bound`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyBoundsInfinite`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -105,7 +105,7 @@ The 8 ℤ^d `freeEnergyAlongExhaustion_latticeGraph_*` BddAbove /
 per-stage upper-bound / per-stage `log 2` and `log(2 cosh)`
 lower-bound / ferromagnetic per-stage nonneg wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergyBoundsAlongExBridges`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergyMonotonicity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergyMonotonicity.lean
@@ -5,7 +5,7 @@ import IsingModel.Concrete.LatticeGraphBED
 
 Thin `ℤ^d` specializations of finite-volume and along-exhaustion partition /
 free-energy monotonicity statements.  These wrappers keep downstream users from
-importing the legacy concrete correlation module when they only need parameter
+importing the original concrete correlation module when they only need parameter
 monotonicity or zero-parameter comparison facts.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergyPointwiseRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergyPointwiseRegularity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyPointwiseRegula
 
 This module contains concrete `latticeGraph` specializations of ambient
 `ContinuousAt` and `DifferentiableAt` APIs for along-exhaustion partition
-function and free energy. It is split out of the legacy concrete correlation
+function and free energy. It is split out of the original concrete correlation
 module so downstream users can depend on a narrower child path.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergyRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergyRegularity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFreeEnergyRegularity
 
 This module contains concrete `latticeGraph` specializations of `Continuous`
 and `Differentiable` APIs for partition functions and free energies. It is
-split out of the legacy concrete correlation module so downstream users can
+split out of the original concrete correlation module so downstream users can
 depend on a narrower child path.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergySuperadditivity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFreeEnergySuperadditivity.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLatticeSum
 
 Narrow child module for concrete `latticeGraph` partition-function and
 free-energy disjoint-union monotonicity / superadditivity wrappers. The theorem
-names are the same as the former legacy declarations, but callers can now avoid
-importing the monolithic concrete legacy module.
+names are the same as the former declarations, but callers can now avoid
+importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionClosedForms.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionClosedForms.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionClosedForms
 
 Narrow child module for concrete `latticeGraph` partition-function closed-form
 wrappers at trivial parameter slices. The theorem names are the same as the
-former legacy declarations, but callers can now avoid importing the monolithic
-concrete legacy module.
+former declarations, but callers can now avoid importing the monolithic
+concrete original module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionGeneralAnalyticity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionGeneralAnalyticity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionGeneralAnalyticit
 
 This module contains concrete `latticeGraph` specializations of joint
 `Continuous` / `Differentiable` APIs and general-h `AnalyticAt` APIs for
-partition functions. It is split out of the legacy concrete correlation module
+partition functions. It is split out of the original concrete correlation module
 so downstream users can depend on a narrower child path.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionRegularity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.PartitionFunctionRegularity
 
 This module contains concrete `latticeGraph` specializations of `Continuous`,
 `Differentiable`, `AnalyticAt`, and `AnalyticOnNhd` APIs for partition
-functions at zero external field. It is split out of the legacy concrete
+functions at zero external field. It is split out of the original concrete
 correlation module so downstream users can depend on a narrower child path.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionSymmetry.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PartitionFunctionSymmetry.lean
@@ -7,8 +7,8 @@ import IsingModel.AmbientLatticeSum
 
 Narrow child module for concrete `latticeGraph` partition-function h-symmetry,
 absolute-field rewrite, and absolute-field monotonicity wrappers. The theorem
-names are the same as the former legacy declarations, but callers can now avoid
-importing the monolithic concrete legacy module.
+names are the same as the former declarations, but callers can now avoid
+importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PerStage.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PerStage.lean
@@ -42,7 +42,7 @@ The four wrappers
 `partitionFunctionComplexAlongExhaustion_at_real_latticeGraph`,
 `freeEnergyComplexAlongExhaustion_at_real_latticeGraph` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PerStageComplexAlongEx`.
-The legacy import path is preserved by re-importing the new child. -/
+The earlier import path is preserved by re-importing the new child. -/
 
 
 /-! ## Moved: ℤ^d per-stage complex analyticity wrappers
@@ -60,7 +60,7 @@ wrappers
 `freeEnergyComplexAlongExhaustion_tendsto_at_real_of_disjointTowerHypotheses_latticeGraph`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PerStageComplex`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -146,7 +146,7 @@ The 5 ℤ^d GJ §17.2/§17.7 critical-exponent wrappers
 `absence_of_even_bound_states_finite_vol_latticeGraph`,
 `absence_of_even_bound_states_infinite_vol_latticeGraph`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PerStageZetaEta`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -162,7 +162,7 @@ The 8 ℤ^d Λ-induced subgraph wrappers
 `twoPoint_convergent_subgraph_latticeGraph`,
 `freeEnergy_convergent_subgraph_latticeGraph`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PerStageSubgraph`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PointwiseRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PointwiseRegularity.lean
@@ -8,7 +8,7 @@ import IsingModel.AmbientLattice.JDerivative
 
 This module contains concrete `latticeGraph` specializations of ambient
 `ContinuousAt`, `DifferentiableAt`, `Continuous`, and `Differentiable` APIs for
-β- and J-direction along-exhaustion correlation. It is split out of the legacy
+β- and J-direction along-exhaustion correlation. It is split out of the original
 concrete correlation module so future pointwise regularity work can build a
 narrower child path.
 -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PointwiseRegularityBetaHZero.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PointwiseRegularityBetaHZero.lean
@@ -4,9 +4,9 @@ import IsingModel.AmbientLattice.BetaDerivative
 import IsingModel.AmbientLattice.JDerivative
 
 /-!
-# Legacy-compatible ℤ^d correlationAlongEx β-direction (h=0) wrappers
+# Compatibility-named ℤ^d correlationAlongEx β-direction (h=0) wrappers
 
-Narrow child module for four legacy-compatible ℤ^d
+Narrow child module for four compatibility-named ℤ^d
 `correlationAlongExhaustion_*_beta` wrappers (at `h = 0`)
 extracted from `PointwiseRegularity.lean`:
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyAnalyticity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyAnalyticity.lean
@@ -5,7 +5,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyAnalyticity
 # Concrete polymer free-energy analyticity wrappers for the lattice graph
 
 Narrow child module for ℤ^d `polymerFreeEnergy` analytic wrappers. The theorem
-names are the same as the former legacy declarations, but callers can now
+names are the same as the former declarations, but callers can now
 import this child module directly.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyBasic.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyBasic.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyBasic
 
 Narrow child module for concrete `ℤ^d` `polymerFreeEnergy` at-zero, at-one,
 and nonnegative sandwich wrappers. This keeps callers that only need these
-forwarders out of the monolithic lattice-correlation legacy module.
+forwarders out of the monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyBounds.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyBounds
 
 Narrow child module for ℤ^d `polymerFreeEnergy` regularity, bounds,
 comparison, and edge-case wrappers. This keeps callers that only need these
-forwarders out of the monolithic concrete legacy module.
+forwarders out of the monolithic concrete module.
 -/
 
 namespace IsingModel
@@ -20,7 +20,7 @@ The 8 ℤ^d `polymerFreeEnergy_Λ_latticeGraph_*` and
 `differentiableOn_Ici_zero` in both Λ and AlongExhaustion forms) now
 live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PolymerFreeEnergyBoundsRegularity`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ### §18.5 polymerFreeEnergy bound family ℤ^d wraps -/
@@ -104,7 +104,7 @@ and `polymerFreeEnergyAlongExhaustion_latticeGraph_{tanh_sandwich,
 le_card_log_two_of_le_one, tanh_le_card_log_two, tanh_double_bound}`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.PolymerFreeEnergyBoundsTanh`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyHighTemperatureBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyHighTemperatureBounds.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyHighTemperatureBo
 
 Narrow child module for the §18.5 `vdPolymerFamilies_sum` sandwich/monotone,
 `ε(t)` bound, and `polymerFreeEnergy(tanh)` high-temperature bound wrappers on
-`latticeGraph d`. The theorem names are the same as the former legacy
+`latticeGraph d`. The theorem names are the same as the former
 declarations, but callers can now import this child module directly.
 -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyTanhBounds.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyTanhBounds.lean
@@ -7,7 +7,7 @@ import IsingModel.AmbientLattice.SpecialCases.PolymerFreeEnergyTanhBounds
 Narrow child module for concrete `ℤ^d` `polymerFreeEnergy` tanh bounds,
 ferromagnetic bounds, the `log(1 + eps)` decomposition, and the `HasDerivAt`
 wrapper. This keeps callers that only need these forwarders out of the
-monolithic lattice-correlation legacy module.
+monolithic lattice-correlation module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyTanhSharpening.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PolymerFreeEnergyTanhSharpening.lean
@@ -8,7 +8,7 @@ wrappers
 Narrow child module for concrete `ℤ^d` polymer free-energy
 `tanh sharpening + β/J strict-mono` wrappers. This keeps callers that
 only need these forwarders out of the monolithic lattice-correlation
-legacy module.
+original module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Regularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Regularity.lean
@@ -7,9 +7,9 @@ import IsingModel.AmbientLattice.FieldDerivative
 # Concrete regularity wrappers for the ℤ^d Ising correlation
 
 This module contains concrete `latticeGraph` specializations of ambient
-`HasDerivAt` APIs. It is split out of the legacy concrete correlation module
+`HasDerivAt` APIs. It is split out of the original concrete correlation module
 so future derivative-wrapper work can build a narrower child path instead of
-touching the monolithic legacy file.
+touching the monolithic original file.
 -/
 
 open scoped symmDiff
@@ -78,7 +78,7 @@ The three wrappers
 `hasDerivAt_freeEnergyΛ_latticeGraph_J`,
 `hasDerivAt_freeEnergyΛ_latticeGraph_field` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.RegularityFreeEnergyLambda`.
-The legacy import path is preserved by re-importing the new child. -/
+The earlier import path is preserved by re-importing the new child. -/
 
 
 /-! ## Moved: ℤ^d Λ-layer `partitionFunctionΛ`/`boltzmannWeightΛ` `hasDerivAt` wrappers
@@ -88,7 +88,7 @@ The 6 ℤ^d Λ-layer
 `hasDerivAt_boltzmannWeightΛ_latticeGraph_{beta,J,field}` wrappers
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.RegularityPartitionBoltzmann`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -98,7 +98,7 @@ The 8 ℤ^d Λ-layer `magnetizationΛ_latticeGraph_hasDerivAt_*` and
 `susceptibilityΛ_latticeGraph_hasDerivAt_*` wrappers (in field/β/
 β_general_h/J directions) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.RegularityMagSusc`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -110,7 +110,7 @@ The 18 ℤ^d along-exhaustion `hasDerivAt` wrappers
 `susceptibilityAlongExhaustion` — in β/β_general_h/J/field
 directions) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.RegularityAlongEx`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMag.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SiteIndepMag.lean
@@ -101,7 +101,7 @@ The 10 ℤ^d `uniformSpontaneousMagnetization*` wrappers
 `_nonneg`, `_le_one`, `neg_one_le_*`,
 `abs_*_le_one`, `_sq_le_one`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMagUniformSpontaneous`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d `spontaneousCorrelation`/`spontaneousMagnetization_latticeGraph` wrappers
@@ -113,7 +113,7 @@ The 8 ℤ^d wrappers `spontaneousCorrelation_latticeGraph_apply`,
 `spontaneousMagnetization_latticeGraph_{nonneg,le_one,monotone_J,monotone_beta}`
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMagSpontaneous`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -166,7 +166,7 @@ The 17 ℤ^d `twoPointFunction_*` / `truncated2TwoPoint_*` /
 `truncated3TwoPoint_*` / `truncated4TwoPoint_*` bounds + symmetry
 wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.SiteIndepMagTwoPoint`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityConvergence.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityConvergence.lean
@@ -6,15 +6,15 @@ import IsingModel.AmbientLattice.SpecialCases.SusceptibilityConvergence
 
 Narrow child module for concrete finite-stage susceptibility convergence
 wrappers on the lattice graph. The theorem names are the same as the former
-legacy declarations, but callers can now avoid importing the monolithic
-concrete legacy module.
+former declarations, but callers can now avoid importing the monolithic
+concrete original module.
 -/
 
 namespace IsingModel
 namespace Ambient
 
 /-! ### susceptibility parameter-direction convergent (β/h/J → ∞)
-ℤ^d wraps. Λ-direct versions remain in the legacy module because they sit with
+ℤ^d wraps. Λ-direct versions remain in the original module because they sit with
 the nearby Λ-level susceptibility regularity wrappers; this module contains the
 along-exhaustion versions only. -/
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityLambda.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityLambda.lean
@@ -6,8 +6,8 @@ import IsingModel.AmbientLattice.Defs
 
 Narrow child module for concrete `latticeGraph` specializations of
 `susceptibilityΛ` regularity and parameter-direction convergence wrappers.
-The theorem names are the same as the former legacy declarations, but callers
-can now avoid importing the monolithic concrete legacy module.
+The theorem names are the same as the former declarations, but callers
+can now avoid importing the monolithic concrete module.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularity.lean
@@ -5,10 +5,10 @@ import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity
 /-!
 # Concrete pointwise regularity wrappers for lattice susceptibility
 
-This module contains concrete `latticeGraph` specializations and legacy
+This module contains concrete `latticeGraph` specializations and compatibility-named
 compatibility names for ambient `ContinuousAt`, `DifferentiableAt`,
 `Continuous`, and `Differentiable` APIs for per-parameter
-`susceptibilityAlongExhaustion` regularity. It is split out of the legacy
+`susceptibilityAlongExhaustion` regularity. It is split out of the original
 concrete correlation module so future susceptibility pointwise work can build a
 narrower child path.
 -/
@@ -18,7 +18,7 @@ open scoped symmDiff
 namespace IsingModel
 namespace Ambient
 
-/-! ### Legacy-compatible ℤ^d along-ex susceptibility regularity names -/
+/-! ### Compatibility-named ℤ^d along-ex susceptibility regularity names -/
 
 /-! ## Moved: susceptibilityAlongExhaustion β-direction (h=0) wrappers
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularityBetaHZero.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/SusceptibilityPointwiseRegularityBetaHZero.lean
@@ -4,9 +4,9 @@ import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularity
 import IsingModel.AmbientLattice.SpecialCases.SusceptibilityPointwiseRegularityAt
 
 /-!
-# Legacy-compatible ℤ^d susceptibility β-direction (h=0) regularity wrappers
+# Compatibility-named ℤ^d susceptibility β-direction (h=0) regularity wrappers
 
-Narrow child module for four legacy-compatible ℤ^d
+Narrow child module for four compatibility-named ℤ^d
 `susceptibilityAlongExhaustion_*_beta` wrappers (at `h = 0`)
 extracted from `SusceptibilityPointwiseRegularity.lean`:
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Translation.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Translation.lean
@@ -23,7 +23,7 @@ and `truncated{2,3,4}Infinite`,
 5 `*_latticeGraph_translation` for `spontaneousCorrelation`,
 `spontaneousMagnetization`, and `truncated{2,3,4}Infinite`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TranslationVadd`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d shift / vaddFinset_eq wrappers
@@ -38,7 +38,7 @@ The 8 ℤ^d shift / vaddFinset_eq wrappers
 `freeEnergyΛ_latticeGraph_vaddFinset_eq`,
 `log_partitionFunctionΛ_latticeGraph_vaddFinset_eq`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TranslationShifts`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Concrete `spontaneousCorrelation` on ℤ^d -/

--- a/IsingModel/Concrete/LatticeGraphCorrelation/TwoPoint.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/TwoPoint.lean
@@ -191,7 +191,7 @@ The 6 concrete ℤ^d `truncated3Infinite_latticeGraph_swap_{ij,jk,ik}`
 and `truncated4Infinite_latticeGraph_swap_{ij,jk,kl}` symmetry
 wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointTruncatedSwaps`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -254,7 +254,7 @@ trivial-slice wrappers (`truncated3TwoPoint_h_zero_of_distinct`,
 `truncated4TwoPoint_beta_zero`, `truncated3TwoPoint_beta_zero`)
 now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointTruncatedTrivialSlices`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -264,7 +264,7 @@ The 3 concrete ℤ^d `twoPointFunction_zero_params`,
 `twoPointFunction_beta_zero`, and `twoPointFunction_J_zero_of_ne_zero`
 trivial-slice wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointFunctionTrivialSlices`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -279,7 +279,7 @@ and 3 `magnetizationInfinite_latticeGraph_cubicExhaustion_monotone_*`
 variants were further narrowed in PR #2026 into
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointMagnetizationMonotone`
 (see the next Moved block).
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d magnetization monotonicity wrappers
@@ -288,7 +288,7 @@ The 5 concrete ℤ^d `spontaneousMagnetization_latticeGraph_cubicExhaustion_mono
 and `magnetizationInfinite_latticeGraph_cubicExhaustion_monotone_{J,h,beta}`
 wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointMagnetizationMonotone`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -301,7 +301,7 @@ The 24 ℤ^d wrappers covering ambient-subgraph monotonicity from
 `partitionFunction*`, `correlation*`, `magnetization*`,
 `spontaneous*`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointAmbientBot`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: truncatedInfinite_latticeGraph wrappers
@@ -311,7 +311,7 @@ nonneg, symmetry, trivial slices `J_zero` / `β_zero` / `h_zero`),
 `truncated3Infinite_latticeGraph_apply`, and
 `truncated4Infinite_latticeGraph_apply` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointTruncatedInfinite`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: truncated3/4Infinite_latticeGraph trivial-slice wrappers
@@ -320,7 +320,7 @@ The 18 ℤ^d `truncated3Infinite_latticeGraph_*` and
 `truncated4Infinite_latticeGraph_*` trivial-slice + nonpos +
 exhaustion-independence wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointTruncatedHigher`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d correlationInfinite wrappers
@@ -330,7 +330,7 @@ The 7 concrete ℤ^d `correlationInfinite_latticeGraph_*` wrappers
 `_cubicExhaustion_monotone_h`, `_beta`, `_J`, `_gks_second`) now
 live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointCorrelationInfinite`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/TwoPointFreeEnergy.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/TwoPointFreeEnergy.lean
@@ -34,7 +34,7 @@ convergence wrappers (`J_zero_tendsto_of_hcard_add`,
 `beta_zero_tendsto_of_eventually_nonempty`,
 `zero_params_tendsto_of_eventually_nonempty`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointFreeEnergyAlongExTendsto`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: ℤ^d freeEnergyInfinite trivial-slice wrappers
@@ -43,7 +43,7 @@ The 9 ℤ^d `freeEnergyInfinite_latticeGraph_{beta_zero,zero_params,J_zero}_*`
 trivial-slice wrappers (3 `_of_eventually_nonempty` + 3 unconditional +
 3 `cubicExhaustion_*`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointFreeEnergyInfTrivialSlices`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -128,7 +128,7 @@ The 5 ℤ^d `freeEnergyInfinite_latticeGraph_*` h-symmetry / |h|-monotonicity
 wrappers (`cubicExhaustion_monotone_abs_h`, `cubicExhaustion_neg_h`,
 `cubicExhaustion_eq_abs_h`, `neg_h`, `eq_abs_h`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointFreeEnergyInfHSymmetry`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -138,7 +138,7 @@ The 7 ℤ^d `freeEnergyInfinite_latticeGraph_*monotone_*` wrappers
 (`monotone_J`, `monotone_h`, `monotone_beta`, `monotone_abs_h`, plus
 3 `cubicExhaustion_monotone_{J,h,beta}` variants) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.TwoPointFreeEnergyInfMonotone`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/UniformMag.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/UniformMag.lean
@@ -28,7 +28,7 @@ The 16 ℤ^d wrappers covering `uniformMagnetization` recasts,
 of_not_mem}`, `magnetizationInfinite_latticeGraph_apply`, and
 `freeEnergyInfinite_latticeGraph_apply` now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.UniformMagRecasts`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: magnetizationAlongExhaustion / correlationAlongExhaustion
@@ -39,7 +39,7 @@ The 17 ℤ^d `magnetizationAlongExhaustion_latticeGraph_*` and
 convergent / bddAbove / bddBelow / `_le_*Infinite` /
 `_tendsto_ciSup` / `_eq_ciSup` wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.UniformMagAlongExConvergence`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 
@@ -50,7 +50,7 @@ The 15 ℤ^d `magnetizationΛ_latticeGraph_*` and
 trivial-slice (h_zero, beta_zero, zero_params, J_zero variants)
 wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.UniformMagMagnetizationTrivial`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: abs / neg / sq bounds wrappers
@@ -61,7 +61,7 @@ The 13 ℤ^d `abs_*_latticeGraph_le_one` /
 `correlationInfinite`, `magnetizationΛ`,
 `magnetizationAlongExhaustion`, `magnetizationInfinite`) now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.UniformMagAbsBounds`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: correlation trivial / GKS-II / FKG / h_zero / cor 4.3.5 wrappers
@@ -73,7 +73,7 @@ trivial slices, `correlationInfinite_latticeGraph_*` empty / GKS-II
 `correlationAlongExhaustion_latticeGraph_*_h_zero` wrappers now live
 in
 `IsingModel.Concrete.LatticeGraphCorrelation.UniformMagCorrelationTrivial`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 

--- a/IsingModel/Concrete/LatticeGraphCorrelation/UniformMagCorrelationTrivial.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/UniformMagCorrelationTrivial.lean
@@ -122,7 +122,7 @@ The 11 ℤ^d `susceptibilityInfinite_latticeGraph_*` and
 zero_params trivial-slice + continuousOn / differentiableOn
 regularity wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.UniformMagSusceptibilityInfinite`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 end Ambient

--- a/IsingModel/Concrete/LatticeGraphCorrelation/UniformMagRecasts.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/UniformMagRecasts.lean
@@ -99,7 +99,7 @@ The 23 ℤ^d `truncated2TwoPoint_*` bounds + trivial slices,
 and `correlationAlongExhaustion_latticeGraph_*` J/h/β monotone
 wrappers now live in
 `IsingModel.Concrete.LatticeGraphCorrelation.UniformMagBoundsMonotonicity`.
-The legacy import path is preserved by re-importing the new child.
+The earlier import path is preserved by re-importing the new child.
 -/
 
 /-! ## Moved: magnetization apply / bound wrappers

--- a/IsingModel/Concrete/LatticeGraphCorrelation/VdPolymerFamiliesAnalyticity.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/VdPolymerFamiliesAnalyticity.lean
@@ -6,7 +6,7 @@ import IsingModel.AmbientLattice.SpecialCases.VdPolymerFamiliesAnalyticity
 
 Narrow child module for ℤ^d `vdPolymerFamilies_sum`,
 `log_vdPolymerFamilies_sum`, and epsilon analyticity wrappers. The theorem names
-are the same as the former legacy declarations, but callers can now import this
+are the same as the former declarations, but callers can now import this
 child module directly.
 -/
 


### PR DESCRIPTION
## Summary

Replaces every remaining doc-comment reference to the now-deleted
`Legacy.lean` shims and to the historical "legacy" naming with
neutral language pointing at the actual umbrellas / monolithic
modules. After this 183-file sweep,
`grep -in 'legacy\|Legacy' IsingModel/` returns zero matches.

Concrete transformations (all in doc comments only):

- `from this parent module and from \`Legacy.lean\`` → `from this
  parent module and from the umbrella \`SpecialCases.lean\``
- `from \`Legacy.lean\` and the umbrella \`HighTemperatureBounds.lean\``
  → `from the umbrella \`HighTemperatureBounds.lean\``
- `The umbrella ... and \`Legacy.lean\` re-import` → `The umbrella
  ... re-imports`
- `The legacy import path is preserved` → `The earlier import path
  is preserved`
- `monolithic legacy module` / `monolithic concrete legacy module`
  → drop the word `legacy`
- `former legacy declarations` → `former declarations`
- `split out of / from the legacy` → `split out of / from the
  original`
- `legacy-compatible` → `compatibility-named`
- `legacy \`Inequalities\` import path` → `original \`Inequalities\`
  import path`
- Several other one-off "legacy X" phrasings → "original X"

No theorem statements, definitions, declarations, or proofs are
touched — this is a doc-comment-only sweep.

Rationale: paired with #2561 and #2562 (which deleted the
`AmbientLattice/SpecialCases/Legacy.lean` and
`Concrete/LatticeGraphCorrelation/Legacy.lean` shims), this removes
the last trace of the `Legacy` naming from the codebase in response
to the user's complaint that the leftover comment references read
as a "trash heap" terminology even after the shim files were gone.

## Test plan

- [x] `lake build` — succeeded (3639 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] `grep -in 'legacy\|Legacy' IsingModel/` — 0 matches
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)