### PR TITLE
Package Lemma 17.5.2 HLS conditional sandwich

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Lipschitz.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Lipschitz.lean
@@ -334,5 +334,58 @@ theorem lemma_17_5_2_hls_sandwich_of_decay_and_all_decay_rates_le
   exact lemma_17_5_2_sandwich_of_decay_and_upper hα hr hdecay
     (hupper hdecay_le)
 
+/-- **GJ §17.5 Lemma 17.5.2 cubic high-temperature HLS-constant conditional
+sandwich**: combine the existing cubic high-temperature lower-bound capstone
+with the HLS convolution constant package. The remaining HLS input is exactly
+the all-admissible-decay-rate estimate for the returned constant `K`.
+
+This is the concrete cubic-exhaustion version of the HLS route toward the full
+Lemma 17.5.2 sandwich. It keeps the final analytic/HLS all-rate estimate as an
+explicit premise, rather than claiming the book's HLS-uniform upper side is
+already proved. -/
+theorem lemma_17_5_2_cubic_high_temp_hls_conditional_sandwich
+    {α d : ℕ} (hα : 1 ≤ α) (hαd : 2 * α > d) {r : ℝ} (hr : 0 < r)
+    (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
+                      ((Ambient.cubicExhaustion d).volume n)).edgeSet]
+    {β J : ℝ} (hJ : 0 ≤ J) (hβ : 0 < β)
+    (hlt : β * J * ↑(2 * d) < 1) {z : Fin d → ℤ}
+    (hinputs :
+      Ambient.correlationInfinite (IsingModel.latticeGraph d)
+          (Ambient.cubicExhaustion d) (⟨J, 0, β⟩ : IsingParams ℝ)
+            {(0 : Fin d → ℤ), z} ∈ Set.Ioo (0 : ℝ) 2 ∧
+        pseudoMassG α r (-Real.log (β * J * ↑(2 * d))) ≤
+          Ambient.correlationInfinite (IsingModel.latticeGraph d)
+            (Ambient.cubicExhaustion d) (⟨J, 0, β⟩ : IsingParams ℝ)
+              {(0 : Fin d → ℤ), z}) :
+    ∃ K : ℝ, 0 < K ∧
+      (∀ x' y' : Fin d → ℤ,
+        ∑' w : Fin d → ℤ,
+            (1 + latticeDistance d x' w : ℝ) ^ (-(α : ℝ)) *
+            (1 + latticeDistance d y' w : ℝ) ^ (-(α : ℝ)) ≤ K) ∧
+      ((∀ a : NNReal,
+          HasExponentialDecay d Λ (⟨J, 0, β⟩ : IsingParams ℝ) (a : ℝ) →
+            (a : ENNReal) ≤
+              ENNReal.ofReal (((2 * α + 1 : ℕ) : ℝ) * K / r) *
+                ENNReal.ofReal
+                  (cubicOriginPseudoMassFromParamsAtPair hα hr β J z)) →
+        HasExponentialDecay d Λ (⟨J, 0, β⟩ : IsingParams ℝ)
+            (cubicOriginPseudoMassFromParamsAtPair hα hr β J z) ∧
+        ENNReal.ofReal (cubicOriginPseudoMassFromParamsAtPair hα hr β J z) ≤
+          latticeMass d Λ (⟨J, 0, β⟩ : IsingParams ℝ) ∧
+        latticeMass d Λ (⟨J, 0, β⟩ : IsingParams ℝ) ≤
+          ENNReal.ofReal (((2 * α + 1 : ℕ) : ℝ) * K / r) *
+            ENNReal.ofReal
+              (cubicOriginPseudoMassFromParamsAtPair hα hr β J z)) := by
+  obtain ⟨K, hK, hK_conv⟩ := lemma_17_5_2_hls_convolution_constant α d hαd
+  refine ⟨K, hK, hK_conv, fun hdecay_le => ?_⟩
+  have hlower :=
+    lemma_17_5_2_cubic_high_temp_lower_capstone hα hr Λ hJ hβ hlt hinputs
+  refine ⟨hlower.1, hlower.2.2, ?_⟩
+  dsimp [latticeMass]
+  apply sSup_le
+  rintro b ⟨a, ha, rfl⟩
+  exact hdecay_le a ha
+
 end Ambient
 end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Lipschitz.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Lipschitz.lean
@@ -288,5 +288,51 @@ theorem lemma_17_5_2_hls_upper_bound_of_all_decay_rates_le
   exact lemma_17_5_2_upper_bound_of_all_decay_rates_le hα hr Λ J β x z
     (ENNReal.ofReal (((2 * α + 1 : ℕ) : ℝ) * K / r)) hdecay_le
 
+/-- **GJ §17.5 Lemma 17.5.2 HLS-constant sandwich package**: once the
+pseudo-mass rate itself validates exponential decay, the same HLS convolution
+constant package reduces the full sandwich to the all-admissible-decay-rate
+upper estimate.
+
+This is the direct capstone shape for the remaining HLS proof: provide the
+all-rate premise for the returned constant `K`, and this theorem returns
+`ofReal m⁻ ≤ latticeMass ≤ ((2α+1)K/r) · ofReal m⁻`. -/
+theorem lemma_17_5_2_hls_sandwich_of_decay_and_all_decay_rates_le
+    {d α : ℕ} (hα : 1 ≤ α) (hαd : 2 * α > d)
+    {r : ℝ} (hr : 0 < r)
+    {Λ : Ambient.Exhaustion (Fin d → ℤ)}
+    [∀ n, Fintype (Ambient.inducedGraph (IsingModel.latticeGraph d)
+                      (Λ.volume n)).edgeSet]
+    {J β : ℝ} {x z : Fin d → ℤ}
+    (hdecay : HasExponentialDecay d Λ (⟨J, 0, β⟩ : IsingParams ℝ)
+      (pseudoMassFromParamsAtPair hα hr d Λ
+        (⟨J, 0, β⟩ : IsingParams ℝ) x z)) :
+    ∃ K : ℝ, 0 < K ∧
+      (∀ x' y' : Fin d → ℤ,
+        ∑' w : Fin d → ℤ,
+            (1 + latticeDistance d x' w : ℝ) ^ (-(α : ℝ)) *
+            (1 + latticeDistance d y' w : ℝ) ^ (-(α : ℝ)) ≤ K) ∧
+      ((∀ a : NNReal,
+          HasExponentialDecay d Λ (⟨J, 0, β⟩ : IsingParams ℝ) (a : ℝ) →
+            (a : ENNReal) ≤
+              ENNReal.ofReal (((2 * α + 1 : ℕ) : ℝ) * K / r) *
+                ENNReal.ofReal
+                  (pseudoMassFromParamsAtPair hα hr d Λ
+                    (⟨J, 0, β⟩ : IsingParams ℝ) x z)) →
+        ENNReal.ofReal
+            (pseudoMassFromParamsAtPair hα hr d Λ
+              (⟨J, 0, β⟩ : IsingParams ℝ) x z)
+          ≤ latticeMass d Λ (⟨J, 0, β⟩ : IsingParams ℝ) ∧
+        latticeMass d Λ (⟨J, 0, β⟩ : IsingParams ℝ) ≤
+          ENNReal.ofReal (((2 * α + 1 : ℕ) : ℝ) * K / r) *
+            ENNReal.ofReal
+              (pseudoMassFromParamsAtPair hα hr d Λ
+                (⟨J, 0, β⟩ : IsingParams ℝ) x z)) := by
+  obtain ⟨K, hK, hK_conv, hupper⟩ :=
+    lemma_17_5_2_hls_upper_bound_of_all_decay_rates_le
+      hα hαd hr Λ J β x z
+  refine ⟨K, hK, hK_conv, fun hdecay_le => ?_⟩
+  exact lemma_17_5_2_sandwich_of_decay_and_upper hα hr hdecay
+    (hupper hdecay_le)
+
 end Ambient
 end IsingModel


### PR DESCRIPTION
## Scope
This PR packages the GJ §17.5 Lemma 17.5.2 HLS-route conditional sandwich layer. It is not intended as a single Lean-theorem PR; the scope is the book-theorem milestone interface for the remaining HLS all-rate estimate.

## Summary
- Add `lemma_17_5_2_hls_sandwich_of_decay_and_all_decay_rates_le`, combining the HLS all-rate upper-bound package with the existing lower-bound decay hypothesis.
- Add `lemma_17_5_2_cubic_high_temp_hls_conditional_sandwich`, the concrete cubic high-temperature conditional sandwich shape for Lemma 17.5.2.
- Keep the final analytic/HLS all-admissible-decay-rate estimate explicit as a premise; this PR does not claim the full HLS-uniform upper bound is complete.

## Verification
- `lake build IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.Lipschitz IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2`
- `lake exe GKSTest`
- `git diff --check`
- touched-file `sorry` / `admit` grep: clean
- touched-file Japanese-text grep: clean

Existing warning replayed during Lean builds: `IsingModel/AmbientLattice/Defs/Regularity/HasDerivBasic.lean:4` longLine.

Part of #1645.
