### PR TITLE
refactor(cluster-expansion): de-duplicate generic helper lemmas — #4298 PR-B2

### DIFF
--- a/IsingModel/ClusterExpansion/MayerCore/CubicMayerCouplingDirectionAnalyticity.lean
+++ b/IsingModel/ClusterExpansion/MayerCore/CubicMayerCouplingDirectionAnalyticity.lean
@@ -26,19 +26,6 @@ namespace IsingModel
 
 open Ambient Set Filter Topology
 
-/-- `Real.tanh` is strictly monotone (local copy; the global version lives in `PseudoMass/Profile`,
-which is not on this import path). -/
-private theorem real_tanh_strictMono_coupling : StrictMono Real.tanh := by
-  intro x y hxy
-  rw [Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh]
-  have hcx : 0 < Real.cosh x := Real.cosh_pos _
-  have hcy : 0 < Real.cosh y := Real.cosh_pos _
-  rw [div_lt_div_iff₀ hcx hcy]
-  have hsub_pos : 0 < Real.sinh (y - x) := Real.sinh_pos_iff.mpr (sub_pos.mpr hxy)
-  have heq : Real.sinh (y - x) =
-      Real.sinh y * Real.cosh x - Real.cosh y * Real.sinh x := Real.sinh_sub y x
-  linarith
-
 /-- **Coupling-direction analyticity at a high-temperature point** (GJ §18.6): the infinite-volume
 cubic-Ising free-energy density at zero field is real-analytic in the **coupling** `J` at any point
 with `0 < β J` and `tanh (β J) < T`. Obtained from the `β`-direction unit-coupling capstone via the
@@ -99,7 +86,7 @@ theorem freeEnergyInfinite_latticeGraph_cubicExhaustion_analyticOnNhd_J_high_tem
   have hβJ_tanh : Real.tanh (β * J) < T := by
     have hlt : β * J < Real.artanh T := by
       rw [mul_comm]; exact (lt_div_iff₀ hβ).mp hJlt
-    calc Real.tanh (β * J) < Real.tanh (Real.artanh T) := real_tanh_strictMono_coupling hlt
+    calc Real.tanh (β * J) < Real.tanh (Real.artanh T) := real_tanh_strictMono hlt
       _ = T := Real.tanh_artanh hT_mem
   exact freeEnergyInfinite_latticeGraph_cubicExhaustion_analyticAt_J_h_zero d hR hT hTR
     (le_of_lt hT1) hkp2dR hρ2dR hkp2dT hρ2dT hβJ_pos hβJ_tanh

--- a/IsingModel/ClusterExpansion/MayerCore/CubicMayerHighTempIntervalAnalyticity.lean
+++ b/IsingModel/ClusterExpansion/MayerCore/CubicMayerHighTempIntervalAnalyticity.lean
@@ -32,19 +32,6 @@ namespace IsingModel
 
 open Ambient Set Filter Topology
 
-/-- `Real.tanh` is strictly monotone (local copy; the global version lives in `PseudoMass/Profile`,
-which is not on this import path). Proved from `sinh (y − x) > 0` for `x < y`. -/
-private theorem real_tanh_strictMono : StrictMono Real.tanh := by
-  intro x y hxy
-  rw [Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh]
-  have hcx : 0 < Real.cosh x := Real.cosh_pos _
-  have hcy : 0 < Real.cosh y := Real.cosh_pos _
-  rw [div_lt_div_iff₀ hcx hcy]
-  have hsub_pos : 0 < Real.sinh (y - x) := Real.sinh_pos_iff.mpr (sub_pos.mpr hxy)
-  have heq : Real.sinh (y - x) =
-      Real.sinh y * Real.cosh x - Real.cosh y * Real.sinh x := Real.sinh_sub y x
-  linarith
-
 /-- **High-temperature interval analyticity** (GJ §18.6): for `J > 0` and KP parameters
 `T, R` satisfying the convergence conditions, the infinite-volume cubic-Ising free-energy density at
 zero field is real-analytic on the whole high-temperature interval `β ∈ (0, artanh T / J)`. The

--- a/IsingModel/ClusterExpansion/MayerCore/ZeroBounds.lean
+++ b/IsingModel/ClusterExpansion/MayerCore/ZeroBounds.lean
@@ -236,6 +236,24 @@ theorem real_tanh_nonneg {x : ℝ} (hx : 0 ≤ x) : 0 ≤ Real.tanh x := by
   rw [Real.tanh_eq_sinh_div_cosh]
   exact div_nonneg (Real.sinh_nonneg_iff.mpr hx) (Real.cosh_pos x).le
 
+/-- **`Real.tanh` is strictly monotone** (shared §18.4 helper): `tanh` is
+strictly increasing on `ℝ`. Proved from `tanh = sinh / cosh` (`cosh > 0`) and
+`sinh (y - x) > 0` for `x < y`. Mathlib does not yet export
+`Real.tanh_strictMono`, so this single project-local copy is reused across the
+`ClusterExpansion` tanh-monotonicity lemmas. -/
+theorem real_tanh_strictMono : StrictMono Real.tanh := by
+  intro x y hxy
+  have hx_pos : 0 < Real.cosh x := Real.cosh_pos x
+  have hy_pos : 0 < Real.cosh y := Real.cosh_pos y
+  rw [Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh,
+      div_lt_div_iff₀ hx_pos hy_pos]
+  have h_sub : Real.sinh y * Real.cosh x - Real.sinh x * Real.cosh y =
+      Real.sinh (y - x) := by rw [Real.sinh_sub]; ring
+  have h_sinh_pos : 0 < Real.sinh (y - x) := by
+    rw [show (0 : ℝ) = Real.sinh 0 from Real.sinh_zero.symm]
+    exact Real.sinh_strictMono (sub_pos.mpr hxy)
+  linarith
+
 /-- **`log (vdPolymerFamilies_sum tanh(β·J))` analyticAt in `β`**
 (Step 608): under `0 ≤ β·J`, the function
 `β' ↦ Real.log (∑_Γ ∏_{P ∈ Γ} tanh(β'·J)^|P|)` is `AnalyticAt ℝ` at `β`.

--- a/IsingModel/ClusterExpansion/StrictPositivity/TanhMonotone.lean
+++ b/IsingModel/ClusterExpansion/StrictPositivity/TanhMonotone.lean
@@ -18,25 +18,6 @@ combines `polymerFreeEnergy_lt_of_lt_of_polymers_nonempty` (PR #1559)
 with the strict monotonicity of `Real.tanh` (proved here as a local
 helper from `sinh_strictMono`). -/
 
-/-- **`Real.tanh` strict monotonicity** (project-local helper):
-proved from `sinh_strictMono` via the identity
-`tanh y - tanh x = sinh(y - x) / (cosh x · cosh y)` (with both cosh
-positive). Mathlib doesn't yet export `Real.tanh_strictMono`. -/
-private theorem real_tanh_strictMono : StrictMono Real.tanh := by
-  intro x y hxy
-  have hx_pos : 0 < Real.cosh x := Real.cosh_pos x
-  have hy_pos : 0 < Real.cosh y := Real.cosh_pos y
-  rw [Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh,
-      div_lt_div_iff₀ hx_pos hy_pos]
-  -- Goal: sinh x · cosh y < sinh y · cosh x
-  -- Use: sinh y · cosh x - sinh x · cosh y = sinh(y - x) > 0.
-  have h_sub : Real.sinh y * Real.cosh x - Real.sinh x * Real.cosh y =
-      Real.sinh (y - x) := by rw [Real.sinh_sub]; ring
-  have h_sinh_pos : 0 < Real.sinh (y - x) := by
-    rw [show (0 : ℝ) = Real.sinh 0 from Real.sinh_zero.symm]
-    exact Real.sinh_strictMono (sub_pos.mpr hxy)
-  linarith
-
 /-- **`polymerFreeEnergy(tanh(β·J))` strictly increasing in β at fixed
 `J > 0` under polymers exist** (§18.4 tanh-monotonicity bundle). -/
 theorem polymerFreeEnergy_tanh_lt_of_lt_in_beta_of_polymers_nonempty

--- a/IsingModel/ClusterExpansion/TwoPointCorrelationHTBound.lean
+++ b/IsingModel/ClusterExpansion/TwoPointCorrelationHTBound.lean
@@ -78,7 +78,7 @@ theorem twoPointHTBoundValue_pos (Δ : ℕ) : 0 < twoPointHTBoundValue Δ := by
   exact div_pos (Real.exp_pos 8) hden
 
 /-- On the smaller KP threshold `r < 1/64`, the Mayer-difference coefficient is at most `8`. -/
-private lemma kpCoeff_le_eight {r : ℝ} (h0 : 0 ≤ r) (hr : r < 1 / 64) :
+lemma kpCoeff_le_eight {r : ℝ} (h0 : 0 ≤ r) (hr : r < 1 / 64) :
     (1 / (1 - r)) * (1 - 4 * r / (1 - r) ^ 2)⁻¹ ^ 2 ≤ 8 := by
   have hr_half : r < 1 / 2 := by linarith
   have hden_pos : 0 < 1 - r := by linarith
@@ -104,7 +104,7 @@ private lemma kpCoeff_le_eight {r : ℝ} (h0 : 0 ≤ r) (hr : r < 1 / 64) :
     (by norm_num : (0 : ℝ) ≤ (2 : ℝ))]
 
 /-- The elementary exponential identity used to package the per-component bound. -/
-private lemma activity_exp_card_identity (R : ℝ) (n : ℕ) :
+lemma activity_exp_card_identity (R : ℝ) (n : ℕ) :
     R ^ n * Real.exp (8 * ((n : ℝ) + 1)) = Real.exp 8 * (R * Real.exp 8) ^ n := by
   rw [mul_add, mul_one]
   have hmul : 8 * (n : ℝ) = (n : ℝ) * 8 := by ring

--- a/IsingModel/ClusterExpansion/TwoPointCorrelationInfiniteAnalytic.lean
+++ b/IsingModel/ClusterExpansion/TwoPointCorrelationInfiniteAnalytic.lean
@@ -294,40 +294,6 @@ private theorem correlationComplex_high_temp_expansion_h_zero_htSubgraphSum_on_u
     (fun z hz => twoPointHTUniformRadius_cosh_ne Δ J z hz)
     (fun z hz => twoPointHTUniformRadius_tanh_lt Δ J z hz)
 
-/-- On the smaller KP threshold `r < 1/64`, the Mayer-difference coefficient is at most `8`. -/
-private lemma uniform_kpCoeff_le_eight {r : ℝ} (h0 : 0 ≤ r) (hr : r < 1 / 64) :
-    (1 / (1 - r)) * (1 - 4 * r / (1 - r) ^ 2)⁻¹ ^ 2 ≤ 8 := by
-  have hr_half : r < 1 / 2 := by linarith
-  have hden_pos : 0 < 1 - r := by linarith
-  have hden_sq_pos : 0 < (1 - r) ^ 2 := pow_pos hden_pos 2
-  have hden_sq_ge : (1 / 4 : ℝ) ≤ (1 - r) ^ 2 := by
-    nlinarith [h0, hr_half]
-  have hrho_le : 4 * r / (1 - r) ^ 2 ≤ (1 / 2 : ℝ) := by
-    rw [div_le_iff₀ hden_sq_pos]
-    nlinarith [hden_sq_ge, hr]
-  have hone_minus_rho_pos : 0 < 1 - 4 * r / (1 - r) ^ 2 := by linarith
-  have hinv1 : 1 / (1 - r) ≤ (2 : ℝ) := by
-    rw [div_le_iff₀ hden_pos]
-    nlinarith [hr_half]
-  have hinv2 : (1 - 4 * r / (1 - r) ^ 2)⁻¹ ≤ (2 : ℝ) := by
-    rw [inv_le_comm₀ hone_minus_rho_pos (by norm_num : (0 : ℝ) < 2)]
-    linarith
-  have hinv2_nonneg : 0 ≤ (1 - 4 * r / (1 - r) ^ 2)⁻¹ :=
-    inv_nonneg.mpr (le_of_lt hone_minus_rho_pos)
-  have hsquare : (1 - 4 * r / (1 - r) ^ 2)⁻¹ ^ 2 ≤ (4 : ℝ) := by
-    nlinarith [mul_le_mul hinv2 hinv2 hinv2_nonneg (by norm_num : (0 : ℝ) ≤ (2 : ℝ))]
-  nlinarith [mul_le_mul hinv1 hsquare
-    (by positivity : 0 ≤ (1 - 4 * r / (1 - r) ^ 2)⁻¹ ^ 2)
-    (by norm_num : (0 : ℝ) ≤ (2 : ℝ))]
-
-/-- The elementary exponential identity used to package the per-component bound. -/
-private lemma uniform_activity_exp_card_identity (R : ℝ) (n : ℕ) :
-    R ^ n * Real.exp (8 * ((n : ℝ) + 1)) = Real.exp 8 * (R * Real.exp 8) ^ n := by
-  rw [mul_add, mul_one]
-  have hmul : 8 * (n : ℝ) = (n : ℝ) * 8 := by ring
-  rw [hmul, Real.exp_add, Real.exp_nat_mul, mul_pow]
-  ring
-
 /-- **Degree-uniform two-point norm bound on a connected `cosh≠0` / activity-radius domain.**
 On an open preconnected `U ∋ 0` where `cosh(βJ) ≠ 0` and `‖tanh(βJ)‖ < twoPointHTActivityRadius Δ`,
 the two-point correlation is bounded by `twoPointHTBoundValue Δ`, uniformly over `U`. The `ball 0`
@@ -399,7 +365,7 @@ theorem correlationComplex_two_point_norm_le_on_connected
     set κ : ℝ := (1 / (1 - rr)) * (1 - 4 * rr / (1 - rr) ^ 2)⁻¹ ^ 2 with hκdef
     have hrr_nonneg : 0 ≤ rr := by positivity
     have hκle : κ ≤ 8 := by
-      simpa [κ, rr] using uniform_kpCoeff_le_eight hrr_nonneg (by simpa [rr] using httG64)
+      simpa [κ, rr] using kpCoeff_le_eight hrr_nonneg (by simpa [rr] using httG64)
     have hdiff :=
       norm_mayerExpansionTermComplex_tsum_sub_Gavoid_le_support_card_complex
         (G := G) (C := C) (z := t) hkpt hρt
@@ -439,7 +405,7 @@ theorem correlationComplex_two_point_norm_le_on_connected
           exact mul_le_mul htpow hratio8 (norm_nonneg _) (pow_nonneg hRnonneg _)
       _ = A * a ^ C.card := by
           rw [hAdef, hadef]
-          exact uniform_activity_exp_card_identity R C.card
+          exact activity_exp_card_identity R C.card
   have hratioBound :=
     twoPointRatio_norm_le_geometric (G := G) (i := i) (j := j) hij t A a hAnonneg hanonneg hper hqG
   have hcompare :


### PR DESCRIPTION
Part of #4298 (post-axiom-free refactoring; goal B = simplification). Final #4298 item.

An independent investigation found the codebase already well-factored (lattice distance, connectivity, degree bounds, casts are single-canonical; no safe dedup there). Only **two** clusters had ≥2 real call sites and a clean shared home (respecting the project's anti-over-abstraction rule).

## Cluster 1 — two char-identical `private` arithmetic helpers (zero risk)
`kpCoeff_le_eight` and `activity_exp_card_identity` were duplicated **verbatim** in `ClusterExpansion/TwoPointCorrelationHTBound.lean` and `…/TwoPointCorrelationInfiniteAnalytic.lean` (as `private uniform_*`). `InfiniteAnalytic` already imports `HTBound`, so: de-`private` the two `HTBound` lemmas, delete the `uniform_*` copies, point the 2 call sites at the shared versions. Both are purely generic real arithmetic — no Ising content.

## Cluster 2 — `real_tanh_strictMono` defined 3× (low risk)
`StrictMono Real.tanh` (not exported by mathlib) had three copies: `StrictPositivity/TanhMonotone.lean`, `MayerCore/CubicMayerHighTempIntervalAnalyticity.lean`, and `MayerCore/CubicMayerCouplingDirectionAnalyticity.lean` (the last named `real_tanh_strictMono_coupling`). Added one public `real_tanh_strictMono` next to `real_tanh_nonneg` in the low-level `MayerCore/ZeroBounds.lean` (all three consumers already transitively import it), deleted the three copies, fixed the 4 call sites.

## Deferred
Cluster 3 (cross-hierarchy `tanh_nonneg` trio across `ClusterExpansion`/`Dobrushin`/`TransferMatrix`) needs a new shared low-level module imported by three separate hierarchies — not zero-risk; left for a follow-up.

## Verification
- `lake build` green (5530 jobs). `lake exe GKSTest` pass.
- No new linter warnings. `#print axioms` unchanged on the capstones = `[propext, Classical.choice, Quot.sound]`.
- No `def`/`theorem` *statement* changed (only privacy + de-duplication), so docs/index.md and tex/proof-guide.tex need no update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)