### PR TITLE
feat(gj-4.6.1): unconditional infinite-volume free-energy convergence on the cubic exhaustion — #3897

### DIFF
--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -231,6 +231,7 @@ import IsingModel.PeierlsInfinite
 import IsingModel.TranslationInvariance
 import IsingModel.Concrete.IntLattice
 import IsingModel.Concrete.CubicExhaustion
+import IsingModel.Concrete.CubicTiling
 import IsingModel.Concrete.CubicBoxConnectivity
 import IsingModel.Concrete.CubicBoxAdjacencyGeometry
 import IsingModel.Concrete.LatticeGraphBED

--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -232,6 +232,7 @@ import IsingModel.TranslationInvariance
 import IsingModel.Concrete.IntLattice
 import IsingModel.Concrete.CubicExhaustion
 import IsingModel.Concrete.CubicTiling
+import IsingModel.Concrete.CubicFreeEnergy
 import IsingModel.Concrete.CubicBoxConnectivity
 import IsingModel.Concrete.CubicBoxAdjacencyGeometry
 import IsingModel.Concrete.LatticeGraphBED

--- a/IsingModel/Concrete/CubicFreeEnergy.lean
+++ b/IsingModel/Concrete/CubicFreeEnergy.lean
@@ -1,5 +1,6 @@
 import IsingModel.Concrete.CubicTiling
 import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergySuperadditivity
+import IsingModel.Concrete.LatticeGraphCorrelation.TranslationShiftsVaddFinset
 import IsingModel.AmbientLatticeSumGeFerromagnetic
 
 /-!
@@ -52,6 +53,28 @@ theorem log_partitionFunctionΛ_latticeGraph_biUnion_super_additive
           exact add_le_add le_rfl hih
       _ ≤ Real.log (partitionFunctionΛ (latticeGraph d) (B a ∪ I.biUnion B) p) :=
           log_partitionFunctionΛ_latticeGraph_disjUnion_super_additive d hd p hf
+
+/-- **Tiling lower bound for `log Z` on cubes** (ferromagnetic): the cube of radius
+`(2r+1)M + r` contains `(2M+1)^d` disjoint translates of the radius-`r` cube, so
+`(2M+1)^d · log Z_{B_r} ≤ log Z_{B_{(2r+1)M+r}}`. -/
+theorem log_partitionFunctionΛ_cubicBox_tiling_le (d r M : ℕ) (p : IsingParams ℝ)
+    (hf : Ferromagnetic p) :
+    ((2 * M + 1 : ℕ) ^ d : ℝ)
+        * Real.log (partitionFunctionΛ (latticeGraph d) (cubicBox d r) p)
+      ≤ Real.log (partitionFunctionΛ (latticeGraph d)
+          (cubicBox d ((2 * r + 1) * M + r)) p) := by
+  have hsum := log_partitionFunctionΛ_latticeGraph_biUnion_super_additive
+    (cubicBox d M) (cubicTile d r)
+    (fun i _ j _ hij => cubicTile_disjoint hij) p hf
+  have hterm : ∀ k ∈ cubicBox d M,
+      Real.log (partitionFunctionΛ (latticeGraph d) (cubicTile d r k) p)
+        = Real.log (partitionFunctionΛ (latticeGraph d) (cubicBox d r) p) := by
+    intro k _
+    exact log_partitionFunctionΛ_latticeGraph_vaddFinset_eq d (cubicTileCenter r k)
+      (cubicBox d r) p
+  rw [Finset.sum_congr rfl hterm, Finset.sum_const, card_cubicBox, nsmul_eq_mul] at hsum
+  rw [partitionFunctionΛ_latticeGraph_congr_finset d (biUnion_cubicTile d r M) p] at hsum
+  exact_mod_cast hsum
 
 end Ambient
 

--- a/IsingModel/Concrete/CubicFreeEnergy.lean
+++ b/IsingModel/Concrete/CubicFreeEnergy.lean
@@ -1,6 +1,11 @@
 import IsingModel.Concrete.CubicTiling
 import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergySuperadditivity
+import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergySuperadditivityDisjointUnion
+import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergySuperadditivityFE
 import IsingModel.Concrete.LatticeGraphCorrelation.TranslationShiftsVaddFinset
+import IsingModel.Concrete.LatticeGraphBED.LatticeBoundaryBED
+import IsingModel.AmbientLattice.SpecialCases.FreeEnergy
+import IsingModel.AmbientLatticeSumFreeEnergy
 import IsingModel.AmbientLatticeSumGeFerromagnetic
 
 /-!
@@ -143,6 +148,128 @@ theorem tendsto_cubicBox_innerRadius_card_ratio (d r : ℕ) :
   rw [card_cubicBox, card_cubicBox]
   push_cast
   rw [div_pow]
+
+/-- **Cubes are nonempty**: the origin belongs to every `cubicBox`. -/
+theorem cubicBox_nonempty (d n : ℕ) : (cubicBox d n).Nonempty := by
+  refine ⟨0, ?_⟩
+  rw [mem_cubicBox]
+  intro i
+  simp
+
+/-- **`log Z` is monotone along nested cubes** (ferromagnetic): enlarge by the disjoint
+difference. -/
+theorem log_partitionFunctionΛ_cubicBox_mono (d : ℕ) {m n : ℕ} (h : m ≤ n)
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Real.log (partitionFunctionΛ (latticeGraph d) (cubicBox d m) p)
+      ≤ Real.log (partitionFunctionΛ (latticeGraph d) (cubicBox d n) p) := by
+  classical
+  have hsub : cubicBox d m ⊆ cubicBox d n := cubicBox_mono d h
+  calc Real.log (partitionFunctionΛ (latticeGraph d) (cubicBox d m) p)
+      ≤ Real.log (partitionFunctionΛ (latticeGraph d)
+          (cubicBox d m ∪ (cubicBox d n \ cubicBox d m)) p) :=
+        log_partitionFunctionΛ_latticeGraph_le_of_disjoint_union d
+          Finset.disjoint_sdiff p hf
+    _ = Real.log (partitionFunctionΛ (latticeGraph d) (cubicBox d n) p) := by
+        rw [partitionFunctionΛ_latticeGraph_congr_finset d
+          (Finset.union_sdiff_of_subset hsub) p]
+
+/-- **Stage lower bound by the tiling ratio**: for `r ≤ N`,
+`(|B_{innerRadius}|/|B_N|) · f_r ≤ f_N`. -/
+theorem ratio_mul_freeEnergyΛ_cubicBox_le (d r : ℕ) (p : IsingParams ℝ)
+    (hf : Ferromagnetic p) {N : ℕ} (hrN : r ≤ N) :
+    ((cubicBox d (innerRadius r N)).card : ℝ) / ((cubicBox d N).card : ℝ)
+        * freeEnergyΛ (latticeGraph d) (cubicBox d r) p
+      ≤ freeEnergyΛ (latticeGraph d) (cubicBox d N) p := by
+  have hcardpos : (0 : ℝ) < ((cubicBox d N).card : ℝ) := by
+    rw [card_cubicBox]; positivity
+  rw [div_mul_eq_mul_div, div_le_iff₀ hcardpos]
+  have hfr := card_mul_freeEnergyΛ_latticeGraph_eq_log_partitionFunctionΛ_of_nonempty d
+    (cubicBox_nonempty d r) p
+  have hfN := card_mul_freeEnergyΛ_latticeGraph_eq_log_partitionFunctionΛ_of_nonempty d
+    (cubicBox_nonempty d N) p
+  have hcards : ((cubicBox d (innerRadius r N)).card : ℝ)
+      = ((2 * ((N - r) / (2 * r + 1)) + 1 : ℕ) ^ d : ℝ) * ((cubicBox d r).card : ℝ) := by
+    rw [card_cubicBox, card_cubicBox]
+    push_cast
+    rw [← mul_pow]
+    congr 1
+    unfold innerRadius
+    push_cast
+    ring
+  calc ((cubicBox d (innerRadius r N)).card : ℝ)
+        * freeEnergyΛ (latticeGraph d) (cubicBox d r) p
+      = ((2 * ((N - r) / (2 * r + 1)) + 1 : ℕ) ^ d : ℝ)
+          * (((cubicBox d r).card : ℝ)
+            * freeEnergyΛ (latticeGraph d) (cubicBox d r) p) := by
+        rw [hcards]; ring
+    _ = ((2 * ((N - r) / (2 * r + 1)) + 1 : ℕ) ^ d : ℝ)
+          * Real.log (partitionFunctionΛ (latticeGraph d) (cubicBox d r) p) := by
+        rw [hfr]
+    _ ≤ Real.log (partitionFunctionΛ (latticeGraph d)
+          (cubicBox d (innerRadius r N)) p) :=
+        log_partitionFunctionΛ_cubicBox_tiling_le d r ((N - r) / (2 * r + 1)) p hf
+    _ ≤ Real.log (partitionFunctionΛ (latticeGraph d) (cubicBox d N) p) :=
+        log_partitionFunctionΛ_cubicBox_mono d (innerRadius_le hrN) p hf
+    _ = freeEnergyΛ (latticeGraph d) (cubicBox d N) p * ((cubicBox d N).card : ℝ) := by
+        rw [← hfN]; ring
+
+/-- **Every stage value bounds the `liminf` from below**: the tiling ratio tends to `1`, so the
+stage bound survives the limit. -/
+theorem freeEnergyΛ_cubicBox_le_liminf (d r : ℕ) (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    freeEnergyΛ (latticeGraph d) (cubicBox d r) p
+      ≤ Filter.liminf
+          (freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p)
+          Filter.atTop := by
+  have hratio := (tendsto_cubicBox_innerRadius_card_ratio d r).mul_const
+    (freeEnergyΛ (latticeGraph d) (cubicBox d r) p)
+  rw [one_mul] at hratio
+  have hev : ∀ᶠ N in Filter.atTop,
+      ((cubicBox d (innerRadius r N)).card : ℝ) / ((cubicBox d N).card : ℝ)
+          * freeEnergyΛ (latticeGraph d) (cubicBox d r) p
+        ≤ freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p N := by
+    filter_upwards [Filter.eventually_ge_atTop r] with N hN
+    exact ratio_mul_freeEnergyΛ_cubicBox_le d r p hf hN
+  have hbdd : Filter.IsBoundedUnder (· ≤ ·) Filter.atTop
+      (freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p) := by
+    obtain ⟨c, hc⟩ := BddAbove_freeEnergyAlongExhaustion_range (latticeGraph d)
+      (cubicExhaustion d) p (boundedEdgeDensity_latticeGraph_cubicExhaustion d)
+    exact ⟨c, Filter.eventually_map.mpr
+      (Filter.Eventually.of_forall (fun n => hc (Set.mem_range_self n)))⟩
+  calc freeEnergyΛ (latticeGraph d) (cubicBox d r) p
+      = Filter.liminf (fun N : ℕ =>
+          ((cubicBox d (innerRadius r N)).card : ℝ) / ((cubicBox d N).card : ℝ)
+            * freeEnergyΛ (latticeGraph d) (cubicBox d r) p) Filter.atTop :=
+        hratio.liminf_eq.symm
+    _ ≤ _ := Filter.liminf_le_liminf hev hratio.isBoundedUnder_ge hbdd.isCoboundedUnder_ge
+
+/-- **GJ Proposition 4.6.1 on the cubic exhaustion** (unconditional, ferromagnetic): the
+free-energy density along the cubic boxes of `ℤ^d` converges to the infinite-volume free
+energy. Every stage bounds the `liminf` from below (tiling), hence
+`limsup ≤ liminf`, and `freeEnergyInfinite` is the `limsup` by definition. -/
+theorem freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_tendsto (d : ℕ)
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    Filter.Tendsto (freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p)
+      Filter.atTop
+      (nhds (freeEnergyInfinite (latticeGraph d) (cubicExhaustion d) p)) := by
+  have hbddA : Filter.IsBoundedUnder (· ≤ ·) Filter.atTop
+      (freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p) := by
+    obtain ⟨c, hc⟩ := BddAbove_freeEnergyAlongExhaustion_range (latticeGraph d)
+      (cubicExhaustion d) p (boundedEdgeDensity_latticeGraph_cubicExhaustion d)
+    exact ⟨c, Filter.eventually_map.mpr
+      (Filter.Eventually.of_forall (fun n => hc (Set.mem_range_self n)))⟩
+  have hbddB : Filter.IsBoundedUnder (· ≥ ·) Filter.atTop
+      (freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p) :=
+    ⟨0, Filter.eventually_map.mpr (Filter.Eventually.of_forall (fun n =>
+      freeEnergyAlongExhaustion_nonneg_of_ferromagnetic (latticeGraph d)
+        (cubicExhaustion d) p hf (cubicBox_nonempty d n)))⟩
+  have hkey : Filter.limsup
+      (freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p) Filter.atTop
+      ≤ Filter.liminf
+          (freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p)
+          Filter.atTop := by
+    apply Filter.limsup_le_of_le hbddB.isCoboundedUnder_le
+    exact Filter.Eventually.of_forall (fun r => freeEnergyΛ_cubicBox_le_liminf d r p hf)
+  exact tendsto_of_le_liminf_of_limsup_le hkey le_rfl hbddA hbddB
 
 end Ambient
 

--- a/IsingModel/Concrete/CubicFreeEnergy.lean
+++ b/IsingModel/Concrete/CubicFreeEnergy.lean
@@ -1,0 +1,58 @@
+import IsingModel.Concrete.CubicTiling
+import IsingModel.Concrete.LatticeGraphCorrelation.PartitionFreeEnergySuperadditivity
+import IsingModel.AmbientLatticeSumGeFerromagnetic
+
+/-!
+# Free-energy convergence on the cubic exhaustion — analytic layer (GJ §4.6)
+
+The analytic side of GJ Proposition 4.6.1 on the cubic exhaustion: the family form of the
+ferromagnetic `log Z` super-additivity, ready to be applied to the cubic tiling of
+`IsingModel.Concrete.CubicTiling`.
+
+* `log_partitionFunctionΛ_latticeGraph_biUnion_super_additive` — `∑_i log Z_{B i} ≤ log Z_{⋃ B i}`
+  for pairwise disjoint families.
+
+References: Glimm–Jaffe, *Quantum Physics*, 2nd ed. (Springer, 1987), §4.6,
+Proposition 4.6.1, p. 68.
+-/
+
+namespace IsingModel
+
+namespace Ambient
+
+open Finset
+
+/-- **`log Z` is super-additive over finite disjoint families** (ferromagnetic, ℤ^d): Finset
+induction over the binary disjoint-union super-additivity, with the ferromagnetic
+non-negativity of `log Z` at the empty family. -/
+theorem log_partitionFunctionΛ_latticeGraph_biUnion_super_additive
+    {d : ℕ} {ι : Type*} (I : Finset ι) (B : ι → Finset (Fin d → ℤ))
+    (hdisj : ∀ i ∈ I, ∀ j ∈ I, i ≠ j → Disjoint (B i) (B j))
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) :
+    ∑ i ∈ I, Real.log (partitionFunctionΛ (latticeGraph d) (B i) p)
+      ≤ Real.log (partitionFunctionΛ (latticeGraph d) (I.biUnion B) p) := by
+  classical
+  induction I using Finset.induction_on with
+  | empty =>
+    simp only [Finset.sum_empty, Finset.biUnion_empty]
+    exact log_partitionFunctionΛ_nonneg_of_ferromagnetic _ _ p hf
+  | insert a I ha ih =>
+    rw [Finset.sum_insert ha, Finset.biUnion_insert]
+    have hd : Disjoint (B a) (I.biUnion B) := by
+      rw [Finset.disjoint_biUnion_right]
+      intro j hj
+      exact hdisj a (Finset.mem_insert_self a I) j (Finset.mem_insert_of_mem hj)
+        (fun h => ha (h ▸ hj))
+    have hih := ih (fun i hi j hj hij =>
+      hdisj i (Finset.mem_insert_of_mem hi) j (Finset.mem_insert_of_mem hj) hij)
+    calc Real.log (partitionFunctionΛ (latticeGraph d) (B a) p)
+          + ∑ i ∈ I, Real.log (partitionFunctionΛ (latticeGraph d) (B i) p)
+        ≤ Real.log (partitionFunctionΛ (latticeGraph d) (B a) p)
+          + Real.log (partitionFunctionΛ (latticeGraph d) (I.biUnion B) p) := by
+          exact add_le_add le_rfl hih
+      _ ≤ Real.log (partitionFunctionΛ (latticeGraph d) (B a ∪ I.biUnion B) p) :=
+          log_partitionFunctionΛ_latticeGraph_disjUnion_super_additive d hd p hf
+
+end Ambient
+
+end IsingModel

--- a/IsingModel/Concrete/CubicFreeEnergy.lean
+++ b/IsingModel/Concrete/CubicFreeEnergy.lean
@@ -76,6 +76,74 @@ theorem log_partitionFunctionΛ_cubicBox_tiling_le (d r M : ℕ) (p : IsingParam
   rw [partitionFunctionΛ_latticeGraph_congr_finset d (biUnion_cubicTile d r M) p] at hsum
   exact_mod_cast hsum
 
+/-- The **inner tiling radius**: the largest radius of the form `(2r+1)M + r` not exceeding `N`
+(for `r ≤ N`), realising the almost-full tiling of `cubicBox d N`. -/
+def innerRadius (r N : ℕ) : ℕ := (2 * r + 1) * ((N - r) / (2 * r + 1)) + r
+
+/-- **The inner radius is at most `N`** (for `r ≤ N`). -/
+theorem innerRadius_le {r N : ℕ} (h : r ≤ N) : innerRadius r N ≤ N := by
+  have h2 : (2 * r + 1) * ((N - r) / (2 * r + 1)) ≤ N - r := by
+    rw [mul_comm]
+    exact Nat.div_mul_le_self _ _
+  unfold innerRadius
+  omega
+
+/-- **The inner radius is within `2r` of `N`**. -/
+theorem le_innerRadius_add (r N : ℕ) : N ≤ innerRadius r N + 2 * r := by
+  rcases le_total r N with h | h
+  · have hmod := Nat.div_add_mod (N - r) (2 * r + 1)
+    have hlt : (N - r) % (2 * r + 1) < 2 * r + 1 := Nat.mod_lt _ (by omega)
+    unfold innerRadius
+    omega
+  · have h0 : N - r = 0 := by omega
+    unfold innerRadius
+    rw [h0, Nat.zero_div, mul_zero]
+    omega
+
+/-- **The cardinality ratio of the inner cube tends to `1`**: the inner radius differs from `N`
+by at most `2r`, so the side ratio `(2·innerRadius+1)/(2N+1)` is squeezed between
+`1 - 4r/(2N+1)` and `1`, and so is its `d`-th power. -/
+theorem tendsto_cubicBox_innerRadius_card_ratio (d r : ℕ) :
+    Filter.Tendsto (fun N : ℕ =>
+        ((cubicBox d (innerRadius r N)).card : ℝ) / ((cubicBox d N).card : ℝ))
+      Filter.atTop (nhds 1) := by
+  have hden : Filter.Tendsto (fun N : ℕ => ((2 * N + 1 : ℕ) : ℝ)) Filter.atTop
+      Filter.atTop := by
+    apply Filter.tendsto_atTop_mono (fun N => ?_) tendsto_natCast_atTop_atTop
+    push_cast
+    linarith
+  have hbase : Filter.Tendsto (fun N : ℕ =>
+      ((2 * innerRadius r N + 1 : ℕ) : ℝ) / ((2 * N + 1 : ℕ) : ℝ)) Filter.atTop (nhds 1) := by
+    have hlow : Filter.Tendsto (fun N : ℕ =>
+        1 - (4 * r : ℝ) / ((2 * N + 1 : ℕ) : ℝ)) Filter.atTop (nhds 1) := by
+      have h0 : Filter.Tendsto (fun N : ℕ =>
+          (4 * r : ℝ) / ((2 * N + 1 : ℕ) : ℝ)) Filter.atTop (nhds 0) :=
+        Filter.Tendsto.div_atTop tendsto_const_nhds hden
+      simpa using tendsto_const_nhds.sub h0
+    refine tendsto_of_tendsto_of_tendsto_of_le_of_le' hlow tendsto_const_nhds ?_ ?_
+    · filter_upwards with N
+      have hpos : (0 : ℝ) < ((2 * N + 1 : ℕ) : ℝ) := by positivity
+      rw [sub_le_iff_le_add, ← add_div, le_div_iff₀ hpos]
+      have hN : 2 * N + 1 ≤ (2 * innerRadius r N + 1) + 4 * r := by
+        have := le_innerRadius_add r N
+        omega
+      have := (Nat.cast_le (α := ℝ)).mpr hN
+      push_cast at this ⊢
+      linarith
+    · filter_upwards [Filter.eventually_ge_atTop r] with N hN
+      have hpos : (0 : ℝ) < ((2 * N + 1 : ℕ) : ℝ) := by positivity
+      rw [div_le_one hpos]
+      have hle : 2 * innerRadius r N + 1 ≤ 2 * N + 1 := by
+        have := innerRadius_le hN
+        omega
+      exact_mod_cast hle
+  have hpow := hbase.pow d
+  rw [one_pow] at hpow
+  refine hpow.congr (fun N => ?_)
+  rw [card_cubicBox, card_cubicBox]
+  push_cast
+  rw [div_pow]
+
 end Ambient
 
 end IsingModel

--- a/IsingModel/Concrete/CubicTiling.lean
+++ b/IsingModel/Concrete/CubicTiling.lean
@@ -59,6 +59,89 @@ theorem mem_cubicTile {d r : ℕ} {k x : Fin d → ℤ} :
       simp only [cubicTileCenter, vadd_eq_add, Pi.add_apply]
       ring
 
+/-- **The tile index is determined by any of its points**: two indices whose tiles share a
+coordinate value within radius `r` of both centres agree (the spacing `2r+1` exceeds `2r`). -/
+private theorem tile_index_eq_of_close {r a b c : ℤ} (hr : 0 ≤ r)
+    (h1 : |c - (2 * r + 1) * a| ≤ r) (h2 : |c - (2 * r + 1) * b| ≤ r) : a = b := by
+  rcases abs_le.mp h1 with ⟨h1l, h1r⟩
+  rcases abs_le.mp h2 with ⟨h2l, h2r⟩
+  by_contra hne
+  rcases lt_or_gt_of_ne hne with h | h
+  · have hs : (1 : ℤ) ≤ b - a := by omega
+    have : (2 * r + 1) * 1 ≤ (2 * r + 1) * (b - a) :=
+      mul_le_mul_of_nonneg_left hs (by positivity)
+    nlinarith
+  · have hs : (1 : ℤ) ≤ a - b := by omega
+    have : (2 * r + 1) * 1 ≤ (2 * r + 1) * (a - b) :=
+      mul_le_mul_of_nonneg_left hs (by positivity)
+    nlinarith
+
+/-- **Distinct indices give disjoint tiles.** -/
+theorem cubicTile_disjoint {d r : ℕ} {k k' : Fin d → ℤ} (hkk : k ≠ k') :
+    Disjoint (cubicTile d r k) (cubicTile d r k') := by
+  rw [Finset.disjoint_left]
+  intro x hx hx'
+  refine hkk (funext fun i => ?_)
+  exact tile_index_eq_of_close (by positivity)
+    ((mem_cubicTile.mp hx) i) ((mem_cubicTile.mp hx') i)
+
+/-- **The tiles indexed by `cubicBox d M` tile the cube of radius `(2r+1)M + r` exactly**: every
+point decomposes uniquely as `(2r+1)·k + b` with `|kᵢ| ≤ M` and `|bᵢ| ≤ r` (Euclidean division
+of `xᵢ + r` by `2r+1`). -/
+theorem biUnion_cubicTile (d r M : ℕ) :
+    (cubicBox d M).biUnion (cubicTile d r) = cubicBox d ((2 * r + 1) * M + r) := by
+  have hspos : (0 : ℤ) < 2 * (r : ℤ) + 1 := by positivity
+  ext x
+  rw [Finset.mem_biUnion]
+  constructor
+  · rintro ⟨k, hk, hx⟩
+    rw [mem_cubicBox]
+    intro i
+    have hki := (mem_cubicBox.mp hk) i
+    have hxi := abs_le.mp ((mem_cubicTile.mp hx) i)
+    have hkup : (2 * (r : ℤ) + 1) * k i ≤ (2 * (r : ℤ) + 1) * M :=
+      mul_le_mul_of_nonneg_left hki.2 (by positivity)
+    have hklo : -((2 * (r : ℤ) + 1) * M) ≤ (2 * (r : ℤ) + 1) * k i := by
+      have := mul_le_mul_of_nonneg_left hki.1 (le_of_lt hspos)
+      nlinarith
+    constructor
+    · push_cast
+      nlinarith [hxi.1]
+    · push_cast
+      nlinarith [hxi.2]
+  · intro hx
+    refine ⟨fun i => (x i + r) / (2 * (r : ℤ) + 1), ?_, ?_⟩
+    · rw [mem_cubicBox]
+      intro i
+      have hxi := (mem_cubicBox.mp hx) i
+      have hde := Int.mul_ediv_add_emod (x i + r) (2 * (r : ℤ) + 1)
+      have hm0 : 0 ≤ (x i + r) % (2 * (r : ℤ) + 1) :=
+        Int.emod_nonneg _ (by positivity)
+      have hms : (x i + r) % (2 * (r : ℤ) + 1) < 2 * (r : ℤ) + 1 :=
+        Int.emod_lt_of_pos _ hspos
+      push_cast at hxi
+      constructor
+      · -- `-(M) ≤ k i` from `(2r+1)·k i ≥ -(2r+1)M - (2r)` hence `> -(2r+1)(M+1)`
+        by_contra hlt
+        push Not at hlt
+        have hk1 : (x i + r) / (2 * (r : ℤ) + 1) ≤ -(M : ℤ) - 1 := by omega
+        have := mul_le_mul_of_nonneg_left hk1 (le_of_lt hspos)
+        nlinarith
+      · by_contra hlt
+        push Not at hlt
+        have hk1 : (M : ℤ) + 1 ≤ (x i + r) / (2 * (r : ℤ) + 1) := by omega
+        have := mul_le_mul_of_nonneg_left hk1 (le_of_lt hspos)
+        nlinarith
+    · rw [mem_cubicTile]
+      intro i
+      have hde := Int.mul_ediv_add_emod (x i + r) (2 * (r : ℤ) + 1)
+      have hm0 : 0 ≤ (x i + r) % (2 * (r : ℤ) + 1) :=
+        Int.emod_nonneg _ (by positivity)
+      have hms : (x i + r) % (2 * (r : ℤ) + 1) < 2 * (r : ℤ) + 1 :=
+        Int.emod_lt_of_pos _ hspos
+      rw [abs_le]
+      constructor <;> nlinarith
+
 end Ambient
 
 end IsingModel

--- a/IsingModel/Concrete/CubicTiling.lean
+++ b/IsingModel/Concrete/CubicTiling.lean
@@ -1,0 +1,64 @@
+import IsingModel.Concrete.CubicExhaustion
+import IsingModel.TranslationInvariance.Finset
+
+/-!
+# Tiling a cube by translates of a smaller cube (GJ §4.6)
+
+The geometric core of the unconditional infinite-volume free-energy convergence on the cubic
+exhaustion (GJ Proposition 4.6.1): for a fixed radius `r` and spacing `s = 2r+1`, the translates
+of `cubicBox d r` centred at the points `s • k`, `k ∈ cubicBox d M`, are pairwise disjoint and
+tile the cube `cubicBox d (s*M + r)` exactly. Tiling an arbitrarily large cube almost fully by
+copies of a fixed cube turns the disjoint-union super-additivity of `log Z` into the lower bound
+`f_N ≥ (|B_{R_N}|/|B_N|) · f_r`, the Fekete-type input of the convergence proof.
+
+* `cubicTileCenter`, `cubicTile` — the tile of index `k`.
+* `mem_cubicTile` — coordinatewise membership characterisation.
+* `cubicTile_pairwiseDisjoint` — distinct indices give disjoint tiles.
+* `biUnion_cubicTile` — the tiles indexed by `cubicBox d M` tile `cubicBox d (s*M + r)`.
+
+References: Glimm–Jaffe, *Quantum Physics*, 2nd ed. (Springer, 1987), §4.6,
+Proposition 4.6.1, p. 68.
+-/
+
+namespace IsingModel
+
+namespace Ambient
+
+open Finset
+
+/-- The **centre of the tile of index `k`**: the lattice point `(2r+1) • k`. -/
+def cubicTileCenter {d : ℕ} (r : ℕ) (k : Fin d → ℤ) : Fin d → ℤ :=
+  fun i => (2 * (r : ℤ) + 1) * k i
+
+/-- The **tile of index `k`**: the cube of radius `r` centred at `cubicTileCenter r k`. -/
+noncomputable def cubicTile (d r : ℕ) (k : Fin d → ℤ) : Finset (Fin d → ℤ) :=
+  vaddFinset (cubicTileCenter r k) (cubicBox d r)
+
+/-- **Membership in a tile**: every coordinate lies within `r` of the tile centre. -/
+theorem mem_cubicTile {d r : ℕ} {k x : Fin d → ℤ} :
+    x ∈ cubicTile d r k ↔ ∀ i, |x i - (2 * (r : ℤ) + 1) * k i| ≤ r := by
+  unfold cubicTile vaddFinset
+  rw [Finset.mem_image]
+  constructor
+  · rintro ⟨b, hb, rfl⟩
+    intro i
+    have hbi := (mem_cubicBox.mp hb) i
+    have : (cubicTileCenter r k +ᵥ b) i - (2 * (r : ℤ) + 1) * k i = b i := by
+      simp only [cubicTileCenter, vadd_eq_add, Pi.add_apply]
+      ring
+    rw [this]
+    rw [abs_le]
+    exact ⟨hbi.1, hbi.2⟩
+  · intro h
+    refine ⟨fun i => x i - (2 * (r : ℤ) + 1) * k i, ?_, ?_⟩
+    · rw [mem_cubicBox]
+      intro i
+      have := abs_le.mp (h i)
+      exact ⟨this.1, this.2⟩
+    · funext i
+      simp only [cubicTileCenter, vadd_eq_add, Pi.add_apply]
+      ring
+
+end Ambient
+
+end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -1739,6 +1739,7 @@ formalized**, per the full inventory above:
 
 1. **Prop 4.6.1 (free energy convergence) Fekete completion** —
    **DONE (PR #3898)**: the unconditional cubic-exhaustion convergence
+   (for ferromagnetic `p`)
    `Ambient.freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_tendsto`
    (`Concrete/CubicFreeEnergy.lean`) closes this item via the
    tiling–liminf route, with no user-supplied superadditivity or

--- a/docs/index.md
+++ b/docs/index.md
@@ -341,6 +341,7 @@ Named specializations at `A = {i}`:
 |---|---|---|---|
 | `freeEnergy_monotone_{J,h,beta,subgraph}` | monotonicity | `FreeEnergy.lean` | Finite / Discretized Λ↑ |
 | `freeEnergy_convergent_subgraph` (Prop 4.6.1) | `f_{Gₙ}` converges | `FreeEnergy.lean` | Discretized Λ↑ |
+| `Ambient.freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_tendsto` (**Prop 4.6.1, unconditional on ℤ^d**) | `Tendsto (freeEnergyAlongExhaustion (latticeGraph d) (cubicExhaustion d) p) atTop (𝓝 freeEnergyInfinite)` for ferromagnetic `p` — no superadditivity or tower hypotheses. Tiling–liminf route: `cubicTile` translates of `cubicBox d r` tile `cubicBox d ((2r+1)M+r)` exactly (`biUnion_cubicTile`, `cubicTile_disjoint`), family super-additivity (`log_partitionFunctionΛ_latticeGraph_biUnion_super_additive`) + translation invariance give `(|B_inner|/|B_N|)·f_r ≤ f_N` (`ratio_mul_freeEnergyΛ_cubicBox_le`), the ratio tends to `1` (`tendsto_cubicBox_innerRadius_card_ratio`), so every stage bounds the `liminf` (`freeEnergyΛ_cubicBox_le_liminf`) and `limsup ≤ liminf`. | `Concrete/CubicTiling.lean`, `Concrete/CubicFreeEnergy.lean` | **ℤ^d cubic exhaustion, unconditional**. GJ §4.6 Prop 4.6.1, p. 68 |
 | `freeEnergyH_analyticOn` (Thm 4.6.2, real) | `f(h)` real-analytic for `h > 0` | `FreeEnergy.lean` | Finite |
 | `freeEnergyJ_analyticOn` | `f(J)` real-analytic for `J > 0` | `FreeEnergy.lean` | Finite |
 | `partitionFunctionH_analyticAt` | `Z(h)` real-analytic | `FreeEnergy.lean` | Finite |
@@ -1736,7 +1737,13 @@ inventory (2026-04-17).
 The following GJ Ising infinite-volume discussions are **not yet
 formalized**, per the full inventory above:
 
-1. **Prop 4.6.1 (free energy convergence) Fekete completion**:
+1. **Prop 4.6.1 (free energy convergence) Fekete completion** —
+   **DONE (PR #3898)**: the unconditional cubic-exhaustion convergence
+   `Ambient.freeEnergyAlongExhaustion_latticeGraph_cubicExhaustion_tendsto`
+   (`Concrete/CubicFreeEnergy.lean`) closes this item via the
+   tiling–liminf route, with no user-supplied superadditivity or
+   translation-tower inputs. The earlier conditional entry points
+   remain available:
    Fekete-style convergence of `freeEnergyAlongExhaustion` is now
    available through three API entry points (all in
    `AmbientLatticeSum.lean`):

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -7582,6 +7582,47 @@ existing disjoint-union super-additivity, upper bound, and divergence
 infrastructure, the targeted exhaustion class is covered.
 \end{theorem}
 
+\begin{theorem}[Glimm--Jaffe \S 4.6 Prop 4.6.1, \emph{unconditional} on the
+cubic exhaustion of $\mathbb Z^d$; PR \#3898,
+\texttt{freeEnergyAlongExhaustion\_latticeGraph\_cubicExhaustion\_tendsto}]
+For ferromagnetic parameters $p$ and every $d$, the free-energy density along
+the cubic boxes $B_n = [-n,n]^d \cap \mathbb Z^d$ converges, with no
+super-additivity, cardinality-additivity, or translation-tower hypotheses:
+\[
+  \texttt{Tendsto}\,
+    (\texttt{freeEnergyAlongExhaustion}\,(\texttt{latticeGraph}\,d)\,
+      (\texttt{cubicExhaustion}\,d)\,p)\, \texttt{atTop}\,
+    (\mathcal N(\texttt{freeEnergyInfinite})).
+\]
+Proof (tiling--liminf; \texttt{Concrete/CubicTiling.lean},
+\texttt{Concrete/CubicFreeEnergy.lean}). Fix a radius $r$ and set
+$s = 2r+1$. The translates of $B_r$ centred at $s k$, $k \in B_M$, are
+pairwise disjoint (\texttt{cubicTile\_disjoint}; the spacing exceeds the
+diameter) and tile $B_{sM+r}$ exactly (\texttt{biUnion\_cubicTile};
+Euclidean division of $x_i + r$ by $s$). Family super-additivity of
+$\log Z$ over disjoint families
+(\texttt{log\_partitionFunction\(\Lambda\)\_latticeGraph\_biUnion\_super\_additive},
+Finset induction over the binary disjoint-union estimate) and translation
+invariance give $(2M+1)^d \log Z_{B_r} \le \log Z_{B_{sM+r}}$
+(\texttt{log\_partitionFunction\(\Lambda\)\_cubicBox\_tiling\_le}). With the
+inner radius $R_N = s\lfloor (N-r)/s\rfloor + r \le N$ (within $2r$ of $N$)
+and the monotonicity of $\log Z$ along nested cubes, the exact cardinality
+factorisation $(2M+1)^d (2r+1)^d = (2R_N+1)^d$ yields
+$\frac{|B_{R_N}|}{|B_N|}\, f_r \le f_N$
+(\texttt{ratio\_mul\_freeEnergy\(\Lambda\)\_cubicBox\_le}). The volume
+ratio tends to $1$
+(\texttt{tendsto\_cubicBox\_innerRadius\_card\_ratio}; the side ratio is
+squeezed between $1 - 4r/(2N+1)$ and $1$), so every stage value satisfies
+$f_r \le \liminf_N f_N$
+(\texttt{freeEnergy\(\Lambda\)\_cubicBox\_le\_liminf}). Taking the
+$\limsup$ over $r$ gives $\limsup \le \liminf$; with the uniform upper
+bound (bounded edge density) and ferromagnetic non-negativity,
+\texttt{tendsto\_of\_le\_liminf\_of\_limsup\_le} concludes, the limit
+being $\texttt{freeEnergyInfinite} = \limsup$ by definition. Reference:
+Glimm--Jaffe, \emph{Quantum Physics}, 2nd ed., \S 4.6, Proposition 4.6.1,
+p.~68.
+\end{theorem}
+
 \begin{theorem}[Support toward GJ \S 4.6 Thm 4.6.2: finite-volume complex $Z$ analyticity; PR \#193]
 Preliminary support for GJ Theorem 4.6.2: after extending the finite-volume
 partition function $Z_G(J, h, \beta)$ to $(J, h, \beta) \in \mathbb C^3$, it

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -18161,7 +18161,7 @@ FKG lattice-condition argument.
 
 \subsection{freeEnergyAlongExhaustion (§4.6 Prop 4.6.1 scaffold)}
 
-Reference: Glimm--Jaffe \S 4.6 Proposition 4.6.1, pp.\ 78ff
+Reference: Glimm--Jaffe \S 4.6 Proposition 4.6.1, p.\ 68
 (free-energy convergence in the volume direction).
 
 \begin{definition}[\texttt{freeEnergyAlongExhaustion}]


### PR DESCRIPTION
Part of #3897

GJ Proposition 4.6.1 (Quantum Physics, 2nd ed., §4.6, p. 68): the free-energy density along the cubic exhaustion of ℤ^d converges (unconditionally, ferromagnetic parameters) to the infinite-volume free energy.

Route (fixed after codex consultation; math in .self-local/tex/3897-*): **tiling–liminf** — tile an arbitrarily large cube almost fully by translates of a fixed small cube; family superadditivity + translation invariance + monotone enlargement give f_N ≥ (|B_{R_N}|/|B_N|)·f_r, hence liminf ≥ f_r for every r, hence limsup ≤ liminf; conclude with tendsto_of_le_liminf_of_limsup_le toward freeEnergyInfinite = limsup.

Bundled as one GJ-proposition PR: tiling geometry, family superadditivity, inner-fill bound, liminf stage bound, headline theorem, docs/index.md + tex/proof-guide.tex sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)