### PR TITLE
Package Lemma 17.5.2 all-rate upper bridge

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CubicHighTemp.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CubicHighTemp.lean
@@ -157,6 +157,58 @@ theorem lemma_17_5_2_cubic_high_temp_upper_bound_of_active_range
         ENNReal.ofReal (cubicOriginPseudoMassFromParamsAtPair hα hr β J z) :=
           hmul.symm
 
+/-- **GJ §17.5 Lemma 17.5.2 finite all-rate upper bridge, cubic
+high-temperature form**: the finite Step 115 upper-bound bridge also controls
+every admissible nonnegative exponential decay rate. This is the all-rate
+target shape consumed by the order-theoretic upper-bound assembly.
+
+The constant is the finite high-temperature constant
+`-log(tanh(βJ)) / m⁻`, not the HLS-uniform constant from the book. -/
+theorem lemma_17_5_2_cubic_high_temp_all_decay_rates_le_of_active_range
+    {α d : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) (hd : 0 < d)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
+                      ((Ambient.cubicExhaustion d).volume n)).edgeSet]
+    {β J : ℝ} (hJ : 0 < J) (hβ : 0 < β) {z : Fin d → ℤ}
+    (hcorr_cubic :
+      Ambient.correlationInfinite (IsingModel.latticeGraph d)
+          (Ambient.cubicExhaustion d) (⟨J, 0, β⟩ : IsingParams ℝ)
+            {(0 : Fin d → ℤ), z} ∈ Set.Ioo (0 : ℝ) 2)
+    (a : NNReal)
+    (hdecay : HasExponentialDecay d Λ (⟨J, 0, β⟩ : IsingParams ℝ) (a : ℝ)) :
+    (a : ENNReal) ≤
+      ENNReal.ofReal
+          (-Real.log (Real.tanh (β * J)) /
+            cubicOriginPseudoMassFromParamsAtPair hα hr β J z) *
+        ENNReal.ofReal (cubicOriginPseudoMassFromParamsAtPair hα hr β J z) := by
+  have hf : Ferromagnetic (⟨J, 0, β⟩ : IsingParams ℝ) := ⟨hJ.le, le_refl 0, hβ⟩
+  have hpm_eq :
+      pseudoMassFromParamsAtPair hα hr d Λ
+          (⟨J, 0, β⟩ : IsingParams ℝ) (0 : Fin d → ℤ) z =
+        cubicOriginPseudoMassFromParamsAtPair hα hr β J z := by
+    calc
+      pseudoMassFromParamsAtPair hα hr d Λ
+          (⟨J, 0, β⟩ : IsingParams ℝ) (0 : Fin d → ℤ) z =
+        pseudoMassFromParamsAtPair hα hr d (Ambient.cubicExhaustion d)
+          (⟨J, 0, β⟩ : IsingParams ℝ) (0 : Fin d → ℤ) z :=
+          pseudoMassFromParamsAtPair_indep_exhaustion hα hr d Λ
+            (Ambient.cubicExhaustion d) (⟨J, 0, β⟩ : IsingParams ℝ) hf
+            (0 : Fin d → ℤ) z
+      _ = cubicOriginPseudoMassFromParamsAtPair hα hr β J z :=
+          (cubicOriginPseudoMassFromParamsAtPair_eq hα hr β J z).symm
+  have hupper :=
+    lemma_17_5_2_cubic_high_temp_upper_bound_of_active_range
+      hα hr hd Λ hJ hβ hcorr_cubic
+  have hall :=
+    (lemma_17_5_2_upper_bound_iff_all_decay_rates_le hα hr Λ J β
+      (0 : Fin d → ℤ) z
+      (ENNReal.ofReal
+        (-Real.log (Real.tanh (β * J)) /
+          cubicOriginPseudoMassFromParamsAtPair hα hr β J z))).mp hupper
+  have hres := hall a hdecay
+  rw [hpm_eq] at hres
+  simpa using hres
+
 /-- **GJ §17.5 Lemma 17.5.2 finite sandwich capstone, cubic high-temperature
 form**: combining the existing cubic lower-bound capstone with the finite
 Step 115 upper-bound bridge gives an actual two-sided sandwich

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Predicates.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Predicates.lean
@@ -73,6 +73,38 @@ theorem lemma_17_5_2_upper_bound_of_all_decay_rates_le
   rintro b ⟨a, ha, rfl⟩
   exact hdecay_le a ha
 
+/-- **GJ §17.5 Lemma 17.5.2 upper-bound equivalence**: the named upper-bound
+predicate is equivalent to bounding every validating nonnegative exponential
+decay rate by `C · ofReal m⁻`.
+
+This exposes the exact target shape needed by the future HLS argument: prove
+the all-rate estimate, and the `latticeMass` upper-bound side follows by the
+`sSup` definition; conversely, any closed upper-bound predicate immediately
+controls every admissible decay rate. -/
+theorem lemma_17_5_2_upper_bound_iff_all_decay_rates_le
+    {α d : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
+                      (Λ.volume n)).edgeSet]
+    (J β : ℝ) (x z : Fin d → ℤ) (C : ENNReal) :
+    Lemma_17_5_2_UpperBound hα hr Λ J β x z C ↔
+      ∀ a : NNReal,
+        HasExponentialDecay d Λ (⟨J, 0, β⟩ : IsingParams ℝ) (a : ℝ) →
+          (a : ENNReal) ≤
+            C * ENNReal.ofReal
+              (pseudoMassFromParamsAtPair hα hr d Λ
+                (⟨J, 0, β⟩ : IsingParams ℝ) x z) := by
+  constructor
+  · intro hupper a hdecay
+    have ha_mass :
+        (a : ENNReal) ≤ latticeMass d Λ (⟨J, 0, β⟩ : IsingParams ℝ) := by
+      simpa [ENNReal.ofReal_coe_nnreal] using
+        latticeMass_ge_of_HasExponentialDecay (show 0 ≤ (a : ℝ) from a.2) hdecay
+    exact ha_mass.trans hupper
+  · intro hdecay_le
+    exact lemma_17_5_2_upper_bound_of_all_decay_rates_le
+      hα hr Λ J β x z C hdecay_le
+
 /-- **GJ §17.5 Lemma 17.5.2 lower-bound side (named alias)**: if the concrete
 pseudo-mass associated to the pair `(x, z)` at `h = 0` validates exponential
 decay of `truncated2Infinite`, then `ENNReal.ofReal m⁻ ≤ latticeMass`.


### PR DESCRIPTION
## Summary
- add an equivalence between the named Lemma 17.5.2 upper-bound predicate and the all-admissible-decay-rate upper estimate
- add the cubic high-temperature finite all-rate bridge derived from the existing Step 115 upper-bound capstone
- keep the new bridge explicitly finite high-temperature; it does not claim the HLS-uniform constant

## Verification
- lake build IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.Predicates IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.CubicHighTemp
- lake build IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2
- lake exe GKSTest
- git diff --check
- rg -n "\b(sorry|admit)\b" IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Predicates.lean IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CubicHighTemp.lean
- rg -n "[ぁ-んァ-ン一-龯]" IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Predicates.lean IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CubicHighTemp.lean

Existing warning replayed during Lean builds: IsingModel/AmbientLattice/Defs/Regularity/HasDerivBasic.lean:4 longLine.

Closes part of #1645.