### PR TITLE
feat(vitali): equicontinuity-at-a-point from local boundedness — #4280

### DIFF
--- a/IsingModel/ComplexAnalyticity/VitaliPorter/Equicontinuity.lean
+++ b/IsingModel/ComplexAnalyticity/VitaliPorter/Equicontinuity.lean
@@ -1,5 +1,6 @@
 import Mathlib.Analysis.Complex.LocallyUniformLimit
 import Mathlib.Analysis.Calculus.MeanValue
+import Mathlib.Topology.MetricSpace.Equicontinuity
 
 /-!
 # Vitali–Porter: Montel equicontinuity from local boundedness (Cauchy estimates)
@@ -79,6 +80,75 @@ theorem lipschitzBound_of_bounded_on_closedBall
     rw [← norm_deriv_eq_norm_fderiv]
     exact hderiv x hx
   exact hconv.norm_image_sub_le_of_norm_fderiv_le hdiff hfd hw' hw
+
+/-- **Equicontinuity at a point from a local uniform bound** (Montel input, ball form).
+
+If every `F n` is holomorphic on the open `U`, `ball x₀ ρ ⊆ U` (`ρ > 0`), and `‖F n w‖ ≤ M` for all
+`n` and `w ∈ ball x₀ ρ`, then the family `F` is equicontinuous at `x₀`.
+
+Proof: on `closedBall x₀ (ρ/2) ⊆ ball x₀ ρ` every `F n` is bounded by `M`, so by
+`lipschitzBound_of_bounded_on_closedBall` every `F n` is `(M/(ρ/4))`-Lipschitz on the inner disc
+`closedBall x₀ (ρ/4)` — a common modulus of continuity, which is exactly equicontinuity at `x₀`. -/
+theorem equicontinuousAt_of_ball_bound
+    {U : Set ℂ} (hU : IsOpen U) {F : ℕ → ℂ → ℂ}
+    (hF : ∀ n, DifferentiableOn ℂ (F n) U)
+    {x₀ : ℂ} {ρ M : ℝ} (hρ : 0 < ρ) (hballU : ball x₀ ρ ⊆ U)
+    (hbound : ∀ n, ∀ w ∈ ball x₀ ρ, ‖F n w‖ ≤ M) :
+    EquicontinuousAt (fun n => F n) x₀ := by
+  -- Geometry: inner radius `ρ/4 < ρ/2`, and `closedBall x₀ (ρ/2) ⊆ ball x₀ ρ ⊆ U`.
+  have hhalf_lt : ρ / 2 < ρ := by linarith
+  have hquart_lt : ρ / 4 < ρ / 2 := by linarith
+  have hCB_sub : closedBall x₀ (ρ / 2) ⊆ ball x₀ ρ :=
+    Metric.closedBall_subset_ball hhalf_lt
+  have hCB_U : closedBall x₀ (ρ / 2) ⊆ U := hCB_sub.trans hballU
+  have hbound_CB : ∀ n, ∀ w ∈ closedBall x₀ (ρ / 2), ‖F n w‖ ≤ M :=
+    fun n w hw => hbound n w (hCB_sub hw)
+  -- The common Lipschitz constant `L = M / (ρ/2 − ρ/4) = M / (ρ/4) = 4M/ρ`.
+  set L : ℝ := M / (ρ / 2 - ρ / 4) with hL_def
+  have hM0 : 0 ≤ M := (norm_nonneg _).trans (hbound 0 x₀ (Metric.mem_ball_self hρ))
+  have hden : 0 < ρ / 2 - ρ / 4 := by linarith
+  have hL0 : 0 ≤ L := div_nonneg hM0 hden.le
+  -- Uniform Lipschitz bound on the inner disc.
+  have hLip : ∀ n, ∀ x ∈ closedBall x₀ (ρ / 4), ∀ x' ∈ closedBall x₀ (ρ / 4),
+      ‖F n x - F n x'‖ ≤ L * ‖x - x'‖ := by
+    intro n x hx x' hx'
+    exact lipschitzBound_of_bounded_on_closedBall hU (hF n) hquart_lt hCB_U (hbound_CB n) hx hx'
+  -- Convert the common modulus into equicontinuity at `x₀`.
+  rw [Metric.equicontinuousAt_iff]
+  intro ε hε
+  refine ⟨min (ρ / 4) (ε / (L + 1)), lt_min (by linarith) (by positivity), ?_⟩
+  intro x hx n
+  have hx_in : x ∈ closedBall x₀ (ρ / 4) := by
+    rw [Metric.mem_closedBall]
+    exact le_of_lt (lt_of_lt_of_le hx (min_le_left _ _))
+  have hx₀_in : x₀ ∈ closedBall x₀ (ρ / 4) := Metric.mem_closedBall_self (by linarith)
+  have hbnd := hLip n x₀ hx₀_in x hx_in
+  -- `dist (F n x₀) (F n x) = ‖F n x₀ − F n x‖ ≤ L * ‖x₀ − x‖ = L * dist x x₀`.
+  rw [dist_eq_norm]
+  calc ‖F n x₀ - F n x‖ ≤ L * ‖x₀ - x‖ := hbnd
+    _ = L * dist x x₀ := by rw [← dist_eq_norm, dist_comm]
+    _ < ε := by
+        have hdistlt : dist x x₀ < ε / (L + 1) :=
+          lt_of_lt_of_le hx (min_le_right _ _)
+        have hLp1 : 0 < L + 1 := by linarith
+        calc L * dist x x₀ ≤ (L + 1) * dist x x₀ := by
+              apply mul_le_mul_of_nonneg_right (by linarith) dist_nonneg
+          _ < (L + 1) * (ε / (L + 1)) :=
+              mul_lt_mul_of_pos_left hdistlt hLp1
+          _ = ε := by field_simp
+
+/-- **Equicontinuity at a point from the local-boundedness hypothesis** (Montel input).
+
+Existential-`ball` repackaging of `equicontinuousAt_of_ball_bound`: from the local uniform bound
+`∃ r M, 0 < r ∧ ball x₀ r ⊆ U ∧ ∀ n w ∈ ball x₀ r, ‖F n w‖ ≤ M` (the standard "locally uniformly
+bounded family" hypothesis at `x₀`), the holomorphic family `F` is equicontinuous at `x₀`. -/
+theorem equicontinuousAt_of_locallyBounded
+    {U : Set ℂ} (hU : IsOpen U) {F : ℕ → ℂ → ℂ}
+    (hF : ∀ n, DifferentiableOn ℂ (F n) U) {x₀ : ℂ}
+    (hbdd : ∃ r M : ℝ, 0 < r ∧ ball x₀ r ⊆ U ∧ ∀ n, ∀ w ∈ ball x₀ r, ‖F n w‖ ≤ M) :
+    EquicontinuousAt (fun n => F n) x₀ := by
+  obtain ⟨r, M, hr, hrU, hbound⟩ := hbdd
+  exact equicontinuousAt_of_ball_bound hU hF hr hrU hbound
 
 end FunctionTheory
 end IsingModel


### PR DESCRIPTION
Part of **#4280**. Third building block toward eliminating `vitaliPorter_tendstoLocallyUniformlyOn`.

Converts the uniform Lipschitz bound (#4282) into the topological `EquicontinuousAt` predicate that the Arzelà–Ascoli compactness step consumes.

## New (`Equicontinuity.lean`)
- `equicontinuousAt_of_ball_bound`: from a sup bound `M` on `ball x₀ ρ`, the holomorphic family is `EquicontinuousAt x₀` (common `(4M/ρ)`-Lipschitz modulus on `closedBall x₀ (ρ/4)`).
- `equicontinuousAt_of_locallyBounded`: existential-ball form matching the locally-uniformly-bounded hypothesis (= the `hbdd` of the vitaliPorter axiom).

Axiom-free; pure Mathlib. Next: per-compact relative compactness (abstract Ascoli) + diagonal across a compact exhaustion → `TendstoLocallyUniformlyOn` subsequence (#4280).

🤖 Generated with [Claude Code](https://claude.com/claude-code)