### PR TITLE
Narrow ambient lattice conditioning imports

### DIFF
--- a/IsingModel/AmbientLattice/Defs/Core.lean
+++ b/IsingModel/AmbientLattice/Defs/Core.lean
@@ -1,7 +1,7 @@
 import IsingModel.InfiniteVolume
 import IsingModel.FreeEnergy
 import IsingModel.Inequalities.GHS
-import IsingModel.Conditioning
+import IsingModel.Conditioning.Bounds
 import IsingModel.PhaseTransition
 import IsingModel.FieldDerivative
 

--- a/IsingModel/AmbientLattice/Defs/HighTempCorrelation.lean
+++ b/IsingModel/AmbientLattice/Defs/HighTempCorrelation.lean
@@ -1,5 +1,6 @@
 import IsingModel.AmbientLattice.Defs.HighTempPartition
 import IsingModel.AmbientLattice.Defs.Correlation
+import IsingModel.Conditioning.CorrelationRates
 
 /-!
 # Ambient lattice high-temperature correlations

--- a/IsingModel/AmbientLattice/Defs/HighTempPartition.lean
+++ b/IsingModel/AmbientLattice/Defs/HighTempPartition.lean
@@ -1,4 +1,5 @@
 import IsingModel.AmbientLattice.Defs.Core
+import IsingModel.Conditioning.CorrelationClosed
 
 /-!
 # Ambient lattice high-temperature partition bounds

--- a/IsingModel/AmbientLattice/SpontaneousMono.lean
+++ b/IsingModel/AmbientLattice/SpontaneousMono.lean
@@ -1,4 +1,5 @@
 import IsingModel.AmbientLattice.TruncatedFunctions
+import IsingModel.Conditioning.FreeEnergyBound
 
 /-!
 # Parameter monotonicity of spontaneous observables + Cor 4.3.5 at ∞-volume


### PR DESCRIPTION
Part of #1850

Summary:
- replace the AmbientLattice.Defs.Core dependency on the Conditioning umbrella with Conditioning.Bounds
- add explicit high-temperature Conditioning imports to the ambient high-temperature wrapper modules that use those declarations
- add an explicit FreeEnergyBound import where spontaneous monotonicity uses freeEnergy_upper_bound
- keep the finite-volume core and parent compatibility umbrella building without transitive high-temperature conditioning imports through Core

Verification:
- lake build IsingModel.AmbientLattice.Defs.Core IsingModel.AmbientLattice.Defs.Correlation IsingModel.AmbientLattice.Defs.HighTempPartition IsingModel.AmbientLattice.Defs.HighTempCorrelation IsingModel.AmbientLattice.Defs.Regularity IsingModel.AmbientLattice.Defs
- lake build IsingModel.AmbientLattice.SpontaneousMono
- lake build
- lake exe GKSTest
- git diff --check
- git diff --cached --check
- rg -n -w 'sorry|admit' IsingModel/AmbientLattice/Defs/Core.lean IsingModel/AmbientLattice/Defs/HighTempPartition.lean IsingModel/AmbientLattice/Defs/HighTempCorrelation.lean IsingModel/AmbientLattice/SpontaneousMono.lean