### PR TITLE
Narrow Lemma 17.5.2 HLS constants imports

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/HLSConstants.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/HLSConstants.lean
@@ -1,4 +1,7 @@
-import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.CubicHighTemp
+import IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassFoundation
+import IsingModel.Concrete.LatticeGraphCorrelation.LatticeMassHighTempLipschitz.DerivBound
+import IsingModel.PolyDecay
+import IsingModel.PseudoMass.FromParamsBasic.BasicSlices
 
 /-!
 # GJ §17.5 Lemma 17.5.2 capstone — HLS constants and denominator comparisons

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Lipschitz.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/Lipschitz.lean
@@ -1,4 +1,5 @@
 import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.BetaDerivBridges
+import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.CubicHighTemp
 
 /-!
 # GJ §17.5 Lemma 17.5.2 capstone — interval Lipschitz bridges


### PR DESCRIPTION
## Summary
- Narrow `HLSConstants.lean` so it imports only the HLS, lattice-mass foundation, beta-derivative-bound, and pseudo-mass basics it actually uses.
- Add the explicit `CubicHighTemp.lean` import to `Lipschitz.lean`, where the cubic capstone and named-rate APIs are directly used.
- Keep the public theorem statements unchanged while preventing `BetaDerivBridges.lean` and `InfiniteDerivativeLimit.lean` from inheriting cubic capstone imports through `HLSConstants.lean`.

## Verification
- `lake build IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.HLSConstants`
- `lake build IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.HLSConstants IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.BetaDerivBridges IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.InfiniteDerivativeLimit IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.Lipschitz IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2`
- `git diff --check`
- touched Lean line-length check
- `lake exe GKSTest`
- `lake build`