### PR TITLE
Refactor: export canonical HLS entrypoints — #1645

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/Lemma_17_5_2.lean
@@ -39,10 +39,12 @@ import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.CEConditionalCap
 import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.CEConditionalCapstoneGeometricConvenience
 import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.CEConditionalCapstonePolyGeometric
 import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.CEConditionalCapstonePseudoMassLeRate
-import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.HLSBridgeFromCubicTanh
+import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.HLSPerStageSubstantive
+import IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2.HLSBridgeSummary
 
 /-!
 # GJ §17.5 Lemma 17.5.2 capstone
 
-This compatibility module re-exports the split GJ Lemma 17.5.2 capstone layer.
+This compatibility module re-exports the split GJ Lemma 17.5.2 capstone layer,
+including the canonical HLS summary and bridge entry points.
 -/


### PR DESCRIPTION
Part of #1645. Follow-up to #3356 and #3357.

After removing the redundant HLS wrapper layers, the `Lemma_17_5_2` compatibility module still re-exported only `HLSBridgeFromCubicTanh`. This PR points the umbrella at the retained canonical entry surfaces instead:
- `HLSPerStageSubstantive` for the surviving substantive HLS/per-stage route, which re-exports `HLSGeneralExhaustion` and `HLSConsolidatedSummary`;
- `HLSBridgeSummary` for the surviving bridge route, which re-exports the Simon-Lieb/tanh bridge chain.

This keeps downstream users on the post-cleanup provider/bridge API rather than the deleted wrapper ladder.

Verification:
- `lake build IsingModel.Concrete.LatticeGraphCorrelation.Lemma_17_5_2`
- `lake build`
- `lake exe GKSTest`