### PR TITLE
WIP: refactor — clarify CE-route bundle is volume-uniform-only — #3054

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CEConditionalCapstone.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CEConditionalCapstone.lean
@@ -33,59 +33,53 @@ convergence, research-level); a centred circle bound on the correlation value
 increment (3) is the parallel open input from the Simon-Lieb hB side
 (Issue #3044).
 
-## Scope and structural limitation (IMPORTANT — read before using this file)
+## Scope: bundle is a structural bridge, not a proof of Lemma 17.5.2
 
 The CE-route bundles defined here (`CERouteIccGeometricIncrement`,
-`CERouteIccPolyGeometricIncrement`, and the ~42 derived one-step wrappers) are
-designed as **structural bridges from volume-uniform complex circle bounds to
-summable derivative increments**. They are NOT a complete proof of Lemma 17.5.2
-on their own.
+`CERouteIccPolyGeometricIncrement`, and the derived one-step wrappers) are
+**structural bridges from a per-`(β, k)` complex circle bound to a summable
+derivative increment** (consumed by `IncrementCapstone.lean`). The bundles
+are abstract: each entry point accepts user-supplied data (radius `r`, sphere
+bound `B`, ne-zero hypotheses, optionally `R_inc` / `C_k`) and verifies the
+smallness `B / r ≤ M · ratio^k`. The data themselves must come from elsewhere.
 
-**Why the per-fixed-volume convenience entry points (`_of_trivial_Q_smallness_h_zero`,
-`_of_canonical_radius_*`, `_of_R_inc_lipschitz`, `_of_R_inc_uniform_C`,
-`_of_sequence`, `_of_geometric`) do NOT close Lemma 17.5.2 at fixed volume:**
+**Current limitation of the Cauchy-derived data:** If the per-stage Lipschitz
+constants `C_k`, `C_{k+1}` are supplied via `correlationComplex_lipschitz_on_closedBall`
+(PR #3124) using the Cauchy estimate `correlationComplex_norm_deriv_le_of_norm_le_on_sphere`
+(#3052), the resulting `C_k` are **bounded below by `M_real / z_min / R_cauchy`**.
+For the unconditional per-fixed-volume route at `h = 0` (trivial-Q smallness),
+the available disc radius `r = canonicalTrivialQRadiusPair Λ J k = O(1/|Λ_k|)`
+shrinks with the volume, and so does any Cauchy radius `R_cauchy ≤ r`, giving
+`C_k → ∞` rather than `0`. After the triangle decomposition
+`B ≤ R_inc + (C_k + C_{k+1}) · r` from `sphere_circle_bound_of_real_inc_and_lipschitz`,
+the smallness reduces to `R_inc / r + (C_k + C_{k+1}) ≤ M · ratio^k → 0`,
+which the non-decaying `(C_k + C_{k+1})` term cannot satisfy. **No code in this
+file is mathematically unsatisfiable** — the bundles accept any abstract
+`(R_inc, C_k)`; the limitation is in the available *concrete* data, not the
+abstract interface.
 
-The bundle smallness condition has the form
+**Where the bundles DO close Lemma 17.5.2:**
 
-  `B / r ≤ M · ratio^k`  (or `M · (2k+3)^d · ratio^k` for poly-geometric)
+When the user can supply either of:
 
-After the standard triangle decomposition
-`B ≤ R_inc + (C_k + C_{k+1}) · r` (sphere bound from real-axis increment plus
-Lipschitz, `sphere_circle_bound_of_real_inc_and_lipschitz`), the smallness
-becomes
+* **Volume-uniform disc radius** `r` (constant in `k`) together with
+  volume-uniform `Z_ℂ ≠ 0` on that disc — requires complex
+  cluster-expansion convergence (research-level open input, Issue #3054).
+  With constant `r`, the Cauchy Lipschitz at radius `r` is volume-uniform
+  but still constant; combined with a volume-uniform geometric-decay circle
+  bound `B` (Issue #3044, complex Simon-Lieb), the smallness closes.
 
-  `R_inc / r + (C_k + C_{k+1}) ≤ M · ratio^k`.
+* **Decaying abstract Lipschitz** `C_k → 0` (not from the simple Cauchy
+  estimate; e.g., from a finer complex analysis input). The bundle is
+  agnostic about how `C_k` is produced.
 
-For the per-fixed-volume Cauchy entry (trivial-Q smallness at `h = 0`), the
-disc radius `r = canonicalTrivialQRadiusPair Λ J k = O(1/|Λ_k|)` shrinks with
-the volume. The Cauchy Lipschitz constant `C_k` from
-`correlationComplex_lipschitz_on_closedBall` is bounded below by a positive
-constant (volume-uniform Cauchy gives `C ~ M_real / z_min / R_outer ≥ const`),
-so `(C_k + C_{k+1})` does NOT decay to zero. But `M · ratio^k → 0` as
-`k → ∞` (`ratio < 1`). **The smallness is therefore mathematically
-unsatisfiable in this regime** — see the discussion in `.self-local/docs/SESSION-RESUME.md`
-and the codex review attached to PR #3125.
-
-**Where these bundles DO close Lemma 17.5.2:**
-
-The bundle smallness IS satisfiable when both of:
-* The disc radius `r` is **volume-uniform** (constant in `k`) — requires
-  volume-uniform `Z_ℂ ≠ 0` on a constant disc, which is the research-level
-  open problem (complex cluster-expansion convergence, Issue #3054).
-* The complex circle bound `B` is **volume-uniform geometric-decay** —
-  Issue #3044 (complex Simon-Lieb / hB provider).
-
-Once both are supplied, the bundle composes them into the final Lemma 17.5.2
-sandwich. **All current per-fixed-volume "convenience" entry points are
-structural composers, not capstones in the per-fixed-volume regime.**
-
-For users with a direct increment bound (e.g., supplied externally without
-going through the Cauchy decomposition), see
+For users with a **direct increment bound** (`dist(∂_β c_k, ∂_β c_{k+1}) ≤
+M · ratio^k` already in hand from any other route), see
 `lemma_17_5_2_{upper_bound,capstone}_of_{geometric,poly_geometric}_increments_on_covered_stages`
-in `IncrementCapstone.lean` — these take `hincr` directly as input and bypass
-the CE-route bundle entirely. The CE-route here is one of several routes to
-producing `hincr`; it is the natural one when `hincr` is to be derived from
-complex analyticity + Cauchy estimate.
+in `IncrementCapstone.lean` — these take `hincr` directly and bypass the
+CE-route bundle entirely. The CE-route here is the natural assembly when
+`hincr` is to be derived from complex analyticity + Cauchy estimate, but it
+is not the only assembly.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CEConditionalCapstone.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CEConditionalCapstone.lean
@@ -32,6 +32,60 @@ The two volume-uniform CE inputs (1)-(2) remain open (complex cluster-expansion
 convergence, research-level); a centred circle bound on the correlation value
 increment (3) is the parallel open input from the Simon-Lieb hB side
 (Issue #3044).
+
+## Scope and structural limitation (IMPORTANT — read before using this file)
+
+The CE-route bundles defined here (`CERouteIccGeometricIncrement`,
+`CERouteIccPolyGeometricIncrement`, and the ~42 derived one-step wrappers) are
+designed as **structural bridges from volume-uniform complex circle bounds to
+summable derivative increments**. They are NOT a complete proof of Lemma 17.5.2
+on their own.
+
+**Why the per-fixed-volume convenience entry points (`_of_trivial_Q_smallness_h_zero`,
+`_of_canonical_radius_*`, `_of_R_inc_lipschitz`, `_of_R_inc_uniform_C`,
+`_of_sequence`, `_of_geometric`) do NOT close Lemma 17.5.2 at fixed volume:**
+
+The bundle smallness condition has the form
+
+  `B / r ≤ M · ratio^k`  (or `M · (2k+3)^d · ratio^k` for poly-geometric)
+
+After the standard triangle decomposition
+`B ≤ R_inc + (C_k + C_{k+1}) · r` (sphere bound from real-axis increment plus
+Lipschitz, `sphere_circle_bound_of_real_inc_and_lipschitz`), the smallness
+becomes
+
+  `R_inc / r + (C_k + C_{k+1}) ≤ M · ratio^k`.
+
+For the per-fixed-volume Cauchy entry (trivial-Q smallness at `h = 0`), the
+disc radius `r = canonicalTrivialQRadiusPair Λ J k = O(1/|Λ_k|)` shrinks with
+the volume. The Cauchy Lipschitz constant `C_k` from
+`correlationComplex_lipschitz_on_closedBall` is bounded below by a positive
+constant (volume-uniform Cauchy gives `C ~ M_real / z_min / R_outer ≥ const`),
+so `(C_k + C_{k+1})` does NOT decay to zero. But `M · ratio^k → 0` as
+`k → ∞` (`ratio < 1`). **The smallness is therefore mathematically
+unsatisfiable in this regime** — see the discussion in `.self-local/docs/SESSION-RESUME.md`
+and the codex review attached to PR #3125.
+
+**Where these bundles DO close Lemma 17.5.2:**
+
+The bundle smallness IS satisfiable when both of:
+* The disc radius `r` is **volume-uniform** (constant in `k`) — requires
+  volume-uniform `Z_ℂ ≠ 0` on a constant disc, which is the research-level
+  open problem (complex cluster-expansion convergence, Issue #3054).
+* The complex circle bound `B` is **volume-uniform geometric-decay** —
+  Issue #3044 (complex Simon-Lieb / hB provider).
+
+Once both are supplied, the bundle composes them into the final Lemma 17.5.2
+sandwich. **All current per-fixed-volume "convenience" entry points are
+structural composers, not capstones in the per-fixed-volume regime.**
+
+For users with a direct increment bound (e.g., supplied externally without
+going through the Cauchy decomposition), see
+`lemma_17_5_2_{upper_bound,capstone}_of_{geometric,poly_geometric}_increments_on_covered_stages`
+in `IncrementCapstone.lean` — these take `hincr` directly as input and bypass
+the CE-route bundle entirely. The CE-route here is one of several routes to
+producing `hincr`; it is the natural one when `hincr` is to be derived from
+complex analyticity + Cauchy estimate.
 -/
 
 namespace IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CEConditionalCapstone.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2/CEConditionalCapstone.lean
@@ -40,8 +40,10 @@ The CE-route bundles defined here (`CERouteIccGeometricIncrement`,
 **structural bridges from a per-`(β, k)` complex circle bound to a summable
 derivative increment** (consumed by `IncrementCapstone.lean`). The bundles
 are abstract: each entry point accepts user-supplied data (radius `r`, sphere
-bound `B`, ne-zero hypotheses, optionally `R_inc` / `C_k`) and verifies the
-smallness `B / r ≤ M · ratio^k`. The data themselves must come from elsewhere.
+bound `B`, ne-zero hypotheses, optionally `R_inc` / `C_k`) and verifies a
+smallness condition — `B / r ≤ M · ratio^k` for the geometric form, or
+`B / r ≤ M · (2k+3)^d · ratio^k` for the poly-geometric form. The data
+themselves must come from elsewhere.
 
 **Current limitation of the Cauchy-derived data:** If the per-stage Lipschitz
 constants `C_k`, `C_{k+1}` are supplied via `correlationComplex_lipschitz_on_closedBall`


### PR DESCRIPTION
Part of #3054.

Documentation refactor based on codex strategic analysis. Marks the CE-route bundle scope as volume-uniform-only without breaking API. See module doc comment for the full structural limitation explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)