### PR TITLE
GJ §4.3 Cor 4.3.3: |U_4^∞| ≤ pair-product sum on ℤ^d (h=0) — #1645

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/InfiniteVolumeCorrelationInequalities.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/InfiniteVolumeCorrelationInequalities.lean
@@ -67,5 +67,66 @@ theorem truncated4TwoPoint_ge_neg_pair_correlations_of_distinct
   truncated4Infinite_ge_neg_pair_correlations (IsingModel.latticeGraph d)
     (Ambient.cubicExhaustion d) J β hf hr hs hu hrs hru hsu
 
+/-- **GJ §4.3 Cor 4.3.3: `|U_4^∞| ≤ pair-product sum` on ℤ^d at `h = 0`**
+(Glimm–Jaffe 2nd ed., §4.3 Cor 4.3.3; §17.3 p. 308 eq. (17.3.1); §17.5 p. 312).
+
+For ferromagnetic `⟨J, 0, β⟩` and pairwise-distinct `r, s, u : Fin d → ℤ` (all three
+non-zero plus pairwise distinct), the Ursell 4-point function satisfies the absolute-value
+bound
+
+    |U_4^∞(0, r, s, u)| ≤ ⟨σ_0 σ_s⟩ · ⟨σ_r σ_u⟩ + ⟨σ_0 σ_u⟩ · ⟨σ_r σ_s⟩
+
+where each correlation is `correlationInfinite (latticeGraph d) (cubicExhaustion d) ⟨J,0,β⟩`.
+
+This is the form of Lebowitz's inequality (Cor 4.3.3) actually used in the GJ §17.5
+Theorem 17.5.1 proof on p. 312 to bound the numerator of `|x₀ - y₀| · dm⁻/dσ` by the sum
+of two-point cross products.
+
+Proof: combine `truncated4TwoPoint_nonpos_h_zero_of_distinct` (upper bound `U_4 ≤ 0`)
+with `truncated4TwoPoint_ge_neg_pair_correlations_of_distinct` (lower bound
+`-(<σ_0σ_s>·<σ_rσ_u> + <σ_0σ_u>·<σ_rσ_s>) ≤ U_4`). The pair products are non-negative
+(GKS-I), so the absolute value is the sum of the pair products by `abs_le`. -/
+theorem truncated4TwoPoint_abs_le_pair_correlations_of_distinct
+    (d : ℕ) (J β : ℝ) (hf : Ferromagnetic ⟨J, (0 : ℝ), β⟩)
+    {r s u : Fin d → ℤ}
+    (hr : (0 : Fin d → ℤ) ≠ r) (hs : (0 : Fin d → ℤ) ≠ s)
+    (hu : (0 : Fin d → ℤ) ≠ u)
+    (hrs : r ≠ s) (hru : r ≠ u) (hsu : s ≠ u) :
+    |truncated4TwoPoint d ⟨J, 0, β⟩ r s u| ≤
+      correlationInfinite (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d)
+          ⟨J, 0, β⟩ {0, s} *
+        correlationInfinite (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d)
+          ⟨J, 0, β⟩ {r, u} +
+      correlationInfinite (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d)
+          ⟨J, 0, β⟩ {0, u} *
+        correlationInfinite (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d)
+          ⟨J, 0, β⟩ {r, s} := by
+  have hnonpos := truncated4TwoPoint_nonpos_h_zero_of_distinct d J β hf hr hs hu hrs hru hsu
+  have hge := truncated4TwoPoint_ge_neg_pair_correlations_of_distinct
+    d J β hf hr hs hu hrs hru hsu
+  -- Set short names for the pair-product sum
+  set P : ℝ := correlationInfinite (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d)
+      ⟨J, 0, β⟩ {0, s} *
+    correlationInfinite (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d)
+      ⟨J, 0, β⟩ {r, u} +
+    correlationInfinite (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d)
+      ⟨J, 0, β⟩ {0, u} *
+    correlationInfinite (IsingModel.latticeGraph d) (Ambient.cubicExhaustion d)
+      ⟨J, 0, β⟩ {r, s}
+  -- Each correlation is nonneg by GKS-I, so each product is nonneg, so P ≥ 0
+  have h_corr_nn :
+      ∀ x y : Fin d → ℤ, 0 ≤ correlationInfinite (IsingModel.latticeGraph d)
+        (Ambient.cubicExhaustion d) ⟨J, 0, β⟩ {x, y} := by
+    intro x y
+    exact correlationInfinite_nonneg (IsingModel.latticeGraph d)
+      (Ambient.cubicExhaustion d) ⟨J, 0, β⟩ hf {x, y}
+  have hP_nn : 0 ≤ P :=
+    add_nonneg
+      (mul_nonneg (h_corr_nn 0 s) (h_corr_nn r u))
+      (mul_nonneg (h_corr_nn 0 u) (h_corr_nn r s))
+  -- Now `|U_4| ≤ P` follows from `-P ≤ U_4 ≤ 0 ≤ P` via abs_le
+  rw [abs_le]
+  exact ⟨by linarith [hge], by linarith [hnonpos]⟩
+
 end Ambient
 end IsingModel


### PR DESCRIPTION
Part of #1645 (GJ §17.5 Theorem 17.5.1 / Lemma 17.5.2 work plan, Step 119 — `.self-local/work/0119-theorem17-5-1-full.md`).

## Summary

Add concrete theorem `truncated4TwoPoint_abs_le_pair_correlations_of_distinct` in `IsingModel/Concrete/LatticeGraphCorrelation/InfiniteVolumeCorrelationInequalities.lean`:

For ferromagnetic `⟨J, 0, β⟩` and pairwise-distinct `{0, r, s, u} ⊂ ℤ^d`,

```
|U_4^∞(0, r, s, u)| ≤ ⟨σ_0σ_s⟩ · ⟨σ_rσ_u⟩ + ⟨σ_0σ_u⟩ · ⟨σ_rσ_s⟩
```

where each correlation is `correlationInfinite (latticeGraph d) (cubicExhaustion d) ⟨J,0,β⟩`.

This is the **Step 4 of the Step 119 plan** (Lebowitz IIIb application bounding the numerator of `|x₀-y₀|·dm⁻/dσ` by the pair-product sum, GJ §17.5 p. 312):

```
∂_β <σ_0σ_r> = ∑_z [<σ_0σ_r σ_z²> - <σ_0σ_r><σ_z²>]
              ≤ 2·A + 2·∑_z |U_4| ≤ 2·A + 2·∑_z [pair-product sum]   <-- this PR
```

## Proof

Combine existing `truncated4TwoPoint_nonpos_h_zero_of_distinct` (upper bound `U_4 ≤ 0`) with `truncated4TwoPoint_ge_neg_pair_correlations_of_distinct` (lower bound `-(pair products) ≤ U_4`), then use `correlationInfinite_nonneg` (GKS-I) so each pair-product is non-negative. Finally `abs_le` gives `|U_4| ≤ pair-product sum`.

## Files

* `IsingModel/Concrete/LatticeGraphCorrelation/InfiniteVolumeCorrelationInequalities.lean` (+1 theorem, 61 lines incl. doc)

## Verification

* `lake build`: success (2901 jobs)
* `lake exe GKSTest`: passes
* sorry count: 0
* linter warnings introduced: 0

## Next steps (per Step 119 plan)

* Step 5: HLS sum bound (`∑_z 1/((1+(m⁻|x₀-z|)^α)(1+(m⁻|y₀-z|)^α)) ≤ const·|x₀-y₀|^(d-α)·m⁻^(-2α)`).
* Step 6: Conclude `m⁻^(2α) · dm⁻/dσ ≤ const` → `m⁻^(2α+1)` Lipschitz.
* Final: combine with Lemma 17.5.2 sandwich → mass continuity.

## References

* Glimm–Jaffe, *Quantum Physics* (2nd ed.), §4.3 Cor 4.3.3, p. 86; §17.3 eq. (17.3.1), p. 308; §17.5 p. 312.
* Issue #1645 (Theorem 17.5.1 / Lemma 17.5.2 tracking).
* `.self-local/work/0119-theorem17-5-1-full.md` (Step 119 plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)