### PR TITLE
refactor: split ambient FE AnalyticityHZero AnalyticOnNhd wrappers

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -2,6 +2,7 @@ import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZero
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZeroOnNhd
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityOnNhd
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyHighTempExp
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyHSymmetry

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticityHZero.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticityHZero.lean
@@ -1,19 +1,21 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZeroOnNhd
 
 /-!
-# Ambient freeEnergyAlongExhaustion h=0 analyticity wrappers
+# Ambient freeEnergyAlongExhaustion h=0 `AnalyticAt` wrappers
 
-Narrow child module for 4 ambient
-`freeEnergyAlongExhaustion_analytic*_*_h_zero` analyticity wrappers
-extracted from `FreeEnergyAnalyticity.lean`:
+Narrow child module for the two ambient
+`freeEnergyAlongExhaustion_analyticAt_*_h_zero` wrappers extracted
+from `FreeEnergyAnalyticity.lean`:
 
 * `freeEnergyAlongExhaustion_analyticAt_beta_h_zero`,
-* `freeEnergyAlongExhaustion_analyticAt_J_h_zero`,
-* `freeEnergyAlongExhaustion_analyticOnNhd_beta_h_zero`,
-* `freeEnergyAlongExhaustion_analyticOnNhd_J_h_zero`.
+* `freeEnergyAlongExhaustion_analyticAt_J_h_zero`.
 
-Each result is a thin pass-through of the corresponding Λ-level
+The two corresponding `AnalyticOnNhd` wrappers now live in
+`IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZeroOnNhd`
+and are re-imported through this parent module. Each result is a
+thin pass-through of the corresponding Λ-level
 `freeEnergyΛ_analytic*_*_h_zero` lemma. The theorem names are
 unchanged from the former `FreeEnergyAnalyticity` declarations.
 -/
@@ -42,25 +44,14 @@ theorem freeEnergyAlongExhaustion_analyticAt_J_h_zero
       freeEnergyAlongExhaustion G Λ ⟨J', 0, β⟩ n) J :=
   freeEnergyΛ_analyticAt_J_h_zero G (Λ.volume n) β J
 
-/-- **Along-ex: freeEnergy `AnalyticOnNhd ℝ _ Set.univ` in `β` at
-`h = 0`**. -/
-theorem freeEnergyAlongExhaustion_analyticOnNhd_beta_h_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J : ℝ) (n : ℕ) :
-    AnalyticOnNhd ℝ (fun β' : ℝ =>
-      freeEnergyAlongExhaustion G Λ ⟨J, 0, β'⟩ n) Set.univ :=
-  freeEnergyΛ_analyticOnNhd_beta_h_zero G (Λ.volume n) J
+/-! ## Moved: 2 `AnalyticOnNhd` h=0 wrappers
 
-/-- **Along-ex: freeEnergy `AnalyticOnNhd ℝ _ Set.univ` in `J` at
-`h = 0`**. -/
-theorem freeEnergyAlongExhaustion_analyticOnNhd_J_h_zero
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (β : ℝ) (n : ℕ) :
-    AnalyticOnNhd ℝ (fun J' : ℝ =>
-      freeEnergyAlongExhaustion G Λ ⟨J', 0, β⟩ n) Set.univ :=
-  freeEnergyΛ_analyticOnNhd_J_h_zero G (Λ.volume n) β
+The two `freeEnergyAlongExhaustion_analyticOnNhd_*_h_zero` wrappers
+(`_beta_h_zero`, `_J_h_zero`) now live in
+`IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZeroOnNhd`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
+-/
 
 end Ambient
 end IsingModel

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticityHZeroOnNhd.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticityHZeroOnNhd.lean
@@ -1,0 +1,45 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Ambient freeEnergyAlongExhaustion h=0 `AnalyticOnNhd` wrappers
+
+Narrow child module for the two ambient
+`freeEnergyAlongExhaustion_analyticOnNhd_*_h_zero` wrappers
+extracted from `FreeEnergyAnalyticityHZero.lean`:
+
+* `freeEnergyAlongExhaustion_analyticOnNhd_beta_h_zero`
+* `freeEnergyAlongExhaustion_analyticOnNhd_J_h_zero`
+
+Each result is a thin pass-through of the corresponding Λ-level
+`freeEnergyΛ_analyticOnNhd_*_h_zero` lemma. The theorem names are
+unchanged from the former `FreeEnergyAnalyticity` declarations.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: freeEnergy `AnalyticOnNhd ℝ _ Set.univ` in `β` at
+`h = 0`**. -/
+theorem freeEnergyAlongExhaustion_analyticOnNhd_beta_h_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J : ℝ) (n : ℕ) :
+    AnalyticOnNhd ℝ (fun β' : ℝ =>
+      freeEnergyAlongExhaustion G Λ ⟨J, 0, β'⟩ n) Set.univ :=
+  freeEnergyΛ_analyticOnNhd_beta_h_zero G (Λ.volume n) J
+
+/-- **Along-ex: freeEnergy `AnalyticOnNhd ℝ _ Set.univ` in `J` at
+`h = 0`**. -/
+theorem freeEnergyAlongExhaustion_analyticOnNhd_J_h_zero
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (β : ℝ) (n : ℕ) :
+    AnalyticOnNhd ℝ (fun J' : ℝ =>
+      freeEnergyAlongExhaustion G Λ ⟨J', 0, β⟩ n) Set.univ :=
+  freeEnergyΛ_analyticOnNhd_J_h_zero G (Λ.volume n) β
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2600) by extracting the two §17.6-§17.7 ambient
`freeEnergyAlongExhaustion_analyticOnNhd_*_h_zero` wrappers from
`FreeEnergyAnalyticityHZero.lean` into a new narrow child module
`FreeEnergyAnalyticityHZeroOnNhd.lean`:

- `freeEnergyAlongExhaustion_analyticOnNhd_beta_h_zero`
- `freeEnergyAlongExhaustion_analyticOnNhd_J_h_zero`

Each wrapper is a thin pass-through to the corresponding Λ-level
`freeEnergyΛ_analyticOnNhd_*_h_zero` lemma. Theorem
statements/signatures/doc comments are byte-identical to the
previous declarations. Theorem names are unchanged.

The parent re-imports the new child to preserve the earlier import
path, and the umbrella `SpecialCases.lean` is updated to import
the new child. After the split the parent retains only the two
`AnalyticAt` h=0 wrappers, making it a coherent single-purpose
module organized around the `AnalyticAt ℝ` h=0 family.

## Test plan

- [x] `lake build` — succeeded (3647 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)