### PR TITLE
docs(peierls): flag vertex-level hsame circularity (codex design finding, FV §3.7.2)

### DIFF
--- a/IsingModel/Peierls/SingleOrbitConnectedInputs.lean
+++ b/IsingModel/Peierls/SingleOrbitConnectedInputs.lean
@@ -11,6 +11,15 @@ same-vertex wedge connectivity, and connectivity of `F`
 droplet enters. Only the per-edge advance and same-vertex inputs (the wedge/filled geometry) then
 remain.
 
+**Caveat (design):** the `hsame` argument as stated here — connecting *all* contact pairs sharing an
+in-site — is too strong to discharge directly: at a pinch vertex of a filled region the complement
+splits into two arcs whose darts lie in different local wedges, joined only by traversing the whole
+boundary (i.e. by the very single-orbit property being proved). The sound route keeps the global
+invariant at the *contact-pair/wedge* level (controlled advances plus same-arc connectivity, as in
+`reflTransGen_contactMove_same_inSite_arc` and `reflTransGen_contactMove_advance`) rather than at
+the vertex level; this statement is a valid conditional reduction but should not be used as the
+final entry point.
+
 * `reachable_inSite_of_connected` — `F`-connectivity gives the `hreach` input.
 * `boundaryDart_single_orbit_of_connected_inputs` — `hone` from advance, wedge, `F`-connectivity.
 

--- a/IsingModel/Peierls/SingleOrbitGeometric.lean
+++ b/IsingModel/Peierls/SingleOrbitGeometric.lean
@@ -12,6 +12,12 @@ three geometric inputs about a region `F` with a basepoint contact pair `c₀` �
 (`boundaryDart_single_orbit_of_contactPair_basepoint`). The remaining work is supplying these three
 inputs from connectedness and filledness of `F` — the orbit/contact machinery is otherwise complete.
 
+**Caveat (design):** the `hsame` input here (joining *all* contact pairs sharing an in-site) is too
+strong to discharge directly — at a pinch vertex of a filled region it is circular with the
+single-orbit conclusion. This is a valid conditional reduction; the sound discharge keeps the global
+invariant at the contact-pair/wedge level (controlled advances + same-arc connectivity), not the
+vertex level.
+
 * `boundaryDart_single_orbit_of_geometric_inputs` — `hone` from the three geometric inputs.
 
 References: Friedli–Velenik, *Statistical Mechanics of Lattice Systems*

--- a/IsingModel/Peierls/SingleOrbitToBasepoint.lean
+++ b/IsingModel/Peierls/SingleOrbitToBasepoint.lean
@@ -10,6 +10,11 @@ in-site to the basepoint's (`hreach`, from connectedness of `F`). Under these, e
 reaches the fixed basepoint by contact moves (`reflTransGen_contactMove_to_basepoint`) — walk the
 in-site back to the basepoint vertex (chaining), then rotate within the basepoint wedge.
 
+**Caveat (design):** the `hsame` argument (joining *all* contact pairs at a shared in-site) is too
+strong to discharge — at a pinch vertex of a filled region it is circular with single-orbit. This is
+a valid conditional reduction; the sound discharge keeps the global invariant at the
+contact-pair/wedge level (controlled advances + same-arc connectivity), not the vertex level.
+
 * `reflTransGen_contactMove_to_basepoint` — basepoint connectivity from the three geometric inputs.
 
 References: Friedli–Velenik, *Statistical Mechanics of Lattice Systems*


### PR DESCRIPTION
Part of #3631.

A focused codex design review found that the **vertex-level `hsame`** input of the recent conditional capstones (joining *all* contact pairs sharing an in-site) is too strong to discharge directly: at a **pinch vertex** of a filled region the complement splits into two arcs whose darts lie in different local wedges, joined only by traversing the whole boundary — i.e. circular with the single-orbit property being proved.

This PR adds **caveats** (no theorem changes) to the three conditional capstones noting they are valid conditional reductions but should **not** be the final entry point; the sound global invariant is at the **contact-pair/wedge level** (controlled advances + same-arc connectivity, as in `reflTransGen_contactMove_same_inSite_arc` and `reflTransGen_contactMove_advance`).

- `SingleOrbitConnectedInputs.lean`, `SingleOrbitGeometric.lean`, `SingleOrbitToBasepoint.lean` — doc caveats.

## Verification
- `lake build` ✓, `lake exe GKSTest` ✓, zero linter warnings, no `sorry`.

References: Friedli–Velenik (Cambridge, 2017), §3.7.2, pp. 109–116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)