### PR TITLE
Move cluster expansion conditioning import

### DIFF
--- a/IsingModel/ClusterExpansion/Basic.lean
+++ b/IsingModel/ClusterExpansion/Basic.lean
@@ -1,4 +1,3 @@
-import IsingModel.Conditioning
 import IsingModel.PhaseTransition
 import Mathlib.Combinatorics.SimpleGraph.Hasse
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Finite

--- a/IsingModel/ClusterExpansion/Families.lean
+++ b/IsingModel/ClusterExpansion/Families.lean
@@ -1,4 +1,5 @@
 import IsingModel.ClusterExpansion.Incompatibility
+import IsingModel.Conditioning.HighTempClosed
 
 /-!
 # Cluster expansion compatible families and polymer sums


### PR DESCRIPTION
Part of #1850

Summary:
- remove the IsingModel.Conditioning compatibility-umbrella import from ClusterExpansion.Basic
- add an explicit Conditioning.HighTempClosed import to ClusterExpansion.Families, where the high-temperature closed-form declarations are used
- keep ClusterExpansion.Basic importable without the full Conditioning umbrella

Verification:
- lake build IsingModel.ClusterExpansion.Basic IsingModel.ClusterExpansion.Families IsingModel.ClusterExpansion
- lake build
- lake exe GKSTest
- git diff --check
- git diff --cached --check
- rg -n -w 'sorry|admit' IsingModel/ClusterExpansion/Basic.lean IsingModel/ClusterExpansion/Families.lean
- read-only Codex cross-check: no blocking findings