### PR TITLE
feat(gj-18.7): two-point correlation analyticity on the full convergence region — #4289 PR 3b

### DIFF
--- a/IsingModel/ClusterExpansion/TwoPointConvergenceRegion.lean
+++ b/IsingModel/ClusterExpansion/TwoPointConvergenceRegion.lean
@@ -126,5 +126,111 @@ theorem ofReal_mem_U {β : ℝ} (hβ : 0 ≤ β)
       exact Complex.ofReal_ne_zero.mpr (ne_of_gt (Real.cosh_pos _))
   exact (hTpre.subset_connectedComponentIn h0T hTS) ⟨β, Set.right_mem_Icc.mpr hβ, rfl⟩
 
+/-! ## Volume-uniform inputs on the convergence region -/
+
+open Ambient
+
+/-- **Volume-uniform two-point norm bound on the convergence region.** Every exhaustion stage's
+complex two-point correlation is bounded by `twoPointHTBoundValue (2d)` on `U`. -/
+theorem correlationComplexAlongExhaustion_two_point_norm_le_on_U
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (J : ℝ)
+    {i j : Fin d → ℤ} (hij : i ≠ j) :
+    ∀ n : ℕ, ∀ β ∈ U d J,
+      ‖Ambient.correlationComplexAlongExhaustion (IsingModel.latticeGraph d) Λ
+          ({i, j} : Finset (Fin d → ℤ)) (J : ℂ) 0 β n‖ ≤ twoPointHTBoundValue (2 * d) := by
+  classical
+  intro n β hβ
+  unfold Ambient.correlationComplexAlongExhaustion
+  by_cases hsub : ({i, j} : Finset (Fin d → ℤ)) ⊆ Λ.volume n
+  · simp only [hsub, dif_pos]
+    have hi : i ∈ Λ.volume n := hsub (by simp)
+    have hj : j ∈ Λ.volume n := hsub (by simp)
+    have hp : Ambient.liftFinset ({i, j} : Finset (Fin d → ℤ)) hsub =
+        ({⟨i, hi⟩, ⟨j, hj⟩} : Finset (↑(Λ.volume n) : Type _)) :=
+      Ambient.liftFinset_pair hsub hi hj
+    have hij' : (⟨i, hi⟩ : ↑(Λ.volume n)) ≠ ⟨j, hj⟩ := fun h => hij (Subtype.mk.inj h)
+    have hdeg : (Ambient.inducedGraph (IsingModel.latticeGraph d) (Λ.volume n)).maxDegree ≤ 2 * d :=
+      induced_latticeGraph_maxDegree_le d (Λ.volume n)
+    have hbound := correlationComplex_two_point_norm_le_on_connected
+      (G := Ambient.inducedGraph (IsingModel.latticeGraph d) (Λ.volume n))
+      (i := (⟨i, hi⟩ : ↑(Λ.volume n))) (j := ⟨j, hj⟩) hij' J (2 * d) hdeg
+      (isOpen_U d J) (isPreconnected_U d J) (zero_mem_U d J)
+      (fun z hz => cosh_ne_zero_of_mem_U d J hz)
+      (fun z hz => norm_tanh_lt_of_mem_U d J hz)
+      β hβ
+    simpa [hp] using hbound
+  · rw [dif_neg hsub, norm_zero]
+    exact le_of_lt (twoPointHTBoundValue_pos (2 * d))
+
+/-- **Volume-uniform partition non-vanishing on the convergence region.** -/
+theorem partitionFunctionComplexAlongExhaustion_ne_zero_on_U
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (J : ℝ) :
+    ∀ n : ℕ, ∀ z ∈ U d J,
+      Ambient.partitionFunctionComplexAlongExhaustion (IsingModel.latticeGraph d) Λ
+          (J : ℂ) 0 z n ≠ 0 := by
+  intro n z hz
+  set G' := Ambient.inducedGraph (IsingModel.latticeGraph d) (Λ.volume n) with hG'
+  change partitionFunctionComplex G' (J : ℂ) 0 z ≠ 0
+  have hId := partitionFunctionComplex_high_temp_expansion_h_zero_htSubgraphSum_on_connected
+    G' J (isOpen_U d J) (isPreconnected_U d J) (zero_mem_U d J)
+    (fun w hw => cosh_ne_zero_of_mem_U d J hw)
+  have heq := hId hz
+  simp only [] at heq
+  rw [heq]
+  have hR : 0 < R d := twoPointHTActivityRadius_pos (2 * d)
+  have hKP2d : ((2 * d : ℕ) : ℝ) ^ 2 * (Real.exp 1 * R d) < 1 / 6 := by
+    have h64 := twoPointHTActivityRadius_kp_threshold (2 * d)
+    simp only [R]; linarith
+  obtain ⟨hkp2d, hρ2d⟩ := kp_tail_conditions_of_lt hKP2d
+  have hdeg : G'.maxDegree ≤ 2 * d := induced_latticeGraph_maxDegree_le d (Λ.volume n)
+  have hcast : (G'.maxDegree : ℝ) ≤ ((2 * d : ℕ) : ℝ) := by exact_mod_cast hdeg
+  have h0 : (0 : ℝ) ≤ (G'.maxDegree : ℝ) ^ 2 * (Real.exp 1 * R d) := by positivity
+  have h12 : (G'.maxDegree : ℝ) ^ 2 * (Real.exp 1 * R d) ≤
+      ((2 * d : ℕ) : ℝ) ^ 2 * (Real.exp 1 * R d) := by gcongr
+  obtain ⟨hkpG', hρG'⟩ := kpRegion_downward_closed h0 h12 hkp2d hρ2d
+  have hz' : Complex.tanh (z * (J : ℂ)) ∈ Metric.ball (0 : ℂ) (R d) := by
+    rw [Metric.mem_ball, dist_zero_right]; exact norm_tanh_lt_of_mem_U d J hz
+  rw [htSubgraphSum_empty_eq_exp_tsum_mayerExpansionTermComplex G' hR hkpG' hρG' hz']
+  exact mul_ne_zero
+    (mul_ne_zero (by norm_num) (pow_ne_zero _ (cosh_ne_zero_of_mem_U d J hz)))
+    (Complex.exp_ne_zero _)
+
+/-- **Infinite-volume two-point correlation analyticity on the full convergence region `U`**
+(GJ §18.6–18.7). For the cubic lattice and a real high-temperature point `β` lying in `U`, the
+along-exhaustion complex two-point correlations converge locally uniformly on `U` to a function
+holomorphic on `U`, agreeing with `correlationInfinite` at `β`. Axiom-free (the Vitali–Porter
+bridge is now proved). -/
+theorem correlationInfinite_latticeGraph_two_point_analytic_on_U
+    (d : ℕ) (Λ : Ambient.Exhaustion (Fin d → ℤ)) (J : ℝ) (hJ : 0 ≤ J)
+    {i j : Fin d → ℤ} (hij : i ≠ j) {β : ℝ} (hβpos : 0 < β)
+    (hβU : (β : ℂ) ∈ U d J) :
+    ∃ f : ℂ → ℂ, DifferentiableOn ℂ f (U d J) ∧
+      TendstoLocallyUniformlyOn
+        (fun n z => Ambient.correlationComplexAlongExhaustion (IsingModel.latticeGraph d) Λ
+          ({i, j} : Finset (Fin d → ℤ)) (J : ℂ) 0 z n)
+        f Filter.atTop (U d J) ∧
+      f (β : ℂ) = ((Ambient.correlationInfinite (IsingModel.latticeGraph d) Λ
+          (⟨J, 0, β⟩ : IsingParams ℝ) ({i, j} : Finset (Fin d → ℤ)) : ℝ) : ℂ) := by
+  classical
+  have hf : IsingModel.Ferromagnetic (⟨J, 0, β⟩ : IsingParams ℝ) := ⟨hJ, le_rfl, hβpos⟩
+  have hZ : ∀ n, ∀ z ∈ U d J,
+      Ambient.partitionFunctionComplexAlongExhaustion (IsingModel.latticeGraph d) Λ
+        ((⟨J, 0, β⟩ : IsingParams ℝ).J : ℂ) ((⟨J, 0, β⟩ : IsingParams ℝ).h : ℂ) z n ≠ 0 := by
+    intro n z hz
+    simpa using partitionFunctionComplexAlongExhaustion_ne_zero_on_U d Λ J n z hz
+  have hbdd : ∀ z ∈ U d J, ∃ r M : ℝ, 0 < r ∧ Metric.ball z r ⊆ U d J ∧
+      ∀ n, ∀ w ∈ Metric.ball z r,
+        ‖Ambient.correlationComplexAlongExhaustion (IsingModel.latticeGraph d) Λ
+            ({i, j} : Finset (Fin d → ℤ)) ((⟨J, 0, β⟩ : IsingParams ℝ).J : ℂ)
+            ((⟨J, 0, β⟩ : IsingParams ℝ).h : ℂ) w n‖ ≤ M := by
+    intro z hz
+    obtain ⟨r, hrpos, hrsub⟩ := Metric.isOpen_iff.mp (isOpen_U d J) z hz
+    refine ⟨r, twoPointHTBoundValue (2 * d), hrpos, hrsub, fun n w hw => ?_⟩
+    simpa using correlationComplexAlongExhaustion_two_point_norm_le_on_U d Λ J hij n w (hrsub hw)
+  exact Ambient.correlationComplexAlongExhaustion_analytic_of_volume_uniform_bound
+    (IsingModel.latticeGraph d) Λ (⟨J, 0, β⟩ : IsingParams ℝ) hf
+    ({i, j} : Finset (Fin d → ℤ))
+    (isOpen_U d J) (isPreconnected_U d J) hβU hZ hbdd
+
 end ConvergenceRegion
 end IsingModel

--- a/IsingModel/ClusterExpansion/TwoPointCorrelationInfiniteAnalytic.lean
+++ b/IsingModel/ClusterExpansion/TwoPointCorrelationInfiniteAnalytic.lean
@@ -114,7 +114,7 @@ private lemma htSubgraphSum_tanh_analyticAt (G : SimpleGraph ι) [Fintype G.edge
 
 /-- The complex partition function high-temperature identity on any connected domain where
 `cosh (beta * J)` is nonzero. -/
-private theorem partitionFunctionComplex_high_temp_expansion_h_zero_htSubgraphSum_on_connected
+theorem partitionFunctionComplex_high_temp_expansion_h_zero_htSubgraphSum_on_connected
     (G : SimpleGraph ι) [Fintype G.edgeSet] (J : ℝ) {U : Set ℂ}
     (_hU : IsOpen U) (hUconn : IsPreconnected U) (h0U : (0 : ℂ) ∈ U)
     (hcoshU : ∀ z ∈ U, Complex.cosh (z * (J : ℂ)) ≠ 0) :


### PR DESCRIPTION
Part of **#4289** / #4280. Locally-uniform convergence of the along-exhaustion complex two-point correlations on the **whole** convergence region `U` (not just the near-0 disc), **axiom-free** since Vitali–Porter is proved.

## New (`TwoPointConvergenceRegion.lean`)
- `correlationComplexAlongExhaustion_two_point_norm_le_on_U`: volume-uniform norm bound on `U` (per stage via the connected norm bound #4291, induced `maxDegree ≤ 2d`).
- `partitionFunctionComplexAlongExhaustion_ne_zero_on_U`: partition non-vanishing on `U` (per stage: `Z = partitionFunctionComplex(induced)` by def; connected partition identity ⟹ `Z = 2^|V|·cosh^|E|·htSubgraphSum∅`, nonzero since `cosh≠0` and `htSubgraphSum∅ = exp(...) ≠ 0` — KP conditions from the activity-radius threshold via `kpRegion_downward_closed`).
- `correlationInfinite_latticeGraph_two_point_analytic_on_U`: feeds `hZ` + `hbdd` (U open ⟹ `ball z r ⊆ U` directly) into `correlationComplexAlongExhaustion_analytic_of_volume_uniform_bound` (#4235, axiom-free) → `∃ f DifferentiableOn U`, locally-uniform convergence on `U`, `f(β)=correlationInfinite`.

Also de-privatizes the connected partition identity (needed for `hZ`).

Axiom-free; full build passes; linter-clean. **Partial w.r.t. the axiom** — this builds the U-domain analyticity that PR 4 (`.deriv` + real bridge → provider, rescope sharp HLS) will consume to remove `derivativeLimitProvider_latticeGraph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)