### PR TITLE
refactor(kp): parameterize moment-core over abstract polymer set 𝒫 (field-CE F1 foundation R1) — #4433

### DIFF
--- a/IsingModel/ClusterExpansion/FixedVertexChainMid.lean
+++ b/IsingModel/ClusterExpansion/FixedVertexChainMid.lean
@@ -84,7 +84,7 @@ theorem fixedVertexRootedParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.e
             simp [hroot, hdefault]
     _ = ∑ P ∈ rootedPolymers G root,
           (P.card : ℝ) ^ k 0 * (Real.exp 1 * |t|) ^ P.card := by
-          rw [rootedPolymers, Finset.sum_filter]
+          rw [rootedPolymers, rootedGasPolymers, Finset.sum_filter]
 
 /-- The fixed-root peel bound satisfies the same erase/update recursion as the unfiltered
 peel bound. -/

--- a/IsingModel/ClusterExpansion/Penrose/PolymerSeqTreeKP.lean
+++ b/IsingModel/ClusterExpansion/Penrose/PolymerSeqTreeKP.lean
@@ -44,7 +44,7 @@ theorem polymerSeqTree_child_mem_incompatiblePolymers (G : SimpleGraph ι)
     {H : SimpleGraph α} (hsub : H ≤ polymerSeqIncompatibilityGraph ω) (hH : H.IsTree)
     (r v : α) (hv : v ≠ r) :
     ω v ∈ incompatiblePolymers G (ω (Penrose.treeParent hH r v hv)) := by
-  rw [incompatiblePolymers, Finset.mem_filter]
+  rw [incompatiblePolymers, incompatibleGasPolymers, Finset.mem_filter]
   exact ⟨hω v, (polymerSeqTree_parent_incompatible ω hsub hH r v hv).symm⟩
 
 /-- **Parent-edge Kotecky--Preiss weight bound.**  At high temperature

--- a/IsingModel/ClusterExpansion/PolymerActivity.lean
+++ b/IsingModel/ClusterExpansion/PolymerActivity.lean
@@ -34,39 +34,39 @@ namespace IsingModel
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- The polymer activity through a vertex `v`: `∑_{P ∋ v} t^{|P|}`. -/
-noncomputable def rootedPolymerActivity (G : SimpleGraph ι) [Fintype G.edgeSet]
-    (v : ι) (t : ℝ) : ℝ :=
-  ∑ P ∈ rootedPolymers G v, t ^ P.card
+/-- The gas polymer activity through a vertex `v`: `∑_{P ∋ v, P ∈ 𝓟} t^{|P|}`. -/
+noncomputable def rootedGasPolymerActivity (𝓟 : Finset (Finset (Sym2 ι))) (v : ι)
+    (t : ℝ) : ℝ :=
+  ∑ P ∈ rootedGasPolymers 𝓟 v, t ^ P.card
 
-/-- **Per-vertex polymer activity bound (volume-uniform).**  For `0 ≤ t` and
-`Δ²t < 1` (`Δ = G.maxDegree`), the polymer activity through `v` is bounded by the
+/-- **Per-vertex gas polymer activity bound (volume-uniform).**  For `0 ≤ t` and
+`Δ²t < 1` (`Δ = G.maxDegree`), the gas polymer activity through `v` is bounded by the
 geometric series `(1 − Δ²t)⁻¹`, independently of the volume. -/
-theorem rootedPolymerActivity_le_geometric (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] (v : ι) {t : ℝ} (ht0 : 0 ≤ t)
-    (ht : (G.maxDegree : ℝ) ^ 2 * t < 1) :
-    rootedPolymerActivity G v t ≤ (1 - (G.maxDegree : ℝ) ^ 2 * t)⁻¹ := by
+theorem rootedGasPolymerActivity_le_geometric (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟)
+    (v : ι) {t : ℝ} (ht0 : 0 ≤ t) (ht : (G.maxDegree : ℝ) ^ 2 * t < 1) :
+    rootedGasPolymerActivity 𝓟 v t ≤ (1 - (G.maxDegree : ℝ) ^ 2 * t)⁻¹ := by
   have hr0 : (0 : ℝ) ≤ (G.maxDegree : ℝ) ^ 2 * t := mul_nonneg (by positivity) ht0
-  have hmaps : ∀ P ∈ rootedPolymers G v, P.card ∈ Finset.range (G.edgeFinset.card + 1) := by
+  have hmaps : ∀ P ∈ rootedGasPolymers 𝓟 v, P.card ∈ Finset.range (G.edgeFinset.card + 1) := by
     intro P hP
-    rw [rootedPolymers, Finset.mem_filter] at hP
-    have hsub : P ⊆ G.edgeFinset := (mem_allPolymers.mp hP.1).isEven.subset
+    rw [rootedGasPolymers, Finset.mem_filter] at hP
+    have hsub : P ⊆ G.edgeFinset := hgas.mem_edgeFinset P hP.1
     exact Finset.mem_range.mpr (Nat.lt_succ_of_le (Finset.card_le_card hsub))
-  rw [rootedPolymerActivity,
+  rw [rootedGasPolymerActivity,
     ← Finset.sum_fiberwise_of_maps_to hmaps (fun P => t ^ P.card)]
   have hfiber : ∀ ℓ ∈ Finset.range (G.edgeFinset.card + 1),
-      (∑ P ∈ (rootedPolymers G v).filter (fun P => P.card = ℓ), t ^ P.card)
+      (∑ P ∈ (rootedGasPolymers 𝓟 v).filter (fun P => P.card = ℓ), t ^ P.card)
         ≤ ((G.maxDegree : ℝ) ^ 2 * t) ^ ℓ := by
     intro ℓ _
-    have hconst : (∑ P ∈ (rootedPolymers G v).filter (fun P => P.card = ℓ), t ^ P.card)
-        = ((rootedPolymersOfCard G v ℓ).card : ℝ) * t ^ ℓ := by
-      rw [rootedPolymersOfCard]
+    have hconst : (∑ P ∈ (rootedGasPolymers 𝓟 v).filter (fun P => P.card = ℓ), t ^ P.card)
+        = ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) * t ^ ℓ := by
+      rw [rootedGasPolymersOfCard]
       rw [Finset.sum_congr rfl fun P hP => by rw [(Finset.mem_filter.mp hP).2]]
       rw [Finset.sum_const, nsmul_eq_mul]
     rw [hconst]
-    have hcount : ((rootedPolymersOfCard G v ℓ).card : ℝ) ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) := by
-      exact_mod_cast rootedPolymersOfCard_card_le_maxDegree_pow G v ℓ
-    calc ((rootedPolymersOfCard G v ℓ).card : ℝ) * t ^ ℓ
+    have hcount : ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) := by
+      exact_mod_cast rootedGasPolymersOfCard_card_le_maxDegree_pow G hgas v ℓ
+    calc ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) * t ^ ℓ
         ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) * t ^ ℓ :=
           mul_le_mul_of_nonneg_right hcount (pow_nonneg ht0 ℓ)
       _ = ((G.maxDegree : ℝ) ^ 2 * t) ^ ℓ := by rw [mul_pow, pow_mul]
@@ -74,6 +74,20 @@ theorem rootedPolymerActivity_le_geometric (G : SimpleGraph ι) [DecidableRel G.
   refine le_trans ((summable_geometric_of_lt_one hr0 ht).sum_le_tsum _
     (fun ℓ _ => pow_nonneg hr0 ℓ)) ?_
   rw [tsum_geometric_of_lt_one hr0 ht]
+
+/-- The polymer activity through a vertex `v`: `∑_{P ∋ v} t^{|P|}` (even gas). -/
+noncomputable def rootedPolymerActivity (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (v : ι) (t : ℝ) : ℝ :=
+  rootedGasPolymerActivity (allPolymers G) v t
+
+/-- **Per-vertex polymer activity bound (volume-uniform).**  For `0 ≤ t` and
+`Δ²t < 1` (`Δ = G.maxDegree`), the polymer activity through `v` is bounded by the
+geometric series `(1 − Δ²t)⁻¹`, independently of the volume. -/
+theorem rootedPolymerActivity_le_geometric (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (v : ι) {t : ℝ} (ht0 : 0 ≤ t)
+    (ht : (G.maxDegree : ℝ) ^ 2 * t < 1) :
+    rootedPolymerActivity G v t ≤ (1 - (G.maxDegree : ℝ) ^ 2 * t)⁻¹ :=
+  rootedGasPolymerActivity_le_geometric G (evenPolymerGasData G) v ht0 ht
 
 /-- The total polymer activity of `G`: `∑_{P ∈ allPolymers G} t^{|P|}`. -/
 noncomputable def allPolymersActivity (G : SimpleGraph ι) [Fintype G.edgeSet]
@@ -97,7 +111,7 @@ theorem sum_rootedPolymerActivity_eq (G : SimpleGraph ι) [Fintype G.edgeSet]
     (t : ℝ) :
     (∑ v : ι, rootedPolymerActivity G v t)
       = ∑ P ∈ allPolymers G, (polymerSupport P).card • t ^ P.card := by
-  simp only [rootedPolymerActivity, rootedPolymers]
+  simp only [rootedPolymerActivity, rootedGasPolymerActivity, rootedGasPolymers]
   rw [Finset.sum_congr rfl fun v _ => Finset.sum_filter _ _, Finset.sum_comm]
   refine Finset.sum_congr rfl fun P _ => ?_
   rw [Finset.sum_ite_mem, Finset.univ_inter, Finset.sum_const]

--- a/IsingModel/ClusterExpansion/PolymerActivityKP.lean
+++ b/IsingModel/ClusterExpansion/PolymerActivityKP.lean
@@ -44,6 +44,21 @@ namespace IsingModel
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
+/-- **Per-vertex `e`-weighted gas activity bound (Kotecky--Preiss input).**  For
+`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the `e`-weighted gas polymer activity through `v`
+satisfies `∑_{Q ∋ v, Q ∈ 𝓟} (e^{|Q|})·|t|^{|Q|} ≤ (1 − Δ²·e·|t|)⁻¹`. -/
+theorem rootedGasPolymerActivity_expWeighted_le_geometric (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) (v : ι) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ Q ∈ rootedGasPolymers 𝓟 v, Real.exp 1 ^ Q.card * |t| ^ Q.card)
+      ≤ (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))⁻¹ := by
+  have h0 : (0 : ℝ) ≤ Real.exp 1 * |t| := by positivity
+  have hgeo := rootedGasPolymerActivity_le_geometric G hgas v h0 hkp
+  rw [rootedGasPolymerActivity] at hgeo
+  refine le_trans (le_of_eq ?_) hgeo
+  exact Finset.sum_congr rfl fun Q _ => (mul_pow _ _ _).symm
+
 /-- **Per-vertex `e`-weighted activity bound (Kotecky--Preiss input).**  For
 `Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the `e`-weighted polymer activity through `v`
 satisfies `∑_{Q ∋ v} (e^{|Q|})·|t|^{|Q|} ≤ (1 − Δ²·e·|t|)⁻¹`. -/
@@ -51,43 +66,47 @@ theorem rootedPolymerActivity_expWeighted_le_geometric (G : SimpleGraph ι)
     [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
     (∑ Q ∈ rootedPolymers G v, Real.exp 1 ^ Q.card * |t| ^ Q.card)
-      ≤ (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))⁻¹ := by
-  have h0 : (0 : ℝ) ≤ Real.exp 1 * |t| := by positivity
-  have hgeo := rootedPolymerActivity_le_geometric G v h0 hkp
-  rw [rootedPolymerActivity] at hgeo
-  refine le_trans (le_of_eq ?_) hgeo
-  exact Finset.sum_congr rfl fun Q _ => (mul_pow _ _ _).symm
+      ≤ (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))⁻¹ :=
+  rootedGasPolymerActivity_expWeighted_le_geometric G (evenPolymerGasData G) v hkp
+
+/-- The gas polymers (from `𝓟`) that are incompatible with `P` (i.e. share a support
+vertex with `P`). -/
+def incompatibleGasPolymers (𝓟 : Finset (Finset (Sym2 ι)))
+    (P : Finset (Sym2 ι)) : Finset (Finset (Sym2 ι)) :=
+  𝓟.filter (PolymersIncompatible P)
 
 /-- The polymers of `G` that are incompatible with `P` (i.e. share a support
 vertex with `P`). -/
 noncomputable def incompatiblePolymers (G : SimpleGraph ι) [Fintype G.edgeSet]
     (P : Finset (Sym2 ι)) : Finset (Finset (Sym2 ι)) :=
-  (allPolymers G).filter (PolymersIncompatible P)
+  incompatibleGasPolymers (allPolymers G) P
 
-/-- **Incompatibility-neighbourhood activity bound (Kotecky--Preiss input).**  For
-`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the total `e`-weighted activity of the polymers
+/-- **Incompatibility-neighbourhood gas activity bound (Kotecky--Preiss input).**  For
+`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the total `e`-weighted activity of the gas polymers
 incompatible with `P` is at most `|supp P|·(1 − Δ²·e·|t|)⁻¹`.  Each incompatible
 polymer is rooted at one of the `|supp P|` support vertices of `P`, so the
 neighbourhood activity is bounded by `|supp P|` copies of the per-vertex geometric
-bound. -/
-theorem incompatibilityActivity_expWeighted_le (G : SimpleGraph ι)
-    [DecidableRel G.Adj] [Fintype G.edgeSet] (P : Finset (Sym2 ι)) {t : ℝ}
+bound.  The `|supp P|` factor is not yet replaced by `|P|`: each gas applies its own
+support bound in a wrapper. -/
+theorem incompatibilityGasActivity_expWeighted_le (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) (P : Finset (Sym2 ι)) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
-    (∑ Q ∈ incompatiblePolymers G P, (Real.exp 1 * |t|) ^ Q.card)
+    (∑ Q ∈ incompatibleGasPolymers 𝓟 P, (Real.exp 1 * |t|) ^ Q.card)
       ≤ ((polymerSupport P).card : ℝ)
           * (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))⁻¹ := by
   have hw0 : (0 : ℝ) ≤ Real.exp 1 * |t| := by positivity
   -- Each incompatible polymer is counted at least once when ranging over the
   -- shared support vertices of `P`.
-  have key : (∑ Q ∈ incompatiblePolymers G P, (Real.exp 1 * |t|) ^ Q.card)
+  have key : (∑ Q ∈ incompatibleGasPolymers 𝓟 P, (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ v ∈ polymerSupport P,
-          ∑ Q ∈ rootedPolymers G v, (Real.exp 1 * |t|) ^ Q.card := by
-    calc (∑ Q ∈ incompatiblePolymers G P, (Real.exp 1 * |t|) ^ Q.card)
-        ≤ ∑ Q ∈ incompatiblePolymers G P,
+          ∑ Q ∈ rootedGasPolymers 𝓟 v, (Real.exp 1 * |t|) ^ Q.card := by
+    calc (∑ Q ∈ incompatibleGasPolymers 𝓟 P, (Real.exp 1 * |t|) ^ Q.card)
+        ≤ ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
             ∑ _v ∈ (polymerSupport P).filter (· ∈ polymerSupport Q),
               (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_le_sum fun Q hQ => ?_
-          rw [Finset.sum_const, incompatiblePolymers, Finset.mem_filter] at *
+          rw [Finset.sum_const, incompatibleGasPolymers, Finset.mem_filter] at *
           obtain ⟨v, hvP, hvQ⟩ :=
             PolymersIncompatible.iff_exists_shared_vertex.mp hQ.2
           have hne : ((polymerSupport P).filter (· ∈ polymerSupport Q)).Nonempty :=
@@ -102,79 +121,92 @@ theorem incompatibilityActivity_expWeighted_le (G : SimpleGraph ι)
                 mul_le_mul_of_nonneg_right h1 (pow_nonneg hw0 _)
             _ = ((polymerSupport P).filter (· ∈ polymerSupport Q)).card
                   • (Real.exp 1 * |t|) ^ Q.card := (nsmul_eq_mul _ _).symm
-      _ = ∑ Q ∈ incompatiblePolymers G P,
+      _ = ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
             ∑ v ∈ polymerSupport P,
               (if v ∈ polymerSupport Q then (Real.exp 1 * |t|) ^ Q.card else 0) := by
           refine Finset.sum_congr rfl fun Q _ => ?_
           rw [Finset.sum_filter]
       _ = ∑ v ∈ polymerSupport P,
-            ∑ Q ∈ incompatiblePolymers G P,
+            ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
               (if v ∈ polymerSupport Q then (Real.exp 1 * |t|) ^ Q.card else 0) :=
           Finset.sum_comm
       _ ≤ ∑ v ∈ polymerSupport P,
-            ∑ Q ∈ rootedPolymers G v, (Real.exp 1 * |t|) ^ Q.card := by
+            ∑ Q ∈ rootedGasPolymers 𝓟 v, (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_le_sum fun v _ => ?_
           rw [← Finset.sum_filter]
           refine Finset.sum_le_sum_of_subset_of_nonneg ?_ ?_
           · intro Q hQ
-            rw [Finset.mem_filter, incompatiblePolymers, Finset.mem_filter] at hQ
-            rw [rootedPolymers, Finset.mem_filter]
+            rw [Finset.mem_filter, incompatibleGasPolymers, Finset.mem_filter] at hQ
+            rw [rootedGasPolymers, Finset.mem_filter]
             exact ⟨hQ.1.1, hQ.2⟩
           · intro Q _ _; exact pow_nonneg hw0 _
   refine key.trans ?_
   calc (∑ v ∈ polymerSupport P,
-          ∑ Q ∈ rootedPolymers G v, (Real.exp 1 * |t|) ^ Q.card)
+          ∑ Q ∈ rootedGasPolymers 𝓟 v, (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ _v ∈ polymerSupport P,
           (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))⁻¹ := by
         refine Finset.sum_le_sum fun v _ => ?_
-        have hgeo := rootedPolymerActivity_le_geometric G v hw0 hkp
-        rwa [rootedPolymerActivity] at hgeo
+        have hgeo := rootedGasPolymerActivity_le_geometric G hgas v hw0 hkp
+        rwa [rootedGasPolymerActivity] at hgeo
     _ = ((polymerSupport P).card : ℝ)
           * (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))⁻¹ := by
         rw [Finset.sum_const, nsmul_eq_mul]
 
-/-- **Tail per-vertex activity bound.**  Polymers are nonempty (edge-count `≥ 1`),
-so the per-vertex activity is bounded by the *tail* geometric series:
-`∑_{Q ∋ v} u^{|Q|} ≤ (Δ²u)·(1 − Δ²u)⁻¹` for `0 ≤ u`, `Δ²u < 1`.  Unlike the full
+/-- **Incompatibility-neighbourhood activity bound (Kotecky--Preiss input).**  For
+`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the total `e`-weighted activity of the polymers
+incompatible with `P` is at most `|supp P|·(1 − Δ²·e·|t|)⁻¹`.  Even-gas instance of
+`incompatibilityGasActivity_expWeighted_le`. -/
+theorem incompatibilityActivity_expWeighted_le (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] (P : Finset (Sym2 ι)) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ Q ∈ incompatiblePolymers G P, (Real.exp 1 * |t|) ^ Q.card)
+      ≤ ((polymerSupport P).card : ℝ)
+          * (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))⁻¹ :=
+  incompatibilityGasActivity_expWeighted_le G (evenPolymerGasData G) P hkp
+
+/-- **Tail per-vertex gas activity bound.**  Gas polymers are nonempty (edge-count
+`≥ 1`), so the per-vertex gas activity is bounded by the *tail* geometric series:
+`∑_{Q ∋ v, Q ∈ 𝓟} u^{|Q|} ≤ (Δ²u)·(1 − Δ²u)⁻¹` for `0 ≤ u`, `Δ²u < 1`.  Unlike the full
 geometric bound `(1 − Δ²u)⁻¹`, this tail vanishes as `u → 0`, which is what the
 Kotecky--Preiss criterion requires. -/
-theorem rootedPolymerActivity_le_geometric_tail (G : SimpleGraph ι)
-    [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) {u : ℝ} (hu0 : 0 ≤ u)
+theorem rootedGasPolymerActivity_le_geometric_tail (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) (v : ι) {u : ℝ} (hu0 : 0 ≤ u)
     (hu : (G.maxDegree : ℝ) ^ 2 * u < 1) :
-    rootedPolymerActivity G v u
+    rootedGasPolymerActivity 𝓟 v u
       ≤ (G.maxDegree : ℝ) ^ 2 * u * (1 - (G.maxDegree : ℝ) ^ 2 * u)⁻¹ := by
   set r : ℝ := (G.maxDegree : ℝ) ^ 2 * u with hr
   have hr0 : (0 : ℝ) ≤ r := mul_nonneg (by positivity) hu0
-  have hmaps : ∀ P ∈ rootedPolymers G v, P.card ∈ Finset.range (G.edgeFinset.card + 1) := by
+  have hmaps : ∀ P ∈ rootedGasPolymers 𝓟 v, P.card ∈ Finset.range (G.edgeFinset.card + 1) := by
     intro P hP
-    rw [rootedPolymers, Finset.mem_filter] at hP
-    have hsub : P ⊆ G.edgeFinset := (mem_allPolymers.mp hP.1).isEven.subset
+    rw [rootedGasPolymers, Finset.mem_filter] at hP
+    have hsub : P ⊆ G.edgeFinset := hgas.mem_edgeFinset P hP.1
     exact Finset.mem_range.mpr (Nat.lt_succ_of_le (Finset.card_le_card hsub))
-  rw [rootedPolymerActivity,
+  rw [rootedGasPolymerActivity,
     ← Finset.sum_fiberwise_of_maps_to hmaps (fun P => u ^ P.card)]
   have hfiber : ∀ ℓ ∈ Finset.range (G.edgeFinset.card + 1),
-      (∑ P ∈ (rootedPolymers G v).filter (fun P => P.card = ℓ), u ^ P.card)
+      (∑ P ∈ (rootedGasPolymers 𝓟 v).filter (fun P => P.card = ℓ), u ^ P.card)
         ≤ (if ℓ = 0 then 0 else r ^ ℓ) := by
     intro ℓ _
     rcases eq_or_ne ℓ 0 with rfl | hℓ
-    · have hempty : (rootedPolymers G v).filter (fun P => P.card = 0) = ∅ := by
+    · have hempty : (rootedGasPolymers 𝓟 v).filter (fun P => P.card = 0) = ∅ := by
         rw [Finset.filter_eq_empty_iff]
         intro P hP hP0
-        rw [rootedPolymers, Finset.mem_filter] at hP
+        rw [rootedGasPolymers, Finset.mem_filter] at hP
         exact absurd (Finset.card_eq_zero.mp hP0)
-          (Finset.nonempty_iff_ne_empty.mp (mem_allPolymers.mp hP.1).nonempty)
+          (Finset.nonempty_iff_ne_empty.mp (hgas.nonempty P hP.1))
       rw [hempty, Finset.sum_empty]
       exact le_of_eq (if_pos rfl).symm
     · rw [if_neg hℓ]
-      have hconst : (∑ P ∈ (rootedPolymers G v).filter (fun P => P.card = ℓ), u ^ P.card)
-          = ((rootedPolymersOfCard G v ℓ).card : ℝ) * u ^ ℓ := by
-        rw [rootedPolymersOfCard]
+      have hconst : (∑ P ∈ (rootedGasPolymers 𝓟 v).filter (fun P => P.card = ℓ), u ^ P.card)
+          = ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) * u ^ ℓ := by
+        rw [rootedGasPolymersOfCard]
         rw [Finset.sum_congr rfl fun P hP => by rw [(Finset.mem_filter.mp hP).2]]
         rw [Finset.sum_const, nsmul_eq_mul]
       rw [hconst]
-      have hcount : ((rootedPolymersOfCard G v ℓ).card : ℝ) ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) := by
-        exact_mod_cast rootedPolymersOfCard_card_le_maxDegree_pow G v ℓ
-      calc ((rootedPolymersOfCard G v ℓ).card : ℝ) * u ^ ℓ
+      have hcount : ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) := by
+        exact_mod_cast rootedGasPolymersOfCard_card_le_maxDegree_pow G hgas v ℓ
+      calc ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) * u ^ ℓ
           ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) * u ^ ℓ :=
             mul_le_mul_of_nonneg_right hcount (pow_nonneg hu0 ℓ)
         _ = r ^ ℓ := by rw [hr, mul_pow, pow_mul]
@@ -195,6 +227,17 @@ theorem rootedPolymerActivity_le_geometric_tail (G : SimpleGraph ι)
       rw [if_pos rfl, zero_add, tsum_congr hfun, tsum_mul_left,
         tsum_geometric_of_lt_one hr0 hu]
     rw [htsum]
+
+/-- **Tail per-vertex activity bound.**  Polymers are nonempty (edge-count `≥ 1`),
+so the per-vertex activity is bounded by the *tail* geometric series:
+`∑_{Q ∋ v} u^{|Q|} ≤ (Δ²u)·(1 − Δ²u)⁻¹` for `0 ≤ u`, `Δ²u < 1`.  Even-gas instance of
+`rootedGasPolymerActivity_le_geometric_tail`. -/
+theorem rootedPolymerActivity_le_geometric_tail (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) {u : ℝ} (hu0 : 0 ≤ u)
+    (hu : (G.maxDegree : ℝ) ^ 2 * u < 1) :
+    rootedPolymerActivity G v u
+      ≤ (G.maxDegree : ℝ) ^ 2 * u * (1 - (G.maxDegree : ℝ) ^ 2 * u)⁻¹ :=
+  rootedGasPolymerActivity_le_geometric_tail G (evenPolymerGasData G) v hu0 hu
 
 /-- **A polymer has at most as many support vertices as edges.**  In an even
 subgraph every support vertex has even degree `≥ 2`, so by the handshake identity
@@ -250,13 +293,14 @@ theorem incompatibilityActivity_expWeighted_le_card_of_half (G : SimpleGraph ι)
   -- bound by the support sum of the tail per-vertex activity
   have hkey : (∑ Q ∈ incompatiblePolymers G P, (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ v ∈ polymerSupport P, rootedPolymerActivity G v (Real.exp 1 * |t|) := by
-    simp only [rootedPolymerActivity]
+    simp only [rootedPolymerActivity, rootedGasPolymerActivity]
     calc (∑ Q ∈ incompatiblePolymers G P, (Real.exp 1 * |t|) ^ Q.card)
         ≤ ∑ Q ∈ incompatiblePolymers G P,
             ∑ _v ∈ (polymerSupport P).filter (· ∈ polymerSupport Q),
               (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_le_sum fun Q hQ => ?_
-          rw [Finset.sum_const, incompatiblePolymers, Finset.mem_filter] at *
+          rw [Finset.sum_const, incompatiblePolymers, incompatibleGasPolymers,
+            Finset.mem_filter] at *
           obtain ⟨v, hvP, hvQ⟩ :=
             PolymersIncompatible.iff_exists_shared_vertex.mp hQ.2
           have hne : ((polymerSupport P).filter (· ∈ polymerSupport Q)).Nonempty :=
@@ -286,8 +330,9 @@ theorem incompatibilityActivity_expWeighted_le_card_of_half (G : SimpleGraph ι)
           rw [← Finset.sum_filter]
           refine Finset.sum_le_sum_of_subset_of_nonneg ?_ ?_
           · intro Q hQ
-            rw [Finset.mem_filter, incompatiblePolymers, Finset.mem_filter] at hQ
-            rw [rootedPolymers, Finset.mem_filter]
+            rw [Finset.mem_filter, incompatiblePolymers, incompatibleGasPolymers,
+              Finset.mem_filter] at hQ
+            rw [rootedPolymers, rootedGasPolymers, Finset.mem_filter]
             exact ⟨hQ.1.1, hQ.2⟩
           · intro Q _ _; exact pow_nonneg hu0 _
   refine hkey.trans ?_

--- a/IsingModel/ClusterExpansion/PolymerActivityKPMoment.lean
+++ b/IsingModel/ClusterExpansion/PolymerActivityKPMoment.lean
@@ -25,34 +25,36 @@ namespace IsingModel
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **Incompatibility-neighbourhood moment bound.**  For `P ∈ allPolymers G` and
-`Δ²·e·|t| < 1`, the `d`-th moment of the `e`-weighted activity of the polymers
-incompatible with `P` is bounded by `|P|·d!·(1 − Δ²e|t|)^{-(d+1)}`:
-`∑_{Q ∼ P} |Q|^d (e|t|)^{|Q|} ≤ |P|·d!/(1 − Δ²e|t|)^{d+1}`.  Each incompatible polymer
-is rooted at one of the `|supp P| ≤ |P|` support vertices of `P`, and the per-vertex
-sum is the moment bound `rootedPolymerActivity_cardPow_le`. -/
-theorem incompatibilityActivity_cardPow_expWeighted_le (G : SimpleGraph ι)
-    [DecidableRel G.Adj] [Fintype G.edgeSet] {P : Finset (Sym2 ι)}
-    (hP : P ∈ allPolymers G) (d : ℕ) {t : ℝ}
+/-- **Incompatibility-neighbourhood gas moment bound.**  For `Δ²·e·|t| < 1`, the
+`d`-th moment of the `e`-weighted activity of the gas polymers incompatible with `P`
+is bounded by `|supp P|·d!·(1 − Δ²e|t|)^{-(d+1)}`:
+`∑_{Q ∼ P, Q ∈ 𝓟} |Q|^d (e|t|)^{|Q|} ≤ |supp P|·d!/(1 − Δ²e|t|)^{d+1}`.  Each
+incompatible polymer is rooted at one of the `|supp P|` support vertices of `P`, and
+the per-vertex sum is the moment bound `rootedGasPolymerActivity_cardPow_le`.  The
+`|supp P|` factor is not yet replaced by `|P|`: each gas applies its own support bound
+in a wrapper. -/
+theorem incompatibilityGasActivity_cardPow_expWeighted_le (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) (P : Finset (Sym2 ι)) (d : ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
-    (∑ Q ∈ incompatiblePolymers G P,
+    (∑ Q ∈ incompatibleGasPolymers 𝓟 P,
         (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
-      ≤ (P.card : ℝ)
+      ≤ ((polymerSupport P).card : ℝ)
           * ((d.factorial : ℝ)
               / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) := by
   have hw0 : (0 : ℝ) ≤ Real.exp 1 * |t| := by positivity
-  have key : (∑ Q ∈ incompatiblePolymers G P,
+  have key : (∑ Q ∈ incompatibleGasPolymers 𝓟 P,
         (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ v ∈ polymerSupport P,
-          ∑ Q ∈ rootedPolymers G v,
+          ∑ Q ∈ rootedGasPolymers 𝓟 v,
             (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
-    calc (∑ Q ∈ incompatiblePolymers G P,
+    calc (∑ Q ∈ incompatibleGasPolymers 𝓟 P,
             (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
-        ≤ ∑ Q ∈ incompatiblePolymers G P,
+        ≤ ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
             ∑ _v ∈ (polymerSupport P).filter (· ∈ polymerSupport Q),
               (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_le_sum fun Q hQ => ?_
-          rw [Finset.sum_const, incompatiblePolymers, Finset.mem_filter] at *
+          rw [Finset.sum_const, incompatibleGasPolymers, Finset.mem_filter] at *
           obtain ⟨v, hvP, hvQ⟩ :=
             PolymersIncompatible.iff_exists_shared_vertex.mp hQ.2
           have hne : ((polymerSupport P).filter (· ∈ polymerSupport Q)).Nonempty :=
@@ -67,47 +69,61 @@ theorem incompatibilityActivity_cardPow_expWeighted_le (G : SimpleGraph ι)
                 mul_le_mul_of_nonneg_right h1 (by positivity)
             _ = ((polymerSupport P).filter (· ∈ polymerSupport Q)).card
                   • ((Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card) := (nsmul_eq_mul _ _).symm
-      _ = ∑ Q ∈ incompatiblePolymers G P,
+      _ = ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
             ∑ v ∈ polymerSupport P,
               (if v ∈ polymerSupport Q then
                 (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card else 0) := by
           refine Finset.sum_congr rfl fun Q _ => ?_
           rw [Finset.sum_filter]
       _ = ∑ v ∈ polymerSupport P,
-            ∑ Q ∈ incompatiblePolymers G P,
+            ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
               (if v ∈ polymerSupport Q then
                 (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card else 0) :=
           Finset.sum_comm
       _ ≤ ∑ v ∈ polymerSupport P,
-            ∑ Q ∈ rootedPolymers G v,
+            ∑ Q ∈ rootedGasPolymers 𝓟 v,
               (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_le_sum fun v _ => ?_
           rw [← Finset.sum_filter]
           refine Finset.sum_le_sum_of_subset_of_nonneg ?_ ?_
           · intro Q hQ
-            rw [Finset.mem_filter, incompatiblePolymers, Finset.mem_filter] at hQ
-            rw [rootedPolymers, Finset.mem_filter]
+            rw [Finset.mem_filter, incompatibleGasPolymers, Finset.mem_filter] at hQ
+            rw [rootedGasPolymers, Finset.mem_filter]
             exact ⟨hQ.1.1, hQ.2⟩
           · intro Q _ _; positivity
   refine key.trans ?_
   calc (∑ v ∈ polymerSupport P,
-          ∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
+          ∑ Q ∈ rootedGasPolymers 𝓟 v, (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ _v ∈ polymerSupport P,
           ((d.factorial : ℝ)
             / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) := by
         refine Finset.sum_le_sum fun v _ => ?_
-        exact rootedPolymerActivity_cardPow_le G v d hw0 hkp
+        exact rootedGasPolymerActivity_cardPow_le G hgas v d hw0 hkp
     _ = ((polymerSupport P).card : ℝ)
           * ((d.factorial : ℝ)
               / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) := by
         rw [Finset.sum_const, nsmul_eq_mul]
-    _ ≤ (P.card : ℝ)
+
+/-- **Incompatibility-neighbourhood moment bound.**  For `P ∈ allPolymers G` and
+`Δ²·e·|t| < 1`, the `d`-th moment of the `e`-weighted activity of the polymers
+incompatible with `P` is bounded by `|P|·d!·(1 − Δ²e|t|)^{-(d+1)}`:
+`∑_{Q ∼ P} |Q|^d (e|t|)^{|Q|} ≤ |P|·d!/(1 − Δ²e|t|)^{d+1}`.  Even-gas instance of
+`incompatibilityGasActivity_cardPow_expWeighted_le`, replacing `|supp P|` by `|P|` via
+the even handshake bound `polymerSupport_card_le_card_of_mem_allPolymers`. -/
+theorem incompatibilityActivity_cardPow_expWeighted_le (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {P : Finset (Sym2 ι)}
+    (hP : P ∈ allPolymers G) (d : ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ Q ∈ incompatiblePolymers G P,
+        (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
+      ≤ (P.card : ℝ)
           * ((d.factorial : ℝ)
               / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) := by
-        have hpos : (0 : ℝ) < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) := by
-          linarith
-        refine mul_le_mul_of_nonneg_right ?_
-          (div_nonneg (by positivity) (le_of_lt (pow_pos hpos (d + 1))))
-        exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  refine (incompatibilityGasActivity_cardPow_expWeighted_le G (evenPolymerGasData G) P d
+    hkp).trans ?_
+  have hpos : (0 : ℝ) < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) := by linarith
+  refine mul_le_mul_of_nonneg_right ?_
+    (div_nonneg (by positivity) (le_of_lt (pow_pos hpos (d + 1))))
+  exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/PolymerActivityKPMomentTail.lean
+++ b/IsingModel/ClusterExpansion/PolymerActivityKPMomentTail.lean
@@ -27,37 +27,39 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **Sharpened (tail) incompatibility-neighbourhood moment bound.**  For
-`P ∈ allPolymers G` and `Δ²e|t| < 1`, the `d`-th moment of the `e`-weighted activity of
-the polymers incompatible with `P` carries an extra factor `Δ²e|t|` over
-`incompatibilityActivity_cardPow_expWeighted_le`:
-`∑_{Q ∼ P} |Q|^d (e|t|)^{|Q|} ≤ |P|·(Δ²e|t|)·d!/(1−Δ²e|t|)^{d+1}`.  The reduction to the
-per-vertex moment sums (each incompatible polymer rooted at a shared support vertex) is
-as in #4102; the per-vertex sums are then bounded by the tail moment bound #4121. -/
-theorem incompatibilityActivity_cardPow_expWeighted_tail_le (G : SimpleGraph ι)
-    [DecidableRel G.Adj] [Fintype G.edgeSet] {P : Finset (Sym2 ι)}
-    (hP : P ∈ allPolymers G) (d : ℕ) {t : ℝ}
+/-- **Sharpened (tail) incompatibility-neighbourhood gas moment bound.**  For
+`Δ²e|t| < 1`, the `d`-th moment of the `e`-weighted activity of the gas polymers
+incompatible with `P` carries an extra factor `Δ²e|t|` over
+`incompatibilityGasActivity_cardPow_expWeighted_le`:
+`∑_{Q ∼ P, Q ∈ 𝓟} |Q|^d (e|t|)^{|Q|} ≤ |supp P|·(Δ²e|t|)·d!/(1−Δ²e|t|)^{d+1}`.  The
+reduction to the per-vertex moment sums (each incompatible polymer rooted at a shared
+support vertex) is as in #4102; the per-vertex sums are then bounded by the tail moment
+bound #4121.  The `|supp P|` factor is not yet replaced by `|P|`: each gas applies its
+own support bound in a wrapper. -/
+theorem incompatibilityGasActivity_cardPow_expWeighted_tail_le (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) (P : Finset (Sym2 ι)) (d : ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
-    (∑ Q ∈ incompatiblePolymers G P,
+    (∑ Q ∈ incompatibleGasPolymers 𝓟 P,
         (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
-      ≤ (P.card : ℝ)
+      ≤ ((polymerSupport P).card : ℝ)
           * (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
             * ((d.factorial : ℝ)
                 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1))) := by
   have hw0 : (0 : ℝ) ≤ Real.exp 1 * |t| := by positivity
   -- Reduce to the per-support-vertex moment sums (identical to #4102).
-  have key : (∑ Q ∈ incompatiblePolymers G P,
+  have key : (∑ Q ∈ incompatibleGasPolymers 𝓟 P,
         (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ v ∈ polymerSupport P,
-          ∑ Q ∈ rootedPolymers G v,
+          ∑ Q ∈ rootedGasPolymers 𝓟 v,
             (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
-    calc (∑ Q ∈ incompatiblePolymers G P,
+    calc (∑ Q ∈ incompatibleGasPolymers 𝓟 P,
             (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
-        ≤ ∑ Q ∈ incompatiblePolymers G P,
+        ≤ ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
             ∑ _v ∈ (polymerSupport P).filter (· ∈ polymerSupport Q),
               (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_le_sum fun Q hQ => ?_
-          rw [Finset.sum_const, incompatiblePolymers, Finset.mem_filter] at *
+          rw [Finset.sum_const, incompatibleGasPolymers, Finset.mem_filter] at *
           obtain ⟨v, hvP, hvQ⟩ :=
             PolymersIncompatible.iff_exists_shared_vertex.mp hQ.2
           have hne : ((polymerSupport P).filter (· ∈ polymerSupport Q)).Nonempty :=
@@ -72,50 +74,66 @@ theorem incompatibilityActivity_cardPow_expWeighted_tail_le (G : SimpleGraph ι)
                 mul_le_mul_of_nonneg_right h1 (by positivity)
             _ = ((polymerSupport P).filter (· ∈ polymerSupport Q)).card
                   • ((Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card) := (nsmul_eq_mul _ _).symm
-      _ = ∑ Q ∈ incompatiblePolymers G P,
+      _ = ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
             ∑ v ∈ polymerSupport P,
               (if v ∈ polymerSupport Q then
                 (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card else 0) := by
           refine Finset.sum_congr rfl fun Q _ => ?_
           rw [Finset.sum_filter]
       _ = ∑ v ∈ polymerSupport P,
-            ∑ Q ∈ incompatiblePolymers G P,
+            ∑ Q ∈ incompatibleGasPolymers 𝓟 P,
               (if v ∈ polymerSupport Q then
                 (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card else 0) :=
           Finset.sum_comm
       _ ≤ ∑ v ∈ polymerSupport P,
-            ∑ Q ∈ rootedPolymers G v,
+            ∑ Q ∈ rootedGasPolymers 𝓟 v,
               (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_le_sum fun v _ => ?_
           rw [← Finset.sum_filter]
           refine Finset.sum_le_sum_of_subset_of_nonneg ?_ ?_
           · intro Q hQ
-            rw [Finset.mem_filter, incompatiblePolymers, Finset.mem_filter] at hQ
-            rw [rootedPolymers, Finset.mem_filter]
+            rw [Finset.mem_filter, incompatibleGasPolymers, Finset.mem_filter] at hQ
+            rw [rootedGasPolymers, Finset.mem_filter]
             exact ⟨hQ.1.1, hQ.2⟩
           · intro Q _ _; positivity
   refine key.trans ?_
   calc (∑ v ∈ polymerSupport P,
-          ∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
+          ∑ Q ∈ rootedGasPolymers 𝓟 v, (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ _v ∈ polymerSupport P,
           (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
             * ((d.factorial : ℝ)
                 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1))) := by
         refine Finset.sum_le_sum fun v _ => ?_
-        exact rootedPolymerActivity_cardPow_tail_le G v d hw0 hkp
+        exact rootedGasPolymerActivity_cardPow_tail_le G hgas v d hw0 hkp
     _ = ((polymerSupport P).card : ℝ)
           * (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
             * ((d.factorial : ℝ)
                 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1))) := by
         rw [Finset.sum_const, nsmul_eq_mul]
-    _ ≤ (P.card : ℝ)
+
+/-- **Sharpened (tail) incompatibility-neighbourhood moment bound.**  For
+`P ∈ allPolymers G` and `Δ²e|t| < 1`, the `d`-th moment of the `e`-weighted activity of
+the polymers incompatible with `P` carries an extra factor `Δ²e|t|` over
+`incompatibilityActivity_cardPow_expWeighted_le`:
+`∑_{Q ∼ P} |Q|^d (e|t|)^{|Q|} ≤ |P|·(Δ²e|t|)·d!/(1−Δ²e|t|)^{d+1}`.  Even-gas instance of
+`incompatibilityGasActivity_cardPow_expWeighted_tail_le`, replacing `|supp P|` by `|P|`
+via the even handshake bound `polymerSupport_card_le_card_of_mem_allPolymers`. -/
+theorem incompatibilityActivity_cardPow_expWeighted_tail_le (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {P : Finset (Sym2 ι)}
+    (hP : P ∈ allPolymers G) (d : ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ Q ∈ incompatiblePolymers G P,
+        (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
+      ≤ (P.card : ℝ)
           * (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
             * ((d.factorial : ℝ)
                 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1))) := by
-        have hpos : (0 : ℝ) < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) := by linarith
-        refine mul_le_mul_of_nonneg_right ?_
-          (mul_nonneg (by positivity)
-            (div_nonneg (by positivity) (le_of_lt (pow_pos hpos (d + 1)))))
-        exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  refine (incompatibilityGasActivity_cardPow_expWeighted_tail_le G (evenPolymerGasData G) P d
+    hkp).trans ?_
+  have hpos : (0 : ℝ) < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) := by linarith
+  refine mul_le_mul_of_nonneg_right ?_
+    (mul_nonneg (by positivity)
+      (div_nonneg (by positivity) (le_of_lt (pow_pos hpos (d + 1)))))
+  exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/PolymerActivityMoment.lean
+++ b/IsingModel/ClusterExpansion/PolymerActivityMoment.lean
@@ -25,38 +25,39 @@ namespace IsingModel
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **Per-vertex polymer activity moment bound (volume-uniform).**  For `0 ≤ u` and
-`Δ²u < 1` (`Δ = G.maxDegree`), the `d`-th moment of the per-vertex polymer activity
-is bounded by `d!·(1 − Δ²u)^{-(d+1)}`, independently of the volume:
-`∑_{Q ∋ v} |Q|^d u^{|Q|} ≤ d!/(1 − Δ²u)^{d+1}`.  Partition the rooted polymers by
-cardinality, bound each size-`ℓ` fibre by `Δ^{2ℓ}·ℓ^d·u^ℓ = ℓ^d·(Δ²u)^ℓ` via the
-volume-uniform count, then dominate by the geometric moment series. -/
-theorem rootedPolymerActivity_cardPow_le (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] (v : ι) (d : ℕ) {u : ℝ} (hu0 : 0 ≤ u)
-    (hu : (G.maxDegree : ℝ) ^ 2 * u < 1) :
-    (∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * u ^ Q.card)
+/-- **Per-vertex gas polymer activity moment bound (volume-uniform).**  For `0 ≤ u`
+and `Δ²u < 1` (`Δ = G.maxDegree`), the `d`-th moment of the per-vertex gas polymer
+activity is bounded by `d!·(1 − Δ²u)^{-(d+1)}`, independently of the volume:
+`∑_{Q ∋ v, Q ∈ 𝓟} |Q|^d u^{|Q|} ≤ d!/(1 − Δ²u)^{d+1}`.  Partition the rooted gas
+polymers by cardinality, bound each size-`ℓ` fibre by `Δ^{2ℓ}·ℓ^d·u^ℓ = ℓ^d·(Δ²u)^ℓ`
+via the volume-uniform count, then dominate by the geometric moment series. -/
+theorem rootedGasPolymerActivity_cardPow_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟)
+    (v : ι) (d : ℕ) {u : ℝ} (hu0 : 0 ≤ u) (hu : (G.maxDegree : ℝ) ^ 2 * u < 1) :
+    (∑ Q ∈ rootedGasPolymers 𝓟 v, (Q.card : ℝ) ^ d * u ^ Q.card)
       ≤ (d.factorial : ℝ) / (1 - (G.maxDegree : ℝ) ^ 2 * u) ^ (d + 1) := by
   have hr0 : (0 : ℝ) ≤ (G.maxDegree : ℝ) ^ 2 * u := mul_nonneg (by positivity) hu0
-  have hmaps : ∀ P ∈ rootedPolymers G v, P.card ∈ Finset.range (G.edgeFinset.card + 1) := by
+  have hmaps : ∀ P ∈ rootedGasPolymers 𝓟 v, P.card ∈ Finset.range (G.edgeFinset.card + 1) := by
     intro P hP
-    rw [rootedPolymers, Finset.mem_filter] at hP
-    have hsub : P ⊆ G.edgeFinset := (mem_allPolymers.mp hP.1).isEven.subset
+    rw [rootedGasPolymers, Finset.mem_filter] at hP
+    have hsub : P ⊆ G.edgeFinset := hgas.mem_edgeFinset P hP.1
     exact Finset.mem_range.mpr (Nat.lt_succ_of_le (Finset.card_le_card hsub))
   rw [← Finset.sum_fiberwise_of_maps_to hmaps (fun Q => (Q.card : ℝ) ^ d * u ^ Q.card)]
   have hfiber : ∀ ℓ ∈ Finset.range (G.edgeFinset.card + 1),
-      (∑ Q ∈ (rootedPolymers G v).filter (fun Q => Q.card = ℓ), (Q.card : ℝ) ^ d * u ^ Q.card)
+      (∑ Q ∈ (rootedGasPolymers 𝓟 v).filter (fun Q => Q.card = ℓ), (Q.card : ℝ) ^ d * u ^ Q.card)
         ≤ (ℓ : ℝ) ^ d * ((G.maxDegree : ℝ) ^ 2 * u) ^ ℓ := by
     intro ℓ _
     have hconst :
-        (∑ Q ∈ (rootedPolymers G v).filter (fun Q => Q.card = ℓ), (Q.card : ℝ) ^ d * u ^ Q.card)
-          = ((rootedPolymersOfCard G v ℓ).card : ℝ) * ((ℓ : ℝ) ^ d * u ^ ℓ) := by
-      rw [rootedPolymersOfCard]
+        (∑ Q ∈ (rootedGasPolymers 𝓟 v).filter (fun Q => Q.card = ℓ),
+            (Q.card : ℝ) ^ d * u ^ Q.card)
+          = ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) * ((ℓ : ℝ) ^ d * u ^ ℓ) := by
+      rw [rootedGasPolymersOfCard]
       rw [Finset.sum_congr rfl fun Q hQ => by rw [(Finset.mem_filter.mp hQ).2]]
       rw [Finset.sum_const, nsmul_eq_mul]
     rw [hconst]
-    have hcount : ((rootedPolymersOfCard G v ℓ).card : ℝ) ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) := by
-      exact_mod_cast rootedPolymersOfCard_card_le_maxDegree_pow G v ℓ
-    calc ((rootedPolymersOfCard G v ℓ).card : ℝ) * ((ℓ : ℝ) ^ d * u ^ ℓ)
+    have hcount : ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) := by
+      exact_mod_cast rootedGasPolymersOfCard_card_le_maxDegree_pow G hgas v ℓ
+    calc ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) * ((ℓ : ℝ) ^ d * u ^ ℓ)
         ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) * ((ℓ : ℝ) ^ d * u ^ ℓ) :=
           mul_le_mul_of_nonneg_right hcount (by positivity)
       _ = (ℓ : ℝ) ^ d * ((G.maxDegree : ℝ) ^ 2 * u) ^ ℓ := by rw [mul_pow, pow_mul]; ring
@@ -65,5 +66,17 @@ theorem rootedPolymerActivity_cardPow_le (G : SimpleGraph ι) [DecidableRel G.Ad
   refine le_trans ((summable_pow_mul_geometric_of_norm_lt_one d hnorm).sum_le_tsum _
     (fun ℓ _ => by positivity)) ?_
   exact tsum_pow_mul_geometric_le d hr0 hu
+
+/-- **Per-vertex polymer activity moment bound (volume-uniform).**  For `0 ≤ u` and
+`Δ²u < 1` (`Δ = G.maxDegree`), the `d`-th moment of the per-vertex polymer activity
+is bounded by `d!·(1 − Δ²u)^{-(d+1)}`, independently of the volume:
+`∑_{Q ∋ v} |Q|^d u^{|Q|} ≤ d!/(1 − Δ²u)^{d+1}`.  Even-gas instance of
+`rootedGasPolymerActivity_cardPow_le`. -/
+theorem rootedPolymerActivity_cardPow_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (v : ι) (d : ℕ) {u : ℝ} (hu0 : 0 ≤ u)
+    (hu : (G.maxDegree : ℝ) ^ 2 * u < 1) :
+    (∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * u ^ Q.card)
+      ≤ (d.factorial : ℝ) / (1 - (G.maxDegree : ℝ) ^ 2 * u) ^ (d + 1) :=
+  rootedGasPolymerActivity_cardPow_le G (evenPolymerGasData G) v d hu0 hu
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/PolymerActivityTailMoment.lean
+++ b/IsingModel/ClusterExpansion/PolymerActivityTailMoment.lean
@@ -30,29 +30,30 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **Sharpened (tail) per-vertex polymer-activity moment bound.**  Since every polymer
-through `v` is nonempty, the size-`0` fiber of the moment sum is empty, so the bound of
-`rootedPolymerActivity_cardPow_le` sharpens by a factor `Δ²u`:
-`∑_{Q ∋ v} |Q|^d u^{|Q|} ≤ (Δ²u)·d!/(1−Δ²u)^{d+1}`.  The proof fibers over the polymer
-size `ℓ` as in #4099, drops the empty `ℓ = 0` fiber, reindexes `ℓ ↦ ℓ + 1`, and applies
-the tail geometric-moment bound `tsum_succ_pow_mul_geometric_succ_le`. -/
-theorem rootedPolymerActivity_cardPow_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] (v : ι) (d : ℕ) {u : ℝ} (hu0 : 0 ≤ u)
-    (hu : (G.maxDegree : ℝ) ^ 2 * u < 1) :
-    (∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * u ^ Q.card)
+/-- **Sharpened (tail) per-vertex gas polymer-activity moment bound.**  Since every
+polymer through `v` in the gas `𝓟` is nonempty, the size-`0` fiber of the moment sum is
+empty, so the bound of `rootedGasPolymerActivity_cardPow_le` sharpens by a factor `Δ²u`:
+`∑_{Q ∋ v, Q ∈ 𝓟} |Q|^d u^{|Q|} ≤ (Δ²u)·d!/(1−Δ²u)^{d+1}`.  The proof fibers over the
+polymer size `ℓ` as in #4099, drops the empty `ℓ = 0` fiber, reindexes `ℓ ↦ ℓ + 1`, and
+applies the tail geometric-moment bound `tsum_succ_pow_mul_geometric_succ_le`. -/
+theorem rootedGasPolymerActivity_cardPow_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟)
+    (v : ι) (d : ℕ) {u : ℝ} (hu0 : 0 ≤ u) (hu : (G.maxDegree : ℝ) ^ 2 * u < 1) :
+    (∑ Q ∈ rootedGasPolymers 𝓟 v, (Q.card : ℝ) ^ d * u ^ Q.card)
       ≤ ((G.maxDegree : ℝ) ^ 2 * u)
           * ((d.factorial : ℝ) / (1 - (G.maxDegree : ℝ) ^ 2 * u) ^ (d + 1)) := by
   set r : ℝ := (G.maxDegree : ℝ) ^ 2 * u with hr
   have hr0 : (0 : ℝ) ≤ r := mul_nonneg (by positivity) hu0
-  have hmaps : ∀ P ∈ rootedPolymers G v, P.card ∈ Finset.range (G.edgeFinset.card + 1) := by
+  have hmaps : ∀ P ∈ rootedGasPolymers 𝓟 v, P.card ∈ Finset.range (G.edgeFinset.card + 1) := by
     intro P hP
-    rw [rootedPolymers, Finset.mem_filter] at hP
-    have hsub : P ⊆ G.edgeFinset := (mem_allPolymers.mp hP.1).isEven.subset
+    rw [rootedGasPolymers, Finset.mem_filter] at hP
+    have hsub : P ⊆ G.edgeFinset := hgas.mem_edgeFinset P hP.1
     exact Finset.mem_range.mpr (Nat.lt_succ_of_le (Finset.card_le_card hsub))
   rw [← Finset.sum_fiberwise_of_maps_to hmaps (fun Q => (Q.card : ℝ) ^ d * u ^ Q.card)]
   -- Each fiber is bounded by `if ℓ = 0 then 0 else ℓ^d r^ℓ`.
   have hfiber : ∀ ℓ ∈ Finset.range (G.edgeFinset.card + 1),
-      (∑ Q ∈ (rootedPolymers G v).filter (fun Q => Q.card = ℓ), (Q.card : ℝ) ^ d * u ^ Q.card)
+      (∑ Q ∈ (rootedGasPolymers 𝓟 v).filter (fun Q => Q.card = ℓ),
+          (Q.card : ℝ) ^ d * u ^ Q.card)
         ≤ (if ℓ = 0 then 0 else (ℓ : ℝ) ^ d * r ^ ℓ) := by
     intro ℓ _
     by_cases hℓ : ℓ = 0
@@ -61,22 +62,23 @@ theorem rootedPolymerActivity_cardPow_tail_le (G : SimpleGraph ι) [DecidableRel
       refine le_of_eq (Finset.sum_eq_zero fun Q hQ => ?_)
       rw [Finset.mem_filter] at hQ
       have hcard0 : Q.card = 0 := hQ.2
-      have hQin : Q ∈ rootedPolymers G v := hQ.1
-      rw [rootedPolymers, Finset.mem_filter] at hQin
-      have hne := (mem_allPolymers.mp hQin.1).nonempty
+      have hQin : Q ∈ rootedGasPolymers 𝓟 v := hQ.1
+      rw [rootedGasPolymers, Finset.mem_filter] at hQin
+      have hne := hgas.nonempty Q hQin.1
       rw [← Finset.card_pos] at hne
       exact absurd hcard0 (by omega)
     · rw [if_neg hℓ]
       have hconst :
-          (∑ Q ∈ (rootedPolymers G v).filter (fun Q => Q.card = ℓ), (Q.card : ℝ) ^ d * u ^ Q.card)
-            = ((rootedPolymersOfCard G v ℓ).card : ℝ) * ((ℓ : ℝ) ^ d * u ^ ℓ) := by
-        rw [rootedPolymersOfCard]
+          (∑ Q ∈ (rootedGasPolymers 𝓟 v).filter (fun Q => Q.card = ℓ),
+              (Q.card : ℝ) ^ d * u ^ Q.card)
+            = ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) * ((ℓ : ℝ) ^ d * u ^ ℓ) := by
+        rw [rootedGasPolymersOfCard]
         rw [Finset.sum_congr rfl fun Q hQ => by rw [(Finset.mem_filter.mp hQ).2]]
         rw [Finset.sum_const, nsmul_eq_mul]
       rw [hconst]
-      have hcount : ((rootedPolymersOfCard G v ℓ).card : ℝ) ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) := by
-        exact_mod_cast rootedPolymersOfCard_card_le_maxDegree_pow G v ℓ
-      calc ((rootedPolymersOfCard G v ℓ).card : ℝ) * ((ℓ : ℝ) ^ d * u ^ ℓ)
+      have hcount : ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) := by
+        exact_mod_cast rootedGasPolymersOfCard_card_le_maxDegree_pow G hgas v ℓ
+      calc ((rootedGasPolymersOfCard 𝓟 v ℓ).card : ℝ) * ((ℓ : ℝ) ^ d * u ^ ℓ)
           ≤ (G.maxDegree : ℝ) ^ (2 * ℓ) * ((ℓ : ℝ) ^ d * u ^ ℓ) :=
             mul_le_mul_of_nonneg_right hcount (by positivity)
         _ = (ℓ : ℝ) ^ d * r ^ ℓ := by rw [hr, mul_pow, pow_mul]; ring
@@ -94,5 +96,18 @@ theorem rootedPolymerActivity_cardPow_tail_le (G : SimpleGraph ι) [DecidableRel
       (summable_pow_mul_geometric_of_norm_lt_one d hnorm)
   refine le_trans (hsumm.sum_le_tsum _ (fun m _ => by positivity)) ?_
   exact tsum_succ_pow_mul_geometric_succ_le d hr0 hu
+
+/-- **Sharpened (tail) per-vertex polymer-activity moment bound.**  Since every polymer
+through `v` is nonempty, the size-`0` fiber of the moment sum is empty, so the bound of
+`rootedPolymerActivity_cardPow_le` sharpens by a factor `Δ²u`:
+`∑_{Q ∋ v} |Q|^d u^{|Q|} ≤ (Δ²u)·d!/(1−Δ²u)^{d+1}`.  Even-gas instance of
+`rootedGasPolymerActivity_cardPow_tail_le`. -/
+theorem rootedPolymerActivity_cardPow_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (v : ι) (d : ℕ) {u : ℝ} (hu0 : 0 ≤ u)
+    (hu : (G.maxDegree : ℝ) ^ 2 * u < 1) :
+    (∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * u ^ Q.card)
+      ≤ ((G.maxDegree : ℝ) ^ 2 * u)
+          * ((d.factorial : ℝ) / (1 - (G.maxDegree : ℝ) ^ 2 * u) ^ (d + 1)) :=
+  rootedGasPolymerActivity_cardPow_tail_le G (evenPolymerGasData G) v d hu0 hu
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/PolymerCounting.lean
+++ b/IsingModel/ClusterExpansion/PolymerCounting.lean
@@ -19,6 +19,16 @@ cluster expansion; the (per-volume) high-temperature conditions of
 `InteractingFreeEnergyMayerHighTemp` grow with the volume, whereas this bound does
 not.
 
+## Abstract polymer gas
+
+The counting engine is purely connectivity-based: it never uses even-ness.  It is
+therefore stated over an **abstract polymer set** `𝓟 : Finset (Finset (Sym2 ι))`
+whose members satisfy `PolymerGasData` (each polymer is a nonempty edge-connected
+subset of `G.edgeFinset`).  The even gas (`allPolymers G`, `evenPolymerGasData`)
+and, later, the connected/field gas both instantiate this, so the count and the
+per-vertex activity moment bounds are proved once over `𝓟`; the even-gas
+statements are recovered verbatim as `𝓟 := allPolymers G` wrappers.
+
 The results are finite-graph bounds in terms of `G.maxDegree`.  They do not by
 themselves give a volume-uniform Mayer convergence theorem or the infinite-volume
 pressure; that is a later assembly.
@@ -33,36 +43,90 @@ namespace IsingModel
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- The polymers of `G` whose support contains the vertex `v`. -/
+/-- **Abstract polymer-gas data.**  The hypotheses on an abstract polymer set
+`𝓟 : Finset (Finset (Sym2 ι))` that the volume-uniform Kotecky--Preiss counting and
+moment core consume: every member is a nonempty edge-connected subset of
+`G.edgeFinset`.  The even gas (`allPolymers G`) and the connected/field gas both
+instantiate this, so the count and per-vertex activity moment bounds are proved once
+over `𝓟`.  The support-cardinality bound (`|supp P| ≤ |P|` for even, `≤ |P| + 1` for
+connected) is deliberately *not* part of this bundle: the moment core keeps the
+`|supp P|` factor and each gas applies its own (tight) support bound in a wrapper. -/
+structure PolymerGasData (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) : Prop where
+  /-- Every polymer of the gas is a subset of the edge set of `G`. -/
+  mem_edgeFinset : ∀ P ∈ 𝓟, P ⊆ G.edgeFinset
+  /-- Every polymer of the gas is edge-connected. -/
+  connected : ∀ P ∈ 𝓟, IsEdgeConnected P
+  /-- Every polymer of the gas is nonempty. -/
+  nonempty : ∀ P ∈ 𝓟, P.Nonempty
+
+/-- The gas polymers (from `𝓟`) whose support contains the vertex `v`. -/
+def rootedGasPolymers (𝓟 : Finset (Finset (Sym2 ι))) (v : ι) :
+    Finset (Finset (Sym2 ι)) :=
+  𝓟.filter fun P => v ∈ polymerSupport P
+
+/-- The gas polymers (from `𝓟`) of size `ℓ` whose support contains the vertex `v`. -/
+def rootedGasPolymersOfCard (𝓟 : Finset (Finset (Sym2 ι))) (v : ι) (ℓ : ℕ) :
+    Finset (Finset (Sym2 ι)) :=
+  (rootedGasPolymers 𝓟 v).filter fun P => P.card = ℓ
+
+/-- **Rooted gas polymers inject into closed walks.**  The number of size-`ℓ`
+polymers of the gas `𝓟` through `v` is at most the number of closed walks of length
+`2ℓ` from `v`.  Uses only the connectivity data of `PolymerGasData`. -/
+theorem rootedGasPolymersOfCard_card_le_closedWalkCount (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) (v : ι) (ℓ : ℕ) :
+    (rootedGasPolymersOfCard 𝓟 v ℓ).card ≤ (G.finsetWalkLength (2 * ℓ) v v).card := by
+  refine card_connected_edge_sets_le v ℓ _ (fun C hC => ?_)
+  rw [rootedGasPolymersOfCard, Finset.mem_filter, rootedGasPolymers, Finset.mem_filter] at hC
+  obtain ⟨⟨hCmem, hCv⟩, hCcard⟩ := hC
+  exact ⟨hgas.mem_edgeFinset C hCmem, hgas.connected C hCmem, hCcard,
+    mem_polymerSupport.mp hCv⟩
+
+/-- **Max-degree bound on rooted gas polymer counts (volume-uniform).**  The number
+of size-`ℓ` polymers of the gas `𝓟` through `v` is at most `Δ^{2ℓ}`, where
+`Δ = G.maxDegree`. -/
+theorem rootedGasPolymersOfCard_card_le_maxDegree_pow (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) (v : ι) (ℓ : ℕ) :
+    (rootedGasPolymersOfCard 𝓟 v ℓ).card ≤ G.maxDegree ^ (2 * ℓ) := by
+  refine (rootedGasPolymersOfCard_card_le_closedWalkCount G hgas v ℓ).trans ?_
+  refine le_trans ?_ (walksFromCount_le_pow G (fun w => G.degree_le_maxDegree w) (2 * ℓ) v)
+  rw [walksFromCount]
+  exact Finset.single_le_sum (f := fun u => (G.finsetWalkLength (2 * ℓ) v u).card)
+    (fun u _ => Nat.zero_le _) (Finset.mem_univ v)
+
+omit [Fintype ι] in
+/-- **The even gas satisfies the polymer-gas hypotheses.**  Every even-subgraph
+polymer of `allPolymers G` is a nonempty edge-connected subset of `G.edgeFinset`. -/
+theorem evenPolymerGasData (G : SimpleGraph ι) [Fintype G.edgeSet] :
+    PolymerGasData G (allPolymers G) where
+  mem_edgeFinset _ hP := (mem_allPolymers.mp hP).isEven.subset
+  connected _ hP := (mem_allPolymers.mp hP).connected
+  nonempty _ hP := (mem_allPolymers.mp hP).nonempty
+
+/-- The polymers of `G` whose support contains the vertex `v` (even gas). -/
 noncomputable def rootedPolymers (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) :
     Finset (Finset (Sym2 ι)) :=
-  (allPolymers G).filter fun P => v ∈ polymerSupport P
+  rootedGasPolymers (allPolymers G) v
 
-/-- The polymers of `G` of size `ℓ` whose support contains the vertex `v`. -/
+/-- The polymers of `G` of size `ℓ` whose support contains the vertex `v` (even gas). -/
 noncomputable def rootedPolymersOfCard (G : SimpleGraph ι) [Fintype G.edgeSet]
     (v : ι) (ℓ : ℕ) : Finset (Finset (Sym2 ι)) :=
-  (rootedPolymers G v).filter fun P => P.card = ℓ
+  rootedGasPolymersOfCard (allPolymers G) v ℓ
 
 /-- **Rooted polymers inject into closed walks.**  The number of size-`ℓ` polymers
 through `v` is at most the number of closed walks of length `2ℓ` from `v`. -/
 theorem rootedPolymersOfCard_card_le_closedWalkCount (G : SimpleGraph ι)
     [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) (ℓ : ℕ) :
-    (rootedPolymersOfCard G v ℓ).card ≤ (G.finsetWalkLength (2 * ℓ) v v).card := by
-  refine card_connected_edge_sets_le v ℓ _ (fun C hC => ?_)
-  rw [rootedPolymersOfCard, Finset.mem_filter, rootedPolymers, Finset.mem_filter] at hC
-  obtain ⟨⟨hCmem, hCv⟩, hCcard⟩ := hC
-  have hpoly : IsPolymer G C := mem_allPolymers.mp hCmem
-  exact ⟨hpoly.isEven.subset, hpoly.connected, hCcard, mem_polymerSupport.mp hCv⟩
+    (rootedPolymersOfCard G v ℓ).card ≤ (G.finsetWalkLength (2 * ℓ) v v).card :=
+  rootedGasPolymersOfCard_card_le_closedWalkCount G (evenPolymerGasData G) v ℓ
 
 /-- **Max-degree bound on rooted polymer counts (volume-uniform).**  The number of
 size-`ℓ` polymers through `v` is at most `Δ^{2ℓ}`, where `Δ = G.maxDegree`. -/
 theorem rootedPolymersOfCard_card_le_maxDegree_pow (G : SimpleGraph ι)
     [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) (ℓ : ℕ) :
-    (rootedPolymersOfCard G v ℓ).card ≤ G.maxDegree ^ (2 * ℓ) := by
-  refine (rootedPolymersOfCard_card_le_closedWalkCount G v ℓ).trans ?_
-  refine le_trans ?_ (walksFromCount_le_pow G (fun w => G.degree_le_maxDegree w) (2 * ℓ) v)
-  rw [walksFromCount]
-  exact Finset.single_le_sum (f := fun u => (G.finsetWalkLength (2 * ℓ) v u).card)
-    (fun u _ => Nat.zero_le _) (Finset.mem_univ v)
+    (rootedPolymersOfCard G v ℓ).card ≤ G.maxDegree ^ (2 * ℓ) :=
+  rootedGasPolymersOfCard_card_le_maxDegree_pow G (evenPolymerGasData G) v ℓ
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootMomentBound.lean
+++ b/IsingModel/ClusterExpansion/RootMomentBound.lean
@@ -71,7 +71,7 @@ theorem sum_allPolymers_cardPow_expWeighted_le (G : SimpleGraph ι) [DecidableRe
       _ = ∑ v : ι, ∑ Q ∈ rootedPolymers G v,
             (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_congr rfl fun v _ => ?_
-          rw [rootedPolymers, Finset.sum_filter]
+          rw [rootedPolymers, rootedGasPolymers, Finset.sum_filter]
   refine key.trans ?_
   calc (∑ v : ι, ∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ _v : ι, ((d.factorial : ℝ)

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafColumn.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafColumn.lean
@@ -48,7 +48,7 @@ theorem leafColumnSum_eq (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.ed
       = ∑ x ∈ incompatiblePolymers G P, (x.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ x.card := by
   rw [leafColumnSum, ← Finset.sum_filter]
   congr 1
-  rw [incompatiblePolymers]
+  rw [incompatiblePolymers, incompatibleGasPolymers]
   exact Finset.filter_congr fun x _ => ⟨fun h => h.symm, fun h => h.symm⟩
 
 /-- **Kotecky--Preiss bound for the leaf column sum.**  For `P ∈ allPolymers G` and


### PR DESCRIPTION
## Purpose

Foundation R1 of the field-CE minimal route (#4433): parameterize the even-gas KP moment-core (~6 "Tier-B" files) over an **abstract polymer set** `𝒫 : Finset (Finset (Sym2 ι))` with hypotheses (H-conn connectivity, H-supp support-linear bound `|supp P| ≤ c·|P|`).

This enables both routes to consume the same machinery:
- **β route** (even gas): `𝒫 := allPolymers G`, c=1, recovered by instantiation wrapper → existing β capstones remain unchanged.
- **h-direction route** (field-CE): `𝒫 := allConnectedPolymers G`, c=2, via `|supp C| ≤ |C|+1` (already-proven lemma).

## Design & Scoping

Detailed independent design at `.self-local/reports/scope-kp-parameterization-surface-2026-07-05.md`.

**Verdict:** Bounded, GO-able gated refactor. The peel induction is NOT even-gas-specific; evenness appears in only 4 files at 5 leaf spots, all extracting `P ⊆ G.edgeFinset` (swappable with connectivity). The one evenness-specific fact (`|supp P| ≤ |P|` from handshake lemma) has a connected analogue already proven in the repo. Surgery is "add abstract polymer set + thread + swap one support bound", not a rewrite.

**Tier B (6 files, ~55% of touches):** Real proof edits.
- `PolymerCounting`, `PolymerActivity`, `PolymerActivityMoment`, `PolymerActivityTailMoment`, `PolymerActivityKP`, `PolymerActivityKPMoment` — introduce `𝒫` + `PolymerGasData` hypothesis bundle, generalize core lemmas `rootedPolymerActivity_cardPow_le` (#4099), `incompatibilityActivity_cardPow_expWeighted_le` (#4102). Proofs: the `isEven.subset` and `polymerSupport_card_le` lines read from (H-conn) and (H-supp); all other logic unchanged.

**Tier A (16 files, ~45% of touches):** Pure mechanical threading; proofs untouched.
- `RootedParentActive*` (14 files), `MayerTreeSum{Activity,ExpActivity}` — carry `𝒫` as section variable, pass through call sites.

**Scope discipline (per CLAUDE.local.md over-parameterization gate):** R1 is ONLY moment-core parameterization. Core-threading is R2, rest + instantiation wrappers is R3. Do NOT bundle. (Pair-only consumption downstream.)

## Test-First / Regression Protection

Existing β-direction capstones + moment cores are the regression guard:
1. Build these BEFORE R1 (as named test set).
2. After each refactor PR (R1/R2/R3), rebuild them — must stay green via instantiation wrappers.
3. Final state: `𝒫 := allPolymers` wrapper recovers all β statements verbatim; σ-direction continuation unchanged.

Targets (the 4 capstones + 2 moment cores forming the regression set):
- `TermsComplexHolomorphic.mayerExpansionTermComplex_succ_norm_le_card_div_mul_geometric` 
- `RootedParentActiveTreePeelBoundTail.lean:33`
- `MayerTermTailSummability.mayerTermTail_summable_degree`
- `TermsComplexPerSiteBound.termsComplexPerSiteBound_le_geometric`
- `PolymerActivity.incompatibilityActivity_cardPow_expWeighted_le` (#4102)
- `PolymerActivityMoment.rootedPolymerActivity_cardPow_le` (#4099)

## PR Scope Boundary

✓ Introduce `PolymerGasData` with (H-conn)/(H-supp).
✓ Generalize Tier-B moment-core machinery over abstract `𝒫`.
✗ Do NOT thread `𝒫` into Tier-A induction/tree files (deferred to R2).
✗ Do NOT write instantiation wrappers (deferred to R3).

## Checklist

- [ ] No `sorry`, no `#check`, no `native_decide`.
- [ ] `lake build IsingModel` → zero warnings.
- [ ] Axioms unchanged: `#print axioms` ⊆ {propext, Classical.choice, Quot.sound}.
- [ ] Regression guard (6 capstones) rebuilt; confirm green.
- [ ] All Tier-B proof edits reviewed by codex (even-to-conn fact mapping).

---

Related: #4433 (field-CE minimal route), design #1 of 3-PR gated refactor sequence (R1 moment-core | R2 core-threading | R3 rest+wrappers).
