### PR TITLE
refactor(real-analysis): shared RealTanhAux module for tanh sign helpers — #4306 PR1

### DIFF
--- a/IsingModel/ClusterExpansion/MayerCore/ZeroBounds.lean
+++ b/IsingModel/ClusterExpansion/MayerCore/ZeroBounds.lean
@@ -1,4 +1,5 @@
 import IsingModel.ClusterExpansion.MayerCore.Terms
+import IsingModel.RealTanhAux
 
 /-!
 # Cluster Expansion Mayer Core Zero and Bounds
@@ -228,13 +229,6 @@ theorem log_vdPolymerFamilies_sum_analyticOnNhd_Ici_zero
       (fun s : ℝ => Real.log (∑ Γ ∈ vdCompatiblePolymerFamilies G,
                                  ∏ P ∈ Γ, s ^ P.card)) (Set.Ici 0) :=
   fun _ ht => log_vdPolymerFamilies_sum_analyticAt G ht
-
-/-- **`Real.tanh` is non-negative under non-negative argument** (helper
-for Step 608): `0 ≤ x → 0 ≤ Real.tanh x`. Uses `Real.sinh_nonneg_iff`
-and `Real.cosh_pos`. -/
-theorem real_tanh_nonneg {x : ℝ} (hx : 0 ≤ x) : 0 ≤ Real.tanh x := by
-  rw [Real.tanh_eq_sinh_div_cosh]
-  exact div_nonneg (Real.sinh_nonneg_iff.mpr hx) (Real.cosh_pos x).le
 
 /-- **`Real.tanh` is strictly monotone** (shared §18.4 helper): `tanh` is
 strictly increasing on `ℝ`. Proved from `tanh = sinh / cosh` (`cosh > 0`) and

--- a/IsingModel/RealTanhAux.lean
+++ b/IsingModel/RealTanhAux.lean
@@ -1,0 +1,29 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+
+/-!
+# Real hyperbolic-tangent sign helpers (shared low-level)
+
+Mathlib does not export `Real.tanh_nonneg` / `Real.tanh_pos` as named lemmas.
+These trivial sign facts are needed across three otherwise-disjoint `IsingModel`
+hierarchies (`ClusterExpansion`, `Dobrushin`, `TransferMatrix`), so they live here
+in a mathlib-only base module that all three can import without an import cycle
+(this module imports nothing from `IsingModel`, so no cycle is possible).
+
+See issue #4306 (cross-hierarchy generic-lemma de-duplication).
+-/
+
+namespace IsingModel
+
+/-- **`Real.tanh` is non-negative for a non-negative argument**: `0 ≤ x → 0 ≤ Real.tanh x`.
+Proved from `tanh = sinh / cosh` with `cosh > 0` and `sinh` non-negative on `[0, ∞)`. -/
+theorem real_tanh_nonneg {x : ℝ} (hx : 0 ≤ x) : 0 ≤ Real.tanh x := by
+  rw [Real.tanh_eq_sinh_div_cosh]
+  exact div_nonneg (Real.sinh_nonneg_iff.mpr hx) (Real.cosh_pos x).le
+
+/-- **`Real.tanh` is strictly positive for a positive argument**: `0 < x → 0 < Real.tanh x`.
+Proved from `tanh = sinh / cosh` with `cosh > 0` and `sinh` strictly positive on `(0, ∞)`. -/
+theorem real_tanh_pos {x : ℝ} (hx : 0 < x) : 0 < Real.tanh x := by
+  rw [Real.tanh_eq_sinh_div_cosh]
+  exact div_pos (Real.sinh_pos_iff.mpr hx) (Real.cosh_pos x)
+
+end IsingModel


### PR DESCRIPTION
Part of #4306 (cross-hierarchy generic-lemma de-duplication; refactoring follow-up to #4298). First of two PRs.

## What
Introduces a thin, **mathlib-only** base module `IsingModel/RealTanhAux.lean` (imports only `Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp` — nothing from `IsingModel`, so importing it from anywhere is **cycle-impossible by construction**). It hosts the `tanh` sign helpers shared across the otherwise-disjoint `ClusterExpansion` / `Dobrushin` / `TransferMatrix` hierarchies:
- `real_tanh_nonneg {x} (0 ≤ x) : 0 ≤ Real.tanh x` — **moved** here from `ClusterExpansion/MayerCore/ZeroBounds.lean`.
- `real_tanh_pos {x} (0 < x) : 0 < Real.tanh x` — for PR2 (will subsume `TransferMatrix`'s private `tanh_pos_of_pos` + inline strict-positivity re-proofs).

`ZeroBounds.lean` imports the new module and the local `real_tanh_nonneg` is **deleted** (atomic move — a copy would make `IsingModel.real_tanh_nonneg` ambiguous in files importing both). Its ~33 `ClusterExpansion/*` call sites resolve unchanged (same `IsingModel` namespace, via the transitive import). `real_tanh_strictMono` stays in `ZeroBounds` (ClusterExpansion-only; no cross-hierarchy demand — anti-over-abstraction).

PR2 will repoint the `Dobrushin`/`TransferMatrix`/`Concrete` consumers (`tanh_nonneg_of_nonneg`, `tanh_pos_of_pos`, ~8 inline re-proofs) to these shared lemmas and delete the duplicates.

## Design
Determined by an independent `claude -p` design: the three hierarchies share no IsingModel low-level home for this (routing through `ZeroBounds` would drag all of `ClusterExpansion` into `Dobrushin`/`TransferMatrix`), so a new mathlib-only module is the correct, cycle-safe host. `IsingModel.Basic` is the only common mathlib-only ancestor, but a dedicated narrow module avoids turning `Basic` into a grab-bag.

## Verification
- `lake build` green (olean 2050 → 2051, the new file); no warnings in touched files.
- `lake exe GKSTest` pass.
- `#print axioms` on the capstones unchanged = `[propext, Classical.choice, Quot.sound]`.
- `real_tanh_nonneg` now defined exactly once repo-wide; no docs/tex cite these helpers (no doc-sync needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)