### PR TITLE
refactor: split ambient FE Analyticity AnalyticAt h wrapper

### DIFF
--- a/IsingModel/AmbientLattice/SpecialCases.lean
+++ b/IsingModel/AmbientLattice/SpecialCases.lean
@@ -1,6 +1,7 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticity
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityAtH
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZero
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZeroOnNhd
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityOnNhd

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticity.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticity.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Analyticity
 import IsingModel.AmbientLattice.Exhaustion
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityAtH
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityHZero
 import IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityOnNhd
 
@@ -46,14 +47,13 @@ theorem freeEnergyAlongExhaustion_analyticAt_J_general_h
       freeEnergyAlongExhaustion G Λ ⟨J', h, β⟩ n) J :=
   freeEnergyΛ_analyticAt_J_general_h G (Λ.volume n) β h J
 
-/-- **Along-ex: freeEnergy `AnalyticAt ℝ` in `h`**. -/
-theorem freeEnergyAlongExhaustion_analyticAt_h
-    (G : SimpleGraph V) (Λ : Exhaustion V)
-    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
-    (J β h : ℝ) (n : ℕ) :
-    AnalyticAt ℝ (fun h' : ℝ =>
-      freeEnergyAlongExhaustion G Λ ⟨J, h', β⟩ n) h :=
-  freeEnergyΛ_analyticAt_h G (Λ.volume n) J β h
+/-! ## Moved: 1 AnalyticAt `h` wrapper
+
+The `freeEnergyAlongExhaustion_analyticAt_h` wrapper now lives in
+`IsingModel.AmbientLattice.SpecialCases.FreeEnergyAnalyticityAtH`.
+The earlier import path is preserved by re-exporting the new child
+from this parent module and from the umbrella `SpecialCases.lean`.
+-/
 
 /-! ## Moved: freeEnergyAlongExhaustion AnalyticOnNhd general-h wrappers
 

--- a/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticityAtH.lean
+++ b/IsingModel/AmbientLattice/SpecialCases/FreeEnergyAnalyticityAtH.lean
@@ -1,0 +1,31 @@
+import IsingModel.AmbientLattice.Analyticity
+import IsingModel.AmbientLattice.Exhaustion
+
+/-!
+# Ambient freeEnergyAlongExhaustion AnalyticAt in `h`
+
+Narrow child module for the ambient
+`freeEnergyAlongExhaustion_analyticAt_h` wrapper extracted from
+`FreeEnergyAnalyticity.lean`.
+
+The result is a thin pass-through of the Λ-level
+`freeEnergyΛ_analyticAt_h` lemma. The theorem name is unchanged
+from the former `FreeEnergyAnalyticity` declaration.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+variable {V : Type*} [DecidableEq V]
+
+/-- **Along-ex: freeEnergy `AnalyticAt ℝ` in `h`**. -/
+theorem freeEnergyAlongExhaustion_analyticAt_h
+    (G : SimpleGraph V) (Λ : Exhaustion V)
+    [∀ n, Fintype (inducedGraph G (Λ.volume n)).edgeSet]
+    (J β h : ℝ) (n : ℕ) :
+    AnalyticAt ℝ (fun h' : ℝ =>
+      freeEnergyAlongExhaustion G Λ ⟨J, h', β⟩ n) h :=
+  freeEnergyΛ_analyticAt_h G (Λ.volume n) J β h
+
+end Ambient
+end IsingModel


### PR DESCRIPTION
## Summary

Continues the AmbientLattice/SpecialCases wrapper-split refactoring loop
(after #2605) by extracting the ambient
`freeEnergyAlongExhaustion_analyticAt_h` h-direction wrapper from
`FreeEnergyAnalyticity.lean` into a new narrow child module
`FreeEnergyAnalyticityAtH.lean`.

The wrapper is a thin pass-through to the Λ-level
`freeEnergyΛ_analyticAt_h` lemma. Theorem statement, signature, and
doc comment are byte-identical to the previous declaration. Theorem
name unchanged.

The parent re-imports the new child to preserve the earlier import
path, and the umbrella `SpecialCases.lean` is updated to import
the new child. After the split the parent retains only the two
`AnalyticAt` β/J general-h wrappers.

## Test plan

- [x] `lake build` — succeeded (3652 jobs, no warnings)
- [x] `lake exe GKSTest` — All tests passed
- [x] `grep -rn sorry IsingModel` — 0
- [x] No new linter warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)