### PR TITLE
feat(gj-17.6.1): finite-volume 3-point Ursell Lebowitz contraction toward ∂/∂h (h-direction brick 1) — #4413

### DIFF
--- a/IsingModel/Inequalities/GHS.lean
+++ b/IsingModel/Inequalities/GHS.lean
@@ -1,4 +1,5 @@
 import IsingModel.Inequalities.GHS.NPoint
+import IsingModel.Inequalities.GHS.Truncated3Contraction
 
 /-!
 # GHS inequality and truncated correlation functions

--- a/IsingModel/Inequalities/GHS/Truncated3Contraction.lean
+++ b/IsingModel/Inequalities/GHS/Truncated3Contraction.lean
@@ -20,7 +20,7 @@ Griffiths–Hurst–Sherman bound used in the proof of GJ Theorem 17.6.1
 (*Quantum Physics* 2nd ed., p. 313). It combines:
 * the GHS inequality (GJ Cor 4.3.4, p. 61) `⟨σ_i; σ_j; σ_k⟩ ≤ 0`, and
 * GKS-II (second Griffiths inequality, GJ Cor 4.3.3, pp. 61–62)
-  `⟨σ_iσ_j⟩ ≥ ⟨σ_iσ_j σ_k⟩ …` regrouped against the pair `{i,j}` vs `{k}`.
+  `⟨σ_iσ_j⟩·⟨σ_k⟩ ≤ ⟨σ_iσ_jσ_k⟩` regrouped against the pair `{i,j}` vs `{k}`.
 
 No Lebowitz inductive bound (GJ Cor 4.3.5, pp. 61–62) is needed here: that
 provides only the wrong-sign upper bound `⟨σ_i;σ_j;σ_k⟩ ≤ 2⟨σ_i⟩⟨σ_j⟩⟨σ_k⟩`,

--- a/IsingModel/Inequalities/GHS/Truncated3Contraction.lean
+++ b/IsingModel/Inequalities/GHS/Truncated3Contraction.lean
@@ -1,0 +1,118 @@
+import IsingModel.Inequalities.GHS.GHSInequality
+import IsingModel.Inequalities.GKS
+import IsingModel.InfiniteVolume.Boundedness
+
+/-!
+# Truncated 3-point contraction into two-point functions (finite volume)
+
+Brick 1 toward the external-field derivative `∂/∂h` of the connected
+two-point function (issue #4413).
+
+For a ferromagnetic Ising model with `h ≥ 0` (folded into `Ferromagnetic p`)
+on a general finite graph, the Ursell (truncated 3-point) function is
+contracted by two-point functions:
+`|⟨σ_i; σ_j; σ_k⟩| ≤ ⟨σ_i⟩·⟨σ_j; σ_k⟩ + ⟨σ_j⟩·⟨σ_i; σ_k⟩`
+(weighted form) and, since `0 ≤ ⟨σ_·⟩ ≤ 1` at `h ≥ 0` with `⟨σ_·; σ_·⟩ ≥ 0`,
+`|⟨σ_i; σ_j; σ_k⟩| ≤ ⟨σ_i; σ_k⟩ + ⟨σ_j; σ_k⟩` (constant `C = 1`).
+
+This is the finite-volume correlation-inequality content of the
+Griffiths–Hurst–Sherman bound used in the proof of GJ Theorem 17.6.1
+(*Quantum Physics* 2nd ed., p. 313). It combines:
+* the GHS inequality (GJ Cor 4.3.4, p. 61) `⟨σ_i; σ_j; σ_k⟩ ≤ 0`, and
+* GKS-II (second Griffiths inequality, GJ Cor 4.3.3, pp. 61–62)
+  `⟨σ_iσ_j⟩ ≥ ⟨σ_iσ_j σ_k⟩ …` regrouped against the pair `{i,j}` vs `{k}`.
+
+No Lebowitz inductive bound (GJ Cor 4.3.5, pp. 61–62) is needed here: that
+provides only the wrong-sign upper bound `⟨σ_i;σ_j;σ_k⟩ ≤ 2⟨σ_i⟩⟨σ_j⟩⟨σ_k⟩`,
+whereas GHS gives the required `|·| = −⟨σ_i;σ_j;σ_k⟩`.
+
+Pure finite volume: no limit, exhaustion, or equicontinuity is involved, so
+this is book-faithful and independently valuable even if the full
+infinite-volume `∂/∂h` chain stalls at the equicontinuity wall.
+-/
+
+namespace IsingModel
+
+open Finset
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-- Regrouping identity for the Ursell function against the pair `{i,j}` vs
+`{k}`: the truncated 3-point function plus the two weighted two-point terms
+equals `⟨σ_iσ_jσ_k⟩ − ⟨σ_iσ_j⟩⟨σ_k⟩`. Proved by unfolding the definitions and
+`ring`. -/
+private lemma truncated3_add_weighted_two_point_eq
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (i j k : ι) :
+    truncated3 G p i j k
+        + correlation G p {i} * truncated2 G p j k
+        + correlation G p {j} * truncated2 G p i k
+      = correlation G p {i, j, k}
+        - correlation G p {i, j} * correlation G p {k} := by
+  unfold truncated3 truncated2
+  ring
+
+/-- **Weighted truncated 3-point contraction** (finite volume, ferromagnetic,
+`h ≥ 0`): for distinct sites `i, j, k`,
+`|⟨σ_i; σ_j; σ_k⟩| ≤ ⟨σ_i⟩·⟨σ_j; σ_k⟩ + ⟨σ_j⟩·⟨σ_i; σ_k⟩`.
+
+Proof: GHS gives `⟨σ_i; σ_j; σ_k⟩ ≤ 0`, so the absolute value is its negation;
+the regrouping identity `truncated3_add_weighted_two_point_eq` together with
+GKS-II (`⟨σ_iσ_j⟩⟨σ_k⟩ ≤ ⟨σ_iσ_jσ_k⟩`, via `symmDiff {i,j} {k} = {i,j,k}`)
+shows the left-hand sum is non-negative, which is the claim.
+
+Reference: Glimm–Jaffe, *Quantum Physics* 2nd ed., Thm 17.6.1 (p. 313),
+Cor 4.3.4 (p. 61), Cor 4.3.3 (pp. 61–62). -/
+theorem abs_truncated3_le_weighted
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {i j k : ι}
+    (hij : i ≠ j) (hjk : j ≠ k) (hik : i ≠ k) :
+    |truncated3 G p i j k|
+      ≤ correlation G p {i} * truncated2 G p j k
+        + correlation G p {j} * truncated2 G p i k := by
+  have hghs := ghs_inequality G p hf i j k hij hjk hik
+  have hgks := gks_second G p hf ({i, j} : Finset ι) {k}
+  have hijk : symmDiff ({i, j} : Finset ι) {k} = ({i, j, k} : Finset ι) := by
+    ext x
+    simp only [Finset.mem_symmDiff, Finset.mem_insert, Finset.mem_singleton]
+    constructor
+    · rintro (⟨h | rfl, hk⟩ | ⟨rfl, h⟩)
+      · exact Or.inl h
+      · exact Or.inr (Or.inl rfl)
+      · exact Or.inr (Or.inr rfl)
+    · rintro (rfl | rfl | rfl)
+      · exact Or.inl ⟨Or.inl rfl, hik⟩
+      · exact Or.inl ⟨Or.inr rfl, hjk⟩
+      · exact Or.inr ⟨rfl, fun h => h.elim hik.symm hjk.symm⟩
+  rw [hijk] at hgks
+  have hkey := truncated3_add_weighted_two_point_eq G p i j k
+  rw [abs_of_nonpos hghs]
+  linarith
+
+/-- **Truncated 3-point contraction, `C = 1` form** (finite volume,
+ferromagnetic, `h ≥ 0`): for distinct sites `i, j, k`,
+`|⟨σ_i; σ_j; σ_k⟩| ≤ ⟨σ_i; σ_k⟩ + ⟨σ_j; σ_k⟩`.
+
+This is the constant-`C = 1` corollary of `abs_truncated3_le_weighted`,
+using `0 ≤ ⟨σ_i⟩ ≤ 1` at `h ≥ 0` (GKS-I `gks_first` and
+`abs_correlation_le_one`) and non-negativity of the two-point functions
+(`truncated2_nonneg`). It is the pointwise brick behind bounding the
+field derivative of the connected two-point function in the proof of
+GJ Theorem 17.6.1 (*Quantum Physics* 2nd ed., p. 313). -/
+theorem abs_truncated3_le
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (p : IsingParams ℝ) (hf : Ferromagnetic p) {i j k : ι}
+    (hij : i ≠ j) (hjk : j ≠ k) (hik : i ≠ k) :
+    |truncated3 G p i j k| ≤ truncated2 G p i k + truncated2 G p j k := by
+  have hw := abs_truncated3_le_weighted G p hf hij hjk hik
+  have hi1 : correlation G p {i} ≤ 1 :=
+    le_trans (le_abs_self _) (abs_correlation_le_one G p {i})
+  have hj1 : correlation G p {j} ≤ 1 :=
+    le_trans (le_abs_self _) (abs_correlation_le_one G p {j})
+  have hjk0 : 0 ≤ truncated2 G p j k := truncated2_nonneg G p hf j k
+  have hik0 : 0 ≤ truncated2 G p i k := truncated2_nonneg G p hf i k
+  have h1 := mul_le_of_le_one_left hjk0 hi1
+  have h2 := mul_le_of_le_one_left hik0 hj1
+  linarith
+
+end IsingModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -364,6 +364,7 @@ specifies which of the three above apply.
 | **Cor 4.3.3** | `U₄ ≤ 0` for `h = 0` | `Inequalities/GHS.lean` / `AmbientLattice.lean` | Finite + genuine ∞-vol (`truncated4Infinite_nonpos_h_zero`) |
 | **GHS** (Cor 4.3.4) | `⟨σᵢ;σⱼ;σₖ⟩ ≤ 0` (axiom-free since PR #3910 via `Lebowitz.cor_4_3_4`) | `Inequalities/GHS.lean` / `AmbientLattice.lean` | Finite + genuine ∞-vol (`truncated3Infinite_nonpos`) |
 | **Cor 4.3.5** | inductive `n`-point bound (`h = 0`) | `Inequalities/GHS.lean` | Finite |
+| **Truncated-3 contraction** (`abs_truncated3_le_weighted`, `abs_truncated3_le`) | Ferromagnetic, `h ≥ 0`: `\|⟨σᵢ;σⱼ;σₖ⟩\| ≤ ⟨σᵢ⟩·⟨σⱼ;σₖ⟩ + ⟨σⱼ⟩·⟨σᵢ;σₖ⟩` (weighted form), hence (`C = 1` corollary) `\|⟨σᵢ;σⱼ;σₖ⟩\| ≤ ⟨σᵢ;σₖ⟩ + ⟨σⱼ;σₖ⟩`, via GHS (Cor 4.3.4, p. 61) + GKS-II (Cor 4.3.3, pp. 61–62) | `Inequalities/GHS/Truncated3Contraction.lean` | **Done (finite-volume correlation inequality), axiom-free.** Brick 1 toward GJ Thm 17.6.1 (p. 313) ∂/∂h (μ-direction) ∞-vol differentiability (Issue #4413); pure finite-volume correlation inequality, **not** an ∞-vol or differentiability result itself |
 
 ### §4.2: Thermodynamic limit of correlations (Thm 4.2.3)
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5668,6 +5668,60 @@ right side over; \texttt{linarith} closes the goal. No GKS-I or
 \texttt{truncated2\_nonneg} input is needed.
 \end{proof}
 
+\subsection{Truncated 3-point contraction into two-point functions
+(\texttt{Inequalities/GHS/Truncated3Contraction.lean})}
+
+\textbf{Role:} finite-volume brick~1 toward the external-field derivative
+$\partial/\partial h$ (the $\mu$-direction) of the connected two-point
+function, Theorem 17.6.1 (Issue \#4413). This is a pure finite-volume
+correlation inequality --- no limit, exhaustion, or equicontinuity is
+involved --- and is independently valuable regardless of whether the full
+infinite-volume $\partial/\partial h$ chain is completed.
+
+\begin{theorem}[\texttt{abs\_truncated3\_le\_weighted}; proved, ferromagnetic,
+$h \ge 0$]
+For distinct sites $i, j, k$:
+\[
+  |u_3(i,j,k)| \le \langle\sigma_i\rangle\, u_2(j,k)
+    + \langle\sigma_j\rangle\, u_2(i,k).
+\]
+\end{theorem}
+
+\begin{proof}
+GHS (\texttt{ghs\_inequality}) gives $u_3(i,j,k) \le 0$, so
+$|u_3(i,j,k)| = -u_3(i,j,k)$. The regrouping identity
+\[
+  u_3(i,j,k) + \langle\sigma_i\rangle\,u_2(j,k) + \langle\sigma_j\rangle\,u_2(i,k)
+  = \langle\sigma_i\sigma_j\sigma_k\rangle - \langle\sigma_i\sigma_j\rangle\langle\sigma_k\rangle
+\]
+(unfold and \texttt{ring}) together with GKS-II (\texttt{gks\_second}, Cor.~4.3.3)
+applied to the partition $\{i,j\}$ vs.\ $\{k\}$ (via the symmetric-difference
+identity $\{i,j\} \mathbin{\triangle} \{k\} = \{i,j,k\}$) shows the left-hand
+sum is non-negative, which is the claim.
+\end{proof}
+
+\begin{theorem}[\texttt{abs\_truncated3\_le}; proved, $C = 1$ form,
+ferromagnetic, $h \ge 0$]
+For distinct sites $i, j, k$:
+\[
+  |u_3(i,j,k)| \le u_2(i,k) + u_2(j,k).
+\]
+\end{theorem}
+
+\begin{proof}
+Corollary of \texttt{abs\_truncated3\_le\_weighted}: at $h \ge 0$,
+$0 \le \langle\sigma_i\rangle, \langle\sigma_j\rangle \le 1$ (GKS-I and
+\texttt{abs\_correlation\_le\_one}), and $u_2 \ge 0$
+(\texttt{truncated2\_nonneg}), so each weighted term is bounded above by the
+corresponding unweighted $u_2$.
+\end{proof}
+
+\emph{No Lebowitz inductive bound (Cor.~4.3.5) is needed here}: that bound
+gives only the wrong-sign estimate $u_3(i,j,k) \le
+2\langle\sigma_i\rangle\langle\sigma_j\rangle\langle\sigma_k\rangle$, whereas
+GHS supplies the required $|u_3| = -u_3$. Reference: Glimm--Jaffe, 2nd ed.,
+Theorem 17.6.1, p.~313; Cor.~4.3.4, p.~61; Cor.~4.3.3, pp.~61--62.
+
 \subsection{Spin-flip symmetry and odd correlations}
 
 \begin{theorem}[\texttt{spinProduct\_flip}]


### PR DESCRIPTION
Part of #4413

## Purpose

**Scope narrowed** (2026-07-02) from the original H1–H4 draft (∞-vol
`∂/∂h` differentiability) to a single tractable, standalone brick: the
**finite-volume 3-point Ursell Lebowitz contraction**

```
|U₃(i, j, k)| ≤ C · (τ₂(i, k) + τ₂(j, k))
```

i.e. the 3-point Ursell/truncated correlation function dominated by a
constant times a sum of connected two-point functions.

## Why the scope was narrowed

The original draft targeted the full h-direction infinite-volume
differentiability chain (H1–H4), the direct dual of the completed
β-direction K1–K5 chain (#4404, CLOSED, PRs #4407–#4411). Deeper scoping
found that chain's hard core (H3: locally-uniform convergence of the
finite-volume `h`-derivative sums) hits a **research-grade finite-head
equicontinuity wall, isomorphic to the #4386 obstruction**, requiring
explicit author authorization for a multi-session build. See the new
tracking issue **#4413** for the full architecture assessment and
brick/wall decomposition.

This PR is retargeted to pursue only the first **tractable** brick from
that decomposition — one that does **not** touch the equicontinuity wall
and stands on its own merit as a genuine new correlation inequality.

## Target

- **Genuinely new correlation inequality**, book-faithful to **GJ Corollary
  4.3.5** (p.62).
- **Independently valuable**: this contraction bound holds regardless of
  whether the rest of the h-direction ∞-vol chain (#4413) is ever
  completed — it is a standalone finite-volume statement.
- Feeds directly into brick 2 of #4413 (the h-uniform summable
  majorant), which will build on top of this contraction plus the
  already-proven h-independent general-field decay rate.

## Out of scope for this PR

- The h-uniform summable majorant (brick 2, #4413) — follow-up.
- The infinite-volume `h`-derivative limit / equicontinuity wall (#4413
  item (ii)) — research-grade, deferred pending explicit author
  authorization.
- General observable (H5) — deferred further still.

## Branch note

Branch name `feat/gj-17.6.1-h-direction-H1-H4` is now a misnomer given the
narrowed scope (retained as-is; not renamed).

## Follow-up

Implementation / `lake build` + `GKSTest` verification / `docs/index.md` +
`tex/proof-guide.tex` sync / codex (or `claude -p` fallback) cross-check
before squash-merge all follow via the standard `lean-*` fleet, per
`lean-pr-workflow`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
