### PR TITLE
Drop ambient lattice conditioning umbrella import

### DIFF
--- a/IsingModel/AmbientLattice.lean
+++ b/IsingModel/AmbientLattice.lean
@@ -19,7 +19,6 @@ import IsingModel.AmbientLattice.Analyticity
 import IsingModel.InfiniteVolume
 import IsingModel.FreeEnergy
 import IsingModel.Inequalities.GHS
-import IsingModel.Conditioning
 import IsingModel.PhaseTransition
 import IsingModel.FieldDerivative
 


### PR DESCRIPTION
Part of #1850

Summary:
- remove the direct IsingModel.Conditioning compatibility-umbrella import from IsingModel.AmbientLattice
- rely on the split ambient child modules to import the narrower Conditioning modules they actually use
- keep the top-level AmbientLattice compatibility umbrella building without an extra broad Conditioning edge

Verification:
- lake build IsingModel.AmbientLattice
- lake build
- lake exe GKSTest
- git diff --check
- git diff --cached --check
- rg -n -w 'sorry|admit' IsingModel/AmbientLattice.lean
- read-only Codex cross-check: no blocking findings