### PR TITLE
refactor(dedup): repoint Dobrushin/TransferMatrix tanh-sign re-proofs to RealTanhAux — #4306 PR2

### DIFF
--- a/IsingModel/Concrete/LatticeGraphCorrelation/CubicBoxExtremalCoincidence.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/CubicBoxExtremalCoincidence.lean
@@ -215,7 +215,7 @@ theorem plusStateExpectation_eq_minusStateExpectation_originObs (d : ℕ) (hd : 
       = minusStateExpectation J h β (originLocalObs d g) hS := by
   have hβJ : 0 ≤ β * J := mul_nonneg hβ hJ
   have hα0 : 0 ≤ (2 * (d : ℝ)) * Real.tanh (β * J) :=
-    mul_nonneg (by positivity) (tanh_nonneg_of_nonneg hβJ)
+    mul_nonneg (by positivity) (real_tanh_nonneg hβJ)
   have hα1 : (2 * (d : ℝ)) * Real.tanh (β * J) < 1 := by
     have htanh := tanh_le_self hβJ
     have hnonneg : 0 ≤ 2 * (d : ℝ) := by positivity

--- a/IsingModel/Concrete/LatticeGraphCorrelation/LocalObservableExtremalCoincidence.lean
+++ b/IsingModel/Concrete/LatticeGraphCorrelation/LocalObservableExtremalCoincidence.lean
@@ -148,7 +148,7 @@ theorem gibbsExpectationBC_localObs_inducedLattice_dist_le_resolventTail (d : �
           (fun σ => O.φ (restrictConfig hS σ))|
       ≤ (∑ j : ↑O.S, siteOsc j O.φ) * resolventTail d ((2 * (d : ℝ)) * Real.tanh (β * J)) R := by
   have hα0 : 0 ≤ (2 * (d : ℝ)) * Real.tanh (β * J) :=
-    mul_nonneg (by positivity) (tanh_nonneg_of_nonneg hβJ)
+    mul_nonneg (by positivity) (real_tanh_nonneg hβJ)
   have hα1 : (2 * (d : ℝ)) * Real.tanh (β * J) < 1 := by
     have htanh := tanh_le_self hβJ
     have hnonneg : 0 ≤ 2 * (d : ℝ) := by positivity
@@ -235,7 +235,7 @@ theorem plusStateExpectation_eq_minusStateExpectation (d : ℕ) (hd : 1 ≤ d) {
     plusStateExpectation J h β O hS = minusStateExpectation J h β O hS := by
   have hβJ : 0 ≤ β * J := mul_nonneg hβ hJ
   have hα0 : 0 ≤ (2 * (d : ℝ)) * Real.tanh (β * J) :=
-    mul_nonneg (by positivity) (tanh_nonneg_of_nonneg hβJ)
+    mul_nonneg (by positivity) (real_tanh_nonneg hβJ)
   have hα1 : (2 * (d : ℝ)) * Real.tanh (β * J) < 1 := by
     have htanh := tanh_le_self hβJ
     have hnonneg : 0 ≤ 2 * (d : ℝ) := by positivity

--- a/IsingModel/Dobrushin/BoundaryInfluence.lean
+++ b/IsingModel/Dobrushin/BoundaryInfluence.lean
@@ -1,4 +1,5 @@
 import IsingModel.Dobrushin.SiteOscillation
+import IsingModel.RealTanhAux
 
 /-!
 # The multi-site boundary influence bound (GJ §17.1, Issue #4201)
@@ -119,9 +120,7 @@ theorem gibbsExpectationBC_singleton_localObs_agreesOff_dist_le {β J : ℝ} (h�
         = (singleSiteUpProbBC G β J h x η - singleSiteUpProbBC G β J h x η')
           * (f (Function.update η x Spin.up) - f (Function.update η x Spin.down)) by ring,
     abs_mul]
-  have htanh : 0 ≤ Real.tanh (β * J) := by
-    calc (0 : ℝ) = Real.tanh 0 := Real.tanh_zero.symm
-      _ ≤ Real.tanh (β * J) := tanh_le_tanh_of_le hβJ
+  have htanh : 0 ≤ Real.tanh (β * J) := real_tanh_nonneg hβJ
   exact mul_le_mul (singleSiteUpProbBC_agreesOff_dist_le G hβJ h x hagree)
     (abs_sub_update_le_siteOsc x f η) (abs_nonneg _)
     (mul_nonneg (Nat.cast_nonneg _) htanh)

--- a/IsingModel/Dobrushin/InfiniteVolumeBoundaryInfluence.lean
+++ b/IsingModel/Dobrushin/InfiniteVolumeBoundaryInfluence.lean
@@ -75,7 +75,7 @@ theorem gibbsExpectationBC_localObs_inducedLattice_boundary_influence_uniform_sm
             - gibbsExpectationBC (Ambient.inducedGraph (latticeGraph d) Λ) β (fun _ => J) h Λ' η' f|
           ≤ ε := by
   have hα0 : 0 ≤ (2 * (d : ℝ)) * Real.tanh (β * J) :=
-    mul_nonneg (by positivity) (tanh_nonneg_of_nonneg hβJ)
+    mul_nonneg (by positivity) (real_tanh_nonneg hβJ)
   have hα1 : (2 * (d : ℝ)) * Real.tanh (β * J) < 1 := by
     have htanh := tanh_le_self hβJ
     have hnonneg : 0 ≤ 2 * (d : ℝ) := by positivity

--- a/IsingModel/Dobrushin/InfiniteVolumeUniformInfluence.lean
+++ b/IsingModel/Dobrushin/InfiniteVolumeUniformInfluence.lean
@@ -191,7 +191,7 @@ private theorem isingDobrushinCoeff_induced_latticeGraph_le_uniform (d : ℕ)
       ≤ (2 * (d : ℝ)) * Real.tanh (β * J) := by
   have hdeg := induced_latticeGraph_maxDegree_le d Λ
   rw [isingDobrushinCoeff]
-  have htanh : 0 ≤ Real.tanh (β * J) := tanh_nonneg_of_nonneg hβJ
+  have htanh : 0 ≤ Real.tanh (β * J) := real_tanh_nonneg hβJ
   calc
     ((Ambient.inducedGraph (latticeGraph d) Λ).maxDegree : ℝ) * Real.tanh (β * J)
         ≤ ((2 * d : ℕ) : ℝ) * Real.tanh (β * J) := by
@@ -231,7 +231,7 @@ private theorem dobrushinResolvent_farSum_le_resolventTail_of_distance_control (
   let size : ↑Λ → ℕ := fun y => latticeDistance d x₀.val y.val
   have hα0 : 0 ≤ α := by
     dsimp [α]
-    exact mul_nonneg (by positivity) (tanh_nonneg_of_nonneg hβJ)
+    exact mul_nonneg (by positivity) (real_tanh_nonneg hβJ)
   have hα_le_beta : α ≤ β * J * (2 * (d : ℝ)) := by
     dsimp [α]
     have htanh := tanh_le_self hβJ

--- a/IsingModel/Dobrushin/InfiniteVolumeUniqueness.lean
+++ b/IsingModel/Dobrushin/InfiniteVolumeUniqueness.lean
@@ -150,7 +150,7 @@ theorem gibbsExpectationBC_originObs_cubicExhaustion_boundary_influence_uniform
               (fun _ => J) h Λ' η' (originObs d g (origin_mem_cubicBox d n))|
           ≤ ε := by
   have hα0 : 0 ≤ (2 * (d : ℝ)) * Real.tanh (β * J) :=
-    mul_nonneg (by positivity) (tanh_nonneg_of_nonneg hβJ)
+    mul_nonneg (by positivity) (real_tanh_nonneg hβJ)
   have hα1 : (2 * (d : ℝ)) * Real.tanh (β * J) < 1 := by
     have htanh := tanh_le_self hβJ
     have hnonneg : 0 ≤ 2 * (d : ℝ) := by positivity

--- a/IsingModel/Dobrushin/InfluenceMatrixDecay.lean
+++ b/IsingModel/Dobrushin/InfluenceMatrixDecay.lean
@@ -1,4 +1,5 @@
 import IsingModel.Dobrushin.DobrushinHighTemp
+import IsingModel.RealTanhAux
 
 /-!
 # Exponential decay of the Dobrushin influence-matrix powers (GJ §17.1)
@@ -65,18 +66,12 @@ noncomputable def isingDobrushinCoeff (β J : ℝ) : ℝ :=
   G.maxDegree * Real.tanh (β * J)
 
 omit [Fintype G.edgeSet] in
-/-- **`tanh(βJ) ≥ 0` for `0 ≤ βJ`**: `tanh 0 = 0 ≤ tanh(βJ)` by monotonicity. -/
-theorem tanh_nonneg_of_nonneg {β J : ℝ} (hβJ : 0 ≤ β * J) : 0 ≤ Real.tanh (β * J) := by
-  calc (0 : ℝ) = Real.tanh 0 := Real.tanh_zero.symm
-    _ ≤ Real.tanh (β * J) := tanh_le_tanh_of_le hβJ
-
-omit [Fintype G.edgeSet] in
 /-- **The influence matrix entries are nonnegative** (for `0 ≤ βJ`). -/
 theorem isingInfluenceMatrix_nonneg {β J : ℝ} (hβJ : 0 ≤ β * J) (x y : ι) :
     0 ≤ isingInfluenceMatrix G β J x y := by
   rw [isingInfluenceMatrix, isingInfluence]
   split
-  · exact tanh_nonneg_of_nonneg hβJ
+  · exact real_tanh_nonneg hβJ
   · exact le_refl 0
 
 omit [Fintype G.edgeSet] in
@@ -88,7 +83,7 @@ theorem isingInfluenceMatrix_rowSum_le {β J : ℝ} (hβJ : 0 ≤ β * J) (x : �
     isingInfluence_rowSum G β J x
   rw [hrow, isingDobrushinCoeff]
   exact mul_le_mul_of_nonneg_right (by exact_mod_cast G.degree_le_maxDegree x)
-    (tanh_nonneg_of_nonneg hβJ)
+    (real_tanh_nonneg hβJ)
 
 omit [Fintype G.edgeSet] in
 /-- **Geometric decay of the influence-matrix powers** (GJ §17.1): for `0 ≤ βJ`, the row sums of the
@@ -97,14 +92,14 @@ coefficient. The boundary influence on a site decays geometrically with the numb
 theorem isingInfluenceMatrix_pow_rowSum_le {β J : ℝ} (hβJ : 0 ≤ β * J) (n : ℕ) (x : ι) :
     ∑ y, ((isingInfluenceMatrix G β J) ^ n) x y ≤ (isingDobrushinCoeff G β J) ^ n :=
   matrix_pow_rowSum_le (isingInfluenceMatrix_nonneg G hβJ)
-    (mul_nonneg (Nat.cast_nonneg _) (tanh_nonneg_of_nonneg hβJ))
+    (mul_nonneg (Nat.cast_nonneg _) (real_tanh_nonneg hβJ))
     (isingInfluenceMatrix_rowSum_le G hβJ) n x
 
 omit [Fintype G.edgeSet] [DecidableEq ι] in
 /-- **The Dobrushin coefficient is nonnegative** (for `0 ≤ βJ`). -/
 theorem isingDobrushinCoeff_nonneg {β J : ℝ} (hβJ : 0 ≤ β * J) :
     0 ≤ isingDobrushinCoeff G β J :=
-  mul_nonneg (Nat.cast_nonneg _) (tanh_nonneg_of_nonneg hβJ)
+  mul_nonneg (Nat.cast_nonneg _) (real_tanh_nonneg hβJ)
 
 omit [Fintype G.edgeSet] [DecidableEq ι] in
 /-- **The Dobrushin coefficient is below `1` at high temperature** (GJ §17.1): if `0 ≤ βJ` and

--- a/IsingModel/Dobrushin/OscillationPropagation.lean
+++ b/IsingModel/Dobrushin/OscillationPropagation.lean
@@ -61,7 +61,7 @@ theorem isingInfluence_nonneg {β J : ℝ} (hβJ : 0 ≤ β * J) (x y : ι) :
     0 ≤ isingInfluence G β J x y := by
   rw [isingInfluence]
   split
-  · exact tanh_nonneg_of_nonneg hβJ
+  · exact real_tanh_nonneg hβJ
   · exact le_refl 0
 
 /-- **Oscillation propagation under the heat-bath operator** (GJ §17.1): for `0 ≤ βJ`,

--- a/IsingModel/Dobrushin/SingleSiteGeneralComparison.lean
+++ b/IsingModel/Dobrushin/SingleSiteGeneralComparison.lean
@@ -89,9 +89,7 @@ theorem heatBath_agreesOff_dist_le {β J : ℝ} (hβJ : 0 ≤ β * J) (h : ℝ) 
       ≤ ((S ∩ G.neighborFinset x).card : ℝ) * Real.tanh (β * J) * siteOsc x f
         + ∑ y ∈ S, siteOsc y f := by
   classical
-  have htanh_nonneg : 0 ≤ Real.tanh (β * J) := by
-    calc (0 : ℝ) = Real.tanh 0 := Real.tanh_zero.symm
-      _ ≤ Real.tanh (β * J) := tanh_le_tanh_of_le hβJ
+  have htanh_nonneg : 0 ≤ Real.tanh (β * J) := real_tanh_nonneg hβJ
   simp only [heatBath]
   rw [gibbsExpectationBC_singleton_eq G β J h x η f, gibbsExpectationBC_singleton_eq G β J h x η' f]
   set p := singleSiteUpProbBC G β J h x η with hp

--- a/IsingModel/Dobrushin/SweepContraction.lean
+++ b/IsingModel/Dobrushin/SweepContraction.lean
@@ -37,9 +37,7 @@ omit [Fintype G.edgeSet] in
 Δ(G)·tanh(βJ) = α`. -/
 theorem isingInfluence_rowSum_le_dobrushinCoeff {β J : ℝ} (hβJ : 0 ≤ β * J) (x : ι) :
     ∑ y, isingInfluence G β J x y ≤ isingDobrushinCoeff G β J := by
-  have htanh : 0 ≤ Real.tanh (β * J) := by
-    calc (0 : ℝ) = Real.tanh 0 := Real.tanh_zero.symm
-      _ ≤ Real.tanh (β * J) := tanh_le_tanh_of_le hβJ
+  have htanh : 0 ≤ Real.tanh (β * J) := real_tanh_nonneg hβJ
   have hrow : ∑ y, isingInfluence G β J x y
       = ((Finset.univ ∩ G.neighborFinset x).card : ℝ) * Real.tanh (β * J) :=
     sum_isingInfluence_eq G β J x Finset.univ

--- a/IsingModel/TransferMatrix/FreeLayerWalshOpenAxisInfiniteVolume.lean
+++ b/IsingModel/TransferMatrix/FreeLayerWalshOpenAxisInfiniteVolume.lean
@@ -1,5 +1,6 @@
 import IsingModel.TransferMatrix.FreeLayerWalshOpenAxisDecay
 import IsingModel.AmbientLattice.CorrelationInfinite.Bounds
+import IsingModel.RealTanhAux
 
 /-!
 # Infinite-volume free-layer axis-graph decay
@@ -27,11 +28,6 @@ open scoped BigOperators
 def freeLayerAxisTwoPoint (d : ℕ) (x : Fin d → ℤ) (sep : ℕ) :
     Finset (Fin (d + 1) → ℤ) :=
   {freeLayerAxisPoint d 0 x, freeLayerAxisPoint d sep x}
-
-/-- Positivity of `tanh a` in the positive coupling-temperature regime. -/
-private theorem tanh_pos_of_pos {a : ℝ} (ha : 0 < a) : 0 < Real.tanh a := by
-  rw [Real.tanh_eq_sinh_div_cosh]
-  exact div_pos (Real.sinh_pos_iff.mpr ha) (Real.cosh_pos _)
 
 /-- Finite cubic-box axis decay in `tanh` form, with the transverse coordinate
 given as an ambient lattice point known to lie in the transverse cubic box. -/
@@ -150,7 +146,7 @@ theorem abs_correlationAlongExhaustion_freeLayerAxisGraph_axis_le_tanh
     conv_lhs =>
       arg 1
       rw [hzero]
-    simpa using pow_nonneg (tanh_pos_of_pos hβJ).le sep
+    simpa using pow_nonneg (real_tanh_pos hβJ).le sep
 
 /-- Stagewise cubic-exhaustion free-layer axis decay in mass form. -/
 theorem abs_correlationAlongExhaustion_freeLayerAxisGraph_axis_le_exp_neg_mass

--- a/IsingModel/TransferMatrix/FreeLayerWalshSpectralWindow.lean
+++ b/IsingModel/TransferMatrix/FreeLayerWalshSpectralWindow.lean
@@ -576,10 +576,7 @@ theorem freeLayerWalshSpectralWindow_tanh
       |freeLayerWalshEigenvalue (S := S) a i| ≤
         Real.tanh a * transferEigenvalueTop a ^ Fintype.card S := by
   intro i hi
-  have htanh_nonneg : 0 ≤ Real.tanh a := by
-    rw [Real.tanh_eq_sinh_div_cosh]
-    exact div_nonneg (Real.sinh_nonneg_iff.mpr ha)
-      (le_of_lt (Real.cosh_pos a))
+  have htanh_nonneg : 0 ≤ Real.tanh a := real_tanh_nonneg ha
   have htanh_le_one : Real.tanh a ≤ 1 := le_of_lt (Real.tanh_lt_one a)
   have hcard_pos : 0 < (layerStateDownSet i).card :=
     layerStateDownSet_card_pos_of_ne_freeLayerWalshTop (S := S) hi

--- a/IsingModel/TransferMatrix/OneDimCorrelationLength.lean
+++ b/IsingModel/TransferMatrix/OneDimCorrelationLength.lean
@@ -1,4 +1,5 @@
 import IsingModel.TransferMatrix.OneDimTwoPoint
+import IsingModel.RealTanhAux
 
 /-!
 # Correlation length and mass of the 1D Ising chain (GJ §17.1, §17.5)
@@ -56,9 +57,7 @@ theorem correlationMass_eq_inv_length (a : ℝ) :
 `m = correlationMass a`, for `a = β J > 0` (so `tanh a > 0`). -/
 theorem tanh_pow_eq_exp_neg_mass {a : ℝ} (ha : 0 < a) (n : ℕ) :
     Real.tanh a ^ n = Real.exp (-(correlationMass a) * n) := by
-  have htanh_pos : 0 < Real.tanh a := by
-    rw [Real.tanh_eq_sinh_div_cosh]
-    exact div_pos (Real.sinh_pos_iff.mpr ha) (Real.cosh_pos a)
+  have htanh_pos : 0 < Real.tanh a := real_tanh_pos ha
   rw [correlationMass, neg_neg, mul_comm, ← Real.log_pow,
     Real.exp_log (pow_pos htanh_pos n)]
 

--- a/IsingModel/TransferMatrix/OneDimSusceptibility.lean
+++ b/IsingModel/TransferMatrix/OneDimSusceptibility.lean
@@ -58,9 +58,7 @@ theorem isingSusceptibility1D_eq_two_tsum_sub_one {a : ℝ} (ha : 0 < a) :
 
 /-- The susceptibility is strictly positive for `a = β J > 0`. -/
 theorem isingSusceptibility1D_pos {a : ℝ} (ha : 0 < a) : 0 < isingSusceptibility1D a := by
-  have htanh_pos : 0 < Real.tanh a := by
-    rw [Real.tanh_eq_sinh_div_cosh]
-    exact div_pos (Real.sinh_pos_iff.mpr ha) (Real.cosh_pos a)
+  have htanh_pos : 0 < Real.tanh a := real_tanh_pos ha
   have htanh_lt : Real.tanh a < 1 := Real.tanh_lt_one a
   rw [isingSusceptibility1D]
   apply div_pos <;> linarith

--- a/IsingModel/TransferMatrix/OneSiteLayerOpenBoundaryWindow.lean
+++ b/IsingModel/TransferMatrix/OneSiteLayerOpenBoundaryWindow.lean
@@ -1,5 +1,6 @@
 import IsingModel.TransferMatrix.OneSiteLayerSpectralWindow
 import IsingModel.TransferMatrix.LayerOpenBoundaryWindowSimple
+import IsingModel.RealTanhAux
 import IsingModel.TransferMatrix.LayerOpenSimpleSpectrum
 
 /-!
@@ -191,9 +192,7 @@ theorem correlation_oneSiteLayerOpenSlabGraph_abs_le_of_simpleSpectrum
               (layerInternalWeight (⊥ : SimpleGraph (PUnit.{1})) p))
             oneSiteLayerTop (Real.tanh (p.β * p.J))) *
           Real.tanh (p.β * p.J) ^ sep := by
-  have htanh_nonneg : 0 ≤ Real.tanh (p.β * p.J) := by
-    rw [Real.tanh_eq_sinh_div_cosh]
-    exact le_of_lt (div_pos (Real.sinh_pos_iff.mpr hβJ) (Real.cosh_pos _))
+  have htanh_nonneg : 0 ≤ Real.tanh (p.β * p.J) := real_tanh_nonneg hβJ.le
   have htanh_lt_cap :
       Real.tanh (p.β * p.J) <
         layerOpenBoundarySpectralWindowCap

--- a/IsingModel/TransferMatrix/TwoSiteFreeLayerSpectralWindow.lean
+++ b/IsingModel/TransferMatrix/TwoSiteFreeLayerSpectralWindow.lean
@@ -1,5 +1,6 @@
 import IsingModel.TransferMatrix.OneSiteLayerSpectralWindow
 import Mathlib.LinearAlgebra.Matrix.Kronecker
+import IsingModel.RealTanhAux
 
 /-!
 # Two-site free-layer spectral window
@@ -212,9 +213,7 @@ theorem twoSiteFreeTransferSpectralWindow_tanh {a : ℝ} (ha : 0 ≤ a) :
             ring
       _ ≤ Real.tanh a * (transferEigenvalueTop a ^ 2) := le_rfl
   · have hbot_nonneg := transferEigenvalueBot_nonneg_of_nonneg ha
-    have htanh_nonneg : 0 ≤ Real.tanh a := by
-      rw [Real.tanh_eq_sinh_div_cosh]
-      exact div_nonneg (Real.sinh_nonneg_iff.mpr ha) (Real.cosh_pos a).le
+    have htanh_nonneg : 0 ≤ Real.tanh a := real_tanh_nonneg ha
     have htanh_le_one : Real.tanh a ≤ 1 := le_of_lt (Real.tanh_lt_one a)
     have htop_sq_nonneg : 0 ≤ transferEigenvalueTop a ^ 2 := sq_nonneg _
     have htanh_sq_le : Real.tanh a * Real.tanh a ≤ Real.tanh a := by


### PR DESCRIPTION
Part of #4306 (cross-hierarchy generic-lemma de-duplication). Final PR (closes #4306).

Repoints every `Dobrushin`/`TransferMatrix`/`Concrete` consumer to the shared `IsingModel.real_tanh_nonneg` / `real_tanh_pos` (from `RealTanhAux`, PR1 #4309) and deletes the duplicates.

## Changes (16 files)
- `Dobrushin/InfluenceMatrixDecay.lean`: deleted `theorem tanh_nonneg_of_nonneg` (+ its `omit … in`); 4 internal uses → `real_tanh_nonneg hβJ`.
- Repointed `tanh_nonneg_of_nonneg hβJ → real_tanh_nonneg hβJ` (drop-in: the general `{x}(0≤x)` weakens `{β J}(0≤β*J)` every site satisfies) in `Dobrushin/{OscillationPropagation,InfiniteVolumeUniqueness,InfiniteVolumeUniformInfluence×2,InfiniteVolumeBoundaryInfluence}` + `Concrete/LatticeGraphCorrelation/{CubicBoxExtremalCoincidence,LocalObservableExtremalCoincidence×2}`.
- `TransferMatrix/FreeLayerWalshOpenAxisInfiniteVolume.lean`: deleted `private tanh_pos_of_pos`; use → `real_tanh_pos hβJ`.
- Replaced **8 inline** tanh-sign `have` re-proofs (6 nonneg, 2 pos) across `Dobrushin/{SingleSiteGeneralComparison,SweepContraction,BoundaryInfluence}` + `TransferMatrix/{FreeLayerWalshSpectralWindow,TwoSiteFreeLayerSpectralWindow,OneSiteLayerOpenBoundaryWindow,OneDimSusceptibility,OneDimCorrelationLength}` with the shared lemmas (all clean drop-ins).
- Added `import IsingModel.RealTanhAux` to touched files lacking it transitively.
- **Deliberately left untouched** `Dobrushin/{SingleSiteInfluence,SingleSiteInfluenceMatrix}` — those prove `0 ≤ Real.tanh b − Real.tanh a` (a monotonicity *difference* fact), not `0 ≤ Real.tanh x`; not duplicates.

After this PR, `grep "tanh_nonneg_of_nonneg\|tanh_pos_of_pos" IsingModel/` is **empty** — the tanh-sign fact has a single shared home.

## Verification
- `lake build` green (5531 jobs); no warnings in touched files.
- `lake exe GKSTest` pass.
- `#print axioms` on the capstones unchanged = `[propext, Classical.choice, Quot.sound]`.
- No statement changes (only hypothesis-weakening every call site accepts); no new axioms; no `set_option linter` added; docs/tex cite none of these helpers (no doc-sync).

Closes #4306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)