### PR TITLE
Split Vitali bridge real wrappers

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/PerStageComplex/Branches/VitaliBridge/Real.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PerStageComplex/Branches/VitaliBridge/Real.lean
@@ -1,66 +1,11 @@
-import IsingModel.Concrete.LatticeGraphCorrelation.PerStageComplex.Branches.VitaliBridge.Bridge
+import IsingModel.Concrete.LatticeGraphCorrelation.PerStageComplex.Branches.VitaliBridge.Real.Identified
 
 /-!
 # Conditional Vitali bridge real-axis wrappers
 
-This module contains the real-axis identification wrappers split from
-`PerStageComplex.Branches.VitaliBridge`.
+## Compatibility re-export
+
+The real-axis Vitali bridge wrappers are split into
+`Real/Limit.lean` and `Real/Identified.lean`. This module preserves the old
+import path.
 -/
-
-namespace IsingModel
-namespace Ambient
-
-/-- **ℤ^d real-axis identification of a locally uniform Vitali limit**:
-the Lee-Yang locally uniform limit of the complex along-exhaustion
-free energies agrees at real parameters with the cast of
-`freeEnergyInfinite`. -/
-theorem freeEnergyComplexAlongExhaustion_limit_eq_freeEnergyInfinite_at_real_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (p : IsingParams ℝ)
-    (hBED : Ambient.BoundedEdgeDensity (IsingModel.latticeGraph d) Λ)
-    (hd : Ambient.DisjointTowerHypotheses (IsingModel.latticeGraph d) Λ p)
-    {f : ℂ → ℂ}
-    (hp : (p.h : ℂ) ∈ IsingModel.leeYangDomain)
-    (hconv : TendstoLocallyUniformlyOn
-      (fun n h => Ambient.freeEnergyComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ
-        (p.J : ℂ) h (p.β : ℂ) n)
-      f Filter.atTop IsingModel.leeYangDomain) :
-    f (p.h : ℂ) =
-      ((Ambient.freeEnergyInfinite (IsingModel.latticeGraph d) Λ p : ℝ) : ℂ) :=
-  Ambient.freeEnergyComplexAlongExhaustion_limit_eq_freeEnergyInfinite_at_real
-    (IsingModel.latticeGraph d) Λ p hBED hd hp hconv
-
-/-- **ℤ^d conditional Vitali assembly with real-axis identification**:
-combines holomorphicity of the Lee-Yang locally uniform limit with its
-identification at a real parameter by `freeEnergyInfinite`. -/
-theorem freeEnergyComplexAlongExhaustion_vitali_bridge_leeYangDomain_identified_at_real_latticeGraph
-    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
-    [∀ n, Fintype (Ambient.inducedGraph
-        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
-    (p : IsingParams ℝ)
-    (hBED : Ambient.BoundedEdgeDensity (IsingModel.latticeGraph d) Λ)
-    (hd : Ambient.DisjointTowerHypotheses (IsingModel.latticeGraph d) Λ p)
-    {f : ℂ → ℂ}
-    (hF : ∀ n, DifferentiableOn ℂ
-      (fun h => Ambient.freeEnergyComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ
-        (p.J : ℂ) h (p.β : ℂ) n)
-      IsingModel.leeYangDomain)
-    (hp : (p.h : ℂ) ∈ IsingModel.leeYangDomain)
-    (hconv : TendstoLocallyUniformlyOn
-      (fun n h => Ambient.freeEnergyComplexAlongExhaustion
-        (IsingModel.latticeGraph d) Λ
-        (p.J : ℂ) h (p.β : ℂ) n)
-      f Filter.atTop IsingModel.leeYangDomain) :
-    DifferentiableOn ℂ f IsingModel.leeYangDomain ∧
-      f (p.h : ℂ) =
-        ((Ambient.freeEnergyInfinite (IsingModel.latticeGraph d) Λ p : ℝ) : ℂ) :=
-  Ambient.freeEnergyComplexAlongExhaustion_vitali_bridge_leeYangDomain_identified_at_real
-    (IsingModel.latticeGraph d) Λ p hBED hd hF hp hconv
-
-end Ambient
-
-end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PerStageComplex/Branches/VitaliBridge/Real/Identified.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PerStageComplex/Branches/VitaliBridge/Real/Identified.lean
@@ -1,0 +1,43 @@
+import IsingModel.Concrete.LatticeGraphCorrelation.PerStageComplex.Branches.VitaliBridge.Real.Limit
+
+/-!
+# Conditional Vitali bridge identified real-axis wrappers
+
+This module contains the real-axis identified Vitali bridge wrapper split from
+`PerStageComplex.Branches.VitaliBridge.Real`.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d conditional Vitali assembly with real-axis identification**:
+combines holomorphicity of the Lee-Yang locally uniform limit with its
+identification at a real parameter by `freeEnergyInfinite`. -/
+theorem freeEnergyComplexAlongExhaustion_vitali_bridge_leeYangDomain_identified_at_real_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ)
+    (hBED : Ambient.BoundedEdgeDensity (IsingModel.latticeGraph d) Λ)
+    (hd : Ambient.DisjointTowerHypotheses (IsingModel.latticeGraph d) Λ p)
+    {f : ℂ → ℂ}
+    (hF : ∀ n, DifferentiableOn ℂ
+      (fun h => Ambient.freeEnergyComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ
+        (p.J : ℂ) h (p.β : ℂ) n)
+      IsingModel.leeYangDomain)
+    (hp : (p.h : ℂ) ∈ IsingModel.leeYangDomain)
+    (hconv : TendstoLocallyUniformlyOn
+      (fun n h => Ambient.freeEnergyComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ
+        (p.J : ℂ) h (p.β : ℂ) n)
+      f Filter.atTop IsingModel.leeYangDomain) :
+    DifferentiableOn ℂ f IsingModel.leeYangDomain ∧
+      f (p.h : ℂ) =
+        ((Ambient.freeEnergyInfinite (IsingModel.latticeGraph d) Λ p : ℝ) : ℂ) :=
+  Ambient.freeEnergyComplexAlongExhaustion_vitali_bridge_leeYangDomain_identified_at_real
+    (IsingModel.latticeGraph d) Λ p hBED hd hF hp hconv
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/LatticeGraphCorrelation/PerStageComplex/Branches/VitaliBridge/Real/Limit.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/PerStageComplex/Branches/VitaliBridge/Real/Limit.lean
@@ -1,0 +1,38 @@
+import IsingModel.Concrete.LatticeGraphCorrelation.PerStageComplex.Branches.VitaliBridge.Bridge
+
+/-!
+# Conditional Vitali bridge real-axis limit wrappers
+
+This module contains the real-axis limit-identification wrapper split from
+`PerStageComplex.Branches.VitaliBridge.Real`.
+-/
+
+namespace IsingModel
+namespace Ambient
+
+/-- **ℤ^d real-axis identification of a locally uniform Vitali limit**:
+the Lee-Yang locally uniform limit of the complex along-exhaustion
+free energies agrees at real parameters with the cast of
+`freeEnergyInfinite`. -/
+theorem freeEnergyComplexAlongExhaustion_limit_eq_freeEnergyInfinite_at_real_latticeGraph
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ))
+    [∀ n, Fintype (Ambient.inducedGraph
+        (IsingModel.latticeGraph d) (Λ.volume n)).edgeSet]
+    (p : IsingParams ℝ)
+    (hBED : Ambient.BoundedEdgeDensity (IsingModel.latticeGraph d) Λ)
+    (hd : Ambient.DisjointTowerHypotheses (IsingModel.latticeGraph d) Λ p)
+    {f : ℂ → ℂ}
+    (hp : (p.h : ℂ) ∈ IsingModel.leeYangDomain)
+    (hconv : TendstoLocallyUniformlyOn
+      (fun n h => Ambient.freeEnergyComplexAlongExhaustion
+        (IsingModel.latticeGraph d) Λ
+        (p.J : ℂ) h (p.β : ℂ) n)
+      f Filter.atTop IsingModel.leeYangDomain) :
+    f (p.h : ℂ) =
+      ((Ambient.freeEnergyInfinite (IsingModel.latticeGraph d) Λ p : ℝ) : ℂ) :=
+  Ambient.freeEnergyComplexAlongExhaustion_limit_eq_freeEnergyInfinite_at_real
+    (IsingModel.latticeGraph d) Λ p hBED hd hp hconv
+
+end Ambient
+
+end IsingModel


### PR DESCRIPTION
## Summary
- Split `Branches/VitaliBridge/Real.lean` into real-axis limit and identified Vitali bridge wrappers under `Real/`.
- Kept the legacy `Branches/VitaliBridge/Real.lean` import path as a compatibility re-export, preserving downstream `VitaliBridge`, local-cover Vitali, and `Branches` imports.

## Verification
- `git diff --check`
- focused `lake build` for the new child modules, legacy `VitaliBridge/Real`, downstream `VitaliBridge`, local-cover Vitali bridge, `LocalCoverPatch`, and `Branches`
- legacy `VitaliBridge/Real` import `#check` for both moved theorem names
- full `lake build IsingModel`
- `git diff --cached --check`