### PR TITLE
refactor(kp): thread abstract polymer set 𝓟 through RootedParentActive peel-chain (field-CE F1 foundation R2) — #4433

### DIFF
--- a/IsingModel/ClusterExpansion/MayerTermTailSummability.lean
+++ b/IsingModel/ClusterExpansion/MayerTermTailSummability.lean
@@ -41,25 +41,29 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **The `(Δ²e|t|)^n`-weighted summed peel bound in closed factorial form.**  Summing
-the factorial-product form (#4131) over the spanning trees and bounding the factorial sum
-by `4^n·n!` (#4126): for `Δ²e|t| < 1`,
-`∑_T (Δ²e|t|)^n·peelBound ≤ ((Δ²e|t|)^n·|V|·4^n·n!)/(1−Δ²e|t|)^{2n+1}`. -/
-theorem sum_pow_rootedParentActivePeelBound_le (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] (n : ℕ) {t : ℝ}
+omit [DecidableEq ι] in
+/-- **The `(Δ²e|t|)^n`-weighted summed gas peel bound in closed factorial form.**  Summing
+the gas factorial-product form over the spanning trees and bounding the factorial sum by
+`4^n·n!` (#4126): for `Δ²e|t| < 1` and `0 ≤ c`,
+`∑_T (Δ²e|t|)^n·gasPeelBound ≤ ((Δ²e|t|)^n·c^n·|V|·4^n·n!)/(1−Δ²e|t|)^{2n+1}`.  The even gas
+(`allPolymers G`) takes `c = 1` in `sum_pow_rootedParentActivePeelBound_le`. -/
+theorem sum_pow_rootedGasParentActivePeelBound_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) (c : ℝ)
+    (hc : 0 ≤ c) (n : ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
     (∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
         S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
         ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
-          * rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
+          * rootedGasParentActivePeelBound G 𝓟 c (Penrose.completeGraphTreeParentCode n T)
               (Finset.univ : Finset (Fin n)) (fun _ => 0) t)
-      ≤ (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+      ≤ (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n * c ^ n
           * (Fintype.card ι : ℝ) * (4 : ℝ) ^ n * (n.factorial : ℝ))
           / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1) := by
   set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
   set q : ℝ := 1 - rr with hq
   have hqpos : 0 < q := by rw [hq]; linarith [hkp]
   have hrr0 : 0 ≤ rr := by rw [hrr]; positivity
+  have hcn0 : 0 ≤ c ^ n := pow_nonneg hc n
   -- The cast of the spanning-tree factorial bound (#4126).
   have hcast : (∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
         S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
@@ -77,40 +81,56 @@ theorem sum_pow_rootedParentActivePeelBound_le (G : SimpleGraph ι) [DecidableRe
                 (Finset.univ : Finset (Fin n)) v).factorial : ℕ) : ℝ) := by push_cast; ring
       _ ≤ ((4 ^ n * n.factorial : ℕ) : ℝ) := by exact_mod_cast h
       _ = (4 : ℝ) ^ n * (n.factorial : ℝ) := by push_cast; ring
-  -- ∑_T rr^n·peelBound = rr^n·∑_T peelBound ≤ rr^n·(|V|/q^{2n+1})·(4^n·n!).
+  -- ∑_T rr^n·gasPeelBound = rr^n·∑_T gasPeelBound ≤ rr^n·(c^n·|V|/q^{2n+1})·(4^n·n!).
   rw [← Finset.mul_sum]
   have hpeel : (∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
         S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
-        rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
+        rootedGasParentActivePeelBound G 𝓟 c (Penrose.completeGraphTreeParentCode n T)
           (Finset.univ : Finset (Fin n)) (fun _ => 0) t)
-      ≤ ((Fintype.card ι : ℝ) / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ)) := by
-    calc (∑ T, rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
+      ≤ (c ^ n * (Fintype.card ι : ℝ) / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ)) := by
+    calc (∑ T, rootedGasParentActivePeelBound G 𝓟 c (Penrose.completeGraphTreeParentCode n T)
             (Finset.univ : Finset (Fin n)) (fun _ => 0) t)
-          ≤ ∑ T, ((Fintype.card ι : ℝ)
+          ≤ ∑ T, c ^ n * (((Fintype.card ι : ℝ)
               * ∏ v : Fin (n + 1),
                   ((rootedParentChildCount (Penrose.completeGraphTreeParentCode n T)
                     (Finset.univ : Finset (Fin n)) v).factorial : ℝ))
-              / q ^ (2 * n + 1) := by
+              / q ^ (2 * n + 1)) := by
             refine Finset.sum_le_sum fun T _ => ?_
-            exact rootedParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div
-              G (Penrose.completeGraphTreeParentCode n T) hqpos
-      _ = ((Fintype.card ι : ℝ) / q ^ (2 * n + 1))
+            exact rootedGasParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div
+              G hgas c hc (Penrose.completeGraphTreeParentCode n T) hqpos
+      _ = (c ^ n * (Fintype.card ι : ℝ) / q ^ (2 * n + 1))
             * ∑ T, ∏ v : Fin (n + 1),
                 ((rootedParentChildCount (Penrose.completeGraphTreeParentCode n T)
                   (Finset.univ : Finset (Fin n)) v).factorial : ℝ) := by
             rw [Finset.mul_sum]
-            refine Finset.sum_congr rfl fun T _ => ?_
-            rw [mul_div_right_comm]
-      _ ≤ ((Fintype.card ι : ℝ) / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ)) := by
+            exact Finset.sum_congr rfl fun T _ => by ring
+      _ ≤ (c ^ n * (Fintype.card ι : ℝ) / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ)) := by
             refine mul_le_mul_of_nonneg_left hcast ?_
             exact div_nonneg (by positivity) (le_of_lt (pow_pos hqpos _))
   calc rr ^ n
-        * ∑ T, rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
+        * ∑ T, rootedGasParentActivePeelBound G 𝓟 c (Penrose.completeGraphTreeParentCode n T)
             (Finset.univ : Finset (Fin n)) (fun _ => 0) t
-        ≤ rr ^ n * (((Fintype.card ι : ℝ) / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ))) :=
+        ≤ rr ^ n * ((c ^ n * (Fintype.card ι : ℝ) / q ^ (2 * n + 1))
+            * ((4 : ℝ) ^ n * (n.factorial : ℝ))) :=
           mul_le_mul_of_nonneg_left hpeel (pow_nonneg hrr0 n)
-    _ = (rr ^ n * (Fintype.card ι : ℝ) * (4 : ℝ) ^ n * (n.factorial : ℝ)) / q ^ (2 * n + 1) := by
-          ring
+    _ = (rr ^ n * c ^ n * (Fintype.card ι : ℝ) * (4 : ℝ) ^ n * (n.factorial : ℝ))
+          / q ^ (2 * n + 1) := by ring
+
+/-- **The `(Δ²e|t|)^n`-weighted summed peel bound in closed factorial form.**  Even-gas
+(`c = 1`) instance of `sum_pow_rootedGasParentActivePeelBound_le`. -/
+theorem sum_pow_rootedParentActivePeelBound_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (n : ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
+        S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
+        ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+          * rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
+              (Finset.univ : Finset (Fin n)) (fun _ => 0) t)
+      ≤ (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+          * (Fintype.card ι : ℝ) * (4 : ℝ) ^ n * (n.factorial : ℝ))
+          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1) := by
+  have h := sum_pow_rootedGasParentActivePeelBound_le G (evenPolymerGasData G) 1 zero_le_one n hkp
+  simpa [rootedParentActivePeelBound] using h
 
 /-- **The geometric per-order bound on the Mayer expansion term.**  For `Δ²e|t| < 1`,
 `|mayerExpansionTerm G (n + 1) t| ≤ |V|/(1−r)·(4r/(1−r)²)^n` with `r = Δ²e|t|`.  This

--- a/IsingModel/ClusterExpansion/RootMomentBound.lean
+++ b/IsingModel/ClusterExpansion/RootMomentBound.lean
@@ -27,29 +27,42 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **The root moment bound.**  For `Δ²e|t| < 1`, the `d`-th moment of the `e`-weighted
-activity summed over all polymers of `G` is at most `|V|·d!/(1−Δ²e|t|)^{d+1}`.  Every
-polymer is rooted at each of its `|supp P| ≥ 1` support vertices, so the sum over all
-polymers is dominated by the sum over vertices of the per-vertex moment bound
-`rootedPolymerActivity_cardPow_le`. -/
-theorem sum_allPolymers_cardPow_expWeighted_le (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] (d : ℕ) {t : ℝ}
+/-- **A nonempty polymer has nonempty support.**  Since a nonempty edge set contains an
+edge and every edge contains a vertex, the support cardinality is at least one. -/
+theorem one_le_card_polymerSupport_of_nonempty {P : Finset (Sym2 ι)} (hP : P.Nonempty) :
+    1 ≤ (polymerSupport P).card := by
+  obtain ⟨e, he⟩ := hP
+  refine Finset.card_pos.mpr ?_
+  induction e using Sym2.ind with
+  | _ a b => exact ⟨a, mem_polymerSupport.mpr ⟨_, he, Sym2.mem_mk_left a b⟩⟩
+
+omit [DecidableEq ι] in
+/-- **The root moment bound over an abstract gas.**  For `Δ²e|t| < 1`, the `d`-th moment
+of the `e`-weighted activity summed over all polymers of the gas `𝓟` is at most
+`|V|·d!/(1−Δ²e|t|)^{d+1}`.  Every polymer is rooted at each of its `|supp P| ≥ 1` support
+vertices (nonemptiness from `PolymerGasData`), so the sum over the gas is dominated by the
+sum over vertices of the per-vertex moment bound `rootedGasPolymerActivity_cardPow_le`. -/
+theorem sum_gasPolymers_cardPow_expWeighted_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟)
+    (d : ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
-    (∑ P ∈ allPolymers G, (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card)
+    (∑ P ∈ 𝓟, (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card)
       ≤ (Fintype.card ι : ℝ)
           * ((d.factorial : ℝ)
               / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) := by
+  classical
   have hw0 : (0 : ℝ) ≤ Real.exp 1 * |t| := by positivity
   -- Cover each polymer by its support vertices (each counted ≥ 1 time).
-  have key : (∑ P ∈ allPolymers G, (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card)
-      ≤ ∑ v : ι, ∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
-    calc (∑ P ∈ allPolymers G, (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card)
-        ≤ ∑ P ∈ allPolymers G,
+  have key : (∑ P ∈ 𝓟, (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card)
+      ≤ ∑ v : ι, ∑ Q ∈ rootedGasPolymers 𝓟 v,
+          (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
+    calc (∑ P ∈ 𝓟, (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card)
+        ≤ ∑ P ∈ 𝓟,
             ∑ _v ∈ polymerSupport P, (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card := by
           refine Finset.sum_le_sum fun P hP => ?_
           rw [Finset.sum_const]
           have h1 : (1 : ℝ) ≤ ((polymerSupport P).card : ℝ) := by
-            exact_mod_cast one_le_card_polymerSupport_of_mem_allPolymers G hP
+            exact_mod_cast one_le_card_polymerSupport_of_nonempty (hgas.nonempty P hP)
           calc (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card
               = 1 * ((P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card) := (one_mul _).symm
             _ ≤ ((polymerSupport P).card : ℝ)
@@ -57,7 +70,7 @@ theorem sum_allPolymers_cardPow_expWeighted_le (G : SimpleGraph ι) [DecidableRe
                 mul_le_mul_of_nonneg_right h1 (by positivity)
             _ = (polymerSupport P).card
                   • ((P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card) := (nsmul_eq_mul _ _).symm
-      _ = ∑ P ∈ allPolymers G,
+      _ = ∑ P ∈ 𝓟,
             ∑ v : ι, (if v ∈ polymerSupport P then
               (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card else 0) := by
           refine Finset.sum_congr rfl fun P _ => ?_
@@ -66,20 +79,33 @@ theorem sum_allPolymers_cardPow_expWeighted_le (G : SimpleGraph ι) [DecidableRe
             (fun _ : ι => (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card)
           rw [Finset.filter_univ_mem] at hsf
           exact hsf
-      _ = ∑ v : ι, ∑ P ∈ allPolymers G, (if v ∈ polymerSupport P then
+      _ = ∑ v : ι, ∑ P ∈ 𝓟, (if v ∈ polymerSupport P then
               (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card else 0) := Finset.sum_comm
-      _ = ∑ v : ι, ∑ Q ∈ rootedPolymers G v,
+      _ = ∑ v : ι, ∑ Q ∈ rootedGasPolymers 𝓟 v,
             (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card := by
           refine Finset.sum_congr rfl fun v _ => ?_
-          rw [rootedPolymers, rootedGasPolymers, Finset.sum_filter]
+          rw [rootedGasPolymers, Finset.sum_filter]
   refine key.trans ?_
-  calc (∑ v : ι, ∑ Q ∈ rootedPolymers G v, (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
+  calc (∑ v : ι, ∑ Q ∈ rootedGasPolymers 𝓟 v,
+          (Q.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ Q.card)
       ≤ ∑ _v : ι, ((d.factorial : ℝ)
             / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) :=
-        Finset.sum_le_sum fun v _ => rootedPolymerActivity_cardPow_le G v d hw0 hkp
+        Finset.sum_le_sum fun v _ => rootedGasPolymerActivity_cardPow_le G hgas v d hw0 hkp
     _ = (Fintype.card ι : ℝ)
           * ((d.factorial : ℝ)
               / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) := by
         rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+
+/-- **The root moment bound.**  For `Δ²e|t| < 1`, the `d`-th moment of the `e`-weighted
+activity summed over all polymers of `G` is at most `|V|·d!/(1−Δ²e|t|)^{d+1}`.  Even-gas
+instance of `sum_gasPolymers_cardPow_expWeighted_le`. -/
+theorem sum_allPolymers_cardPow_expWeighted_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (d : ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ P ∈ allPolymers G, (P.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ P.card)
+      ≤ (Fintype.card ι : ℝ)
+          * ((d.factorial : ℝ)
+              / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) :=
+  sum_gasPolymers_cardPow_expWeighted_le G (evenPolymerGasData G) d hkp
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafColumn.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafColumn.lean
@@ -29,33 +29,68 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **The leaf column sum.**  The moment-weighted activity of the polymers `x` of `G`
-incompatible with a fixed polymer `P`: `∑_{x ∼ P} |x|^d·(e|t|)^{|x|}`.  This is the
-inner sum over the leaf value once the leaf coordinate has been peeled out of
-`rootedParentActiveSum`. -/
-noncomputable def leafColumnSum (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] (P : Finset (Sym2 ι)) (d : ℕ) (t : ℝ) : ℝ :=
-  ∑ x ∈ allPolymers G,
+/-- **The leaf column gas sum.**  The moment-weighted activity of the polymers `x` of the
+gas `𝓟` incompatible with a fixed polymer `P`: `∑_{x ∈ 𝓟, x ∼ P} |x|^d·(e|t|)^{|x|}`.
+This is the inner sum over the leaf value once the leaf coordinate has been peeled out of
+`rootedGasParentActiveSum`.  The even gas (`allPolymers G`) is recovered by
+`leafColumnSum`. -/
+noncomputable def leafGasColumnSum (𝓟 : Finset (Finset (Sym2 ι))) (P : Finset (Sym2 ι))
+    (d : ℕ) (t : ℝ) : ℝ :=
+  ∑ x ∈ 𝓟,
     if PolymersIncompatible x P then (x.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ x.card else 0
 
-/-- **The leaf column sum equals the incompatibility-neighbourhood moment sum.**  The
-constrained sum over `allPolymers G` is the unconstrained sum over the incompatibility
-neighbourhood `incompatiblePolymers G P` (using that `PolymersIncompatible` is
-symmetric). -/
+/-- **The leaf column sum.**  The even-gas (`allPolymers G`) instance of
+`leafGasColumnSum`. -/
+noncomputable def leafColumnSum (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (P : Finset (Sym2 ι)) (d : ℕ) (t : ℝ) : ℝ :=
+  leafGasColumnSum (allPolymers G) P d t
+
+/-- **The leaf column gas sum equals the incompatibility-neighbourhood moment sum.**  The
+constrained sum over `𝓟` is the unconstrained sum over the incompatibility neighbourhood
+`incompatibleGasPolymers 𝓟 P` (using that `PolymersIncompatible` is symmetric). -/
+theorem leafGasColumnSum_eq (𝓟 : Finset (Finset (Sym2 ι))) (P : Finset (Sym2 ι)) (d : ℕ)
+    (t : ℝ) :
+    leafGasColumnSum 𝓟 P d t
+      = ∑ x ∈ incompatibleGasPolymers 𝓟 P, (x.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ x.card := by
+  rw [leafGasColumnSum, ← Finset.sum_filter]
+  congr 1
+  rw [incompatibleGasPolymers]
+  exact Finset.filter_congr fun x _ => ⟨fun h => h.symm, fun h => h.symm⟩
+
+/-- **The leaf column sum equals the incompatibility-neighbourhood moment sum.**  Even-gas
+instance of `leafGasColumnSum_eq`. -/
 theorem leafColumnSum_eq (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
     (P : Finset (Sym2 ι)) (d : ℕ) (t : ℝ) :
     leafColumnSum G P d t
-      = ∑ x ∈ incompatiblePolymers G P, (x.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ x.card := by
-  rw [leafColumnSum, ← Finset.sum_filter]
-  congr 1
-  rw [incompatiblePolymers, incompatibleGasPolymers]
-  exact Finset.filter_congr fun x _ => ⟨fun h => h.symm, fun h => h.symm⟩
+      = ∑ x ∈ incompatiblePolymers G P, (x.card : ℝ) ^ d * (Real.exp 1 * |t|) ^ x.card :=
+  leafGasColumnSum_eq (allPolymers G) P d t
+
+/-- **Kotecky--Preiss bound for the leaf column gas sum.**  For `Δ²·e·|t| < 1`
+(`Δ = G.maxDegree`), a support-cardinality bound `|supp P| ≤ c·|P|` for the parent polymer
+`P`, and `0 ≤ c`, the leaf column gas sum is bounded by the incompatibility-neighbourhood
+moment estimate `incompatibilityGasActivity_cardPow_expWeighted_le` followed by the support
+bound: `leafGasColumnSum 𝓟 P d t ≤ c·|P|·d!/(1 − Δ²e|t|)^{d+1}`.  The factor `c·|P|` is the
+moment bump (in `.card` form) folded into the remainder weight at the parent vertex; the
+even gas takes `c = 1`. -/
+theorem leafGasColumnSum_le (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) (P : Finset (Sym2 ι)) (d : ℕ)
+    {c : ℝ} (hsupp : ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    leafGasColumnSum 𝓟 P d t
+      ≤ c * (P.card : ℝ)
+          * ((d.factorial : ℝ)
+              / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) := by
+  rw [leafGasColumnSum_eq]
+  refine (incompatibilityGasActivity_cardPow_expWeighted_le G hgas P d hkp).trans ?_
+  have hpos : (0 : ℝ) < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) := by linarith
+  exact mul_le_mul_of_nonneg_right hsupp
+    (div_nonneg (by positivity) (le_of_lt (pow_pos hpos (d + 1))))
 
 /-- **Kotecky--Preiss bound for the leaf column sum.**  For `P ∈ allPolymers G` and
-`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the leaf column sum is bounded by the
-incompatibility-neighbourhood moment estimate `incompatibilityActivity_cardPow_expWeighted_le`:
-`leafColumnSum G P d t ≤ |P|·d!/(1 − Δ²e|t|)^{d+1}`.  The factor `|P|` is the moment
-bump folded into the remainder weight at the parent vertex. -/
+`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the leaf column sum is bounded by
+`leafColumnSum G P d t ≤ |P|·d!/(1 − Δ²e|t|)^{d+1}`.  Even-gas (`c = 1`) instance of
+`leafGasColumnSum_le`, discharging the support bound via
+`polymerSupport_card_le_card_of_mem_allPolymers`. -/
 theorem leafColumnSum_le (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
     {P : Finset (Sym2 ι)} (hP : P ∈ allPolymers G) (d : ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
@@ -63,7 +98,8 @@ theorem leafColumnSum_le (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.ed
       ≤ (P.card : ℝ)
           * ((d.factorial : ℝ)
               / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1)) := by
-  rw [leafColumnSum_eq]
-  exact incompatibilityActivity_cardPow_expWeighted_le G hP d hkp
+  have hsupp : ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  simpa using leafGasColumnSum_le G (evenPolymerGasData G) P d hsupp hkp
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafColumnTail.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafColumnTail.lean
@@ -26,11 +26,34 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
+/-- **Sharpened (tail) Kotecky--Preiss bound for the leaf column gas sum.**  For
+`Δ²e|t| < 1`, a support-cardinality bound `|supp P| ≤ c·|P|`, and `0 ≤ c`, the leaf
+column gas sum carries an extra factor `Δ²e|t|` over `leafGasColumnSum_le`:
+`leafGasColumnSum 𝓟 P d t ≤ c·|P|·(Δ²e|t|)·d!/(1−Δ²e|t|)^{d+1}`.  This is
+`leafGasColumnSum_eq` followed by the tail incompatibility-neighbourhood moment bound
+`incompatibilityGasActivity_cardPow_expWeighted_tail_le` and the support bound; the even
+gas takes `c = 1`. -/
+theorem leafGasColumnSum_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) (P : Finset (Sym2 ι)) (d : ℕ)
+    {c : ℝ} (hsupp : ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    leafGasColumnSum 𝓟 P d t
+      ≤ c * (P.card : ℝ)
+          * (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+            * ((d.factorial : ℝ)
+                / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1))) := by
+  rw [leafGasColumnSum_eq]
+  refine (incompatibilityGasActivity_cardPow_expWeighted_tail_le G hgas P d hkp).trans ?_
+  have hpos : (0 : ℝ) < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) := by linarith
+  exact mul_le_mul_of_nonneg_right hsupp
+    (mul_nonneg (by positivity)
+      (div_nonneg (by positivity) (le_of_lt (pow_pos hpos (d + 1)))))
+
 /-- **Sharpened (tail) Kotecky--Preiss bound for the leaf column sum.**  For
 `P ∈ allPolymers G` and `Δ²e|t| < 1`, the leaf column sum carries an extra factor
 `Δ²e|t|` over `leafColumnSum_le`:
-`leafColumnSum G P d t ≤ |P|·(Δ²e|t|)·d!/(1−Δ²e|t|)^{d+1}`.  This is `leafColumnSum_eq`
-followed by the tail incompatibility-neighbourhood moment bound #4122. -/
+`leafColumnSum G P d t ≤ |P|·(Δ²e|t|)·d!/(1−Δ²e|t|)^{d+1}`.  Even-gas (`c = 1`) instance
+of `leafGasColumnSum_tail_le`. -/
 theorem leafColumnSum_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
     {P : Finset (Sym2 ι)} (hP : P ∈ allPolymers G) (d : ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
@@ -39,7 +62,8 @@ theorem leafColumnSum_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype
           * (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
             * ((d.factorial : ℝ)
                 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (d + 1))) := by
-  rw [leafColumnSum_eq]
-  exact incompatibilityActivity_cardPow_expWeighted_tail_le G hP d hkp
+  have hsupp : ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  simpa using leafGasColumnSum_tail_le G (evenPolymerGasData G) P d hsupp hkp
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafInner.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafInner.lean
@@ -32,18 +32,19 @@ variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ℕ}
 
 /-- **Per-labelling leaf isolation.**  For a leaf `j` of an active-closed set `A`, a
 remainder labelling `η` of the active vertices of `A.erase j`, and a leaf value `x`
-ranging over `allPolymers G`, the reconstructed summand
+ranging over the gas `𝓟`, the reconstructed summand
 `fun a => (rootedParentActiveSplitEquiv hleaf.1 a).elim x η` summed over `x` factors as
-the remainder summand (the summand of `rootedParentActiveSum` for `A.erase j` at `η`)
-times the leaf column sum at the remainder value `η ⟨par j, _⟩` assigned to the
+the remainder summand (the summand of `rootedGasParentActiveSum` for `A.erase j` at `η`)
+times the leaf column gas sum at the remainder value `η ⟨par j, _⟩` assigned to the
 leaf's parent vertex.  The leaf value
-contributes its own constraint and weight factor (collected into `leafColumnSum`); the
-remaining constraints and weights pass through to the remainder. -/
-theorem rootedParentActiveSum_leaf_inner (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+contributes its own constraint and weight factor (collected into `leafGasColumnSum`); the
+remaining constraints and weights pass through to the remainder.  The even gas
+(`allPolymers G`) is recovered by `rootedParentActiveSum_leaf_inner`. -/
+theorem rootedGasParentActiveSum_leaf_inner (𝓟 : Finset (Finset (Sym2 ι)))
+    {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
     (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
     (k : Fin (n + 1) → ℕ) (t : ℝ) (η : RootedParentActive (A.erase j) → Finset (Sym2 ι)) :
-    (∑ x ∈ allPolymers G,
+    (∑ x ∈ 𝓟,
         (if ∀ i, ∀ hi : i ∈ A,
             PolymersIncompatible
               ((rootedParentActiveSplitEquiv hleaf.1 (rootedParentActiveChild hi)).elim x η)
@@ -59,7 +60,7 @@ theorem rootedParentActiveSum_leaf_inner (G : SimpleGraph ι) [DecidableRel G.Ad
           ∏ w : RootedParentActive (A.erase j),
             ((η w).card : ℝ) ^ k w.1 * (Real.exp 1 * |t|) ^ (η w).card
         else 0)
-        * leafColumnSum G (η ⟨par j, hleaf.parent_mem_erase hclosed⟩) (k (Fin.succ j)) t := by
+        * leafGasColumnSum 𝓟 (η ⟨par j, hleaf.parent_mem_erase hclosed⟩) (k (Fin.succ j)) t := by
   classical
   set hj : j ∈ A := hleaf.1 with hhj
   set hclosed' : RootedParentActiveClosed par (A.erase j) := hclosed.erase_leaf hleaf with hhc'
@@ -132,19 +133,44 @@ theorem rootedParentActiveSum_leaf_inner (G : SimpleGraph ι) [DecidableRel G.Ad
     by_cases hC : Crest <;> by_cases hL : Cleaf x <;>
       simp [hC, hL, mul_comm]
   calc
-    (∑ x ∈ allPolymers G,
+    (∑ x ∈ 𝓟,
         (if ∀ i, ∀ hi : i ∈ A,
             PolymersIncompatible (recon x (rootedParentActiveChild hi))
               (recon x (rootedParentActiveParent hclosed hi)) then
           ∏ v : RootedParentActive A,
             ((recon x v).card : ℝ) ^ k v.1 * q ^ (recon x v).card else 0))
-        = ∑ x ∈ allPolymers G,
+        = ∑ x ∈ 𝓟,
             (if Crest then Prest else 0) * (if Cleaf x then leafW x else 0) :=
           Finset.sum_congr rfl fun x _ => hsummand x
     _ = (if Crest then Prest else 0)
-          * ∑ x ∈ allPolymers G, (if Cleaf x then leafW x else 0) := by
+          * ∑ x ∈ 𝓟, (if Cleaf x then leafW x else 0) := by
         rw [Finset.mul_sum]
-    _ = (if Crest then Prest else 0) * leafColumnSum G P (k (Fin.succ j)) t := by
+    _ = (if Crest then Prest else 0) * leafGasColumnSum 𝓟 P (k (Fin.succ j)) t := by
         rfl
+
+/-- **Per-labelling leaf isolation.**  Even-gas (`allPolymers G`) instance of
+`rootedGasParentActiveSum_leaf_inner`. -/
+theorem rootedParentActiveSum_leaf_inner (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+    (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
+    (k : Fin (n + 1) → ℕ) (t : ℝ) (η : RootedParentActive (A.erase j) → Finset (Sym2 ι)) :
+    (∑ x ∈ allPolymers G,
+        (if ∀ i, ∀ hi : i ∈ A,
+            PolymersIncompatible
+              ((rootedParentActiveSplitEquiv hleaf.1 (rootedParentActiveChild hi)).elim x η)
+              ((rootedParentActiveSplitEquiv hleaf.1
+                (rootedParentActiveParent hclosed hi)).elim x η) then
+          ∏ v : RootedParentActive A,
+            (((rootedParentActiveSplitEquiv hleaf.1 v).elim x η).card : ℝ) ^ k v.1
+              * (Real.exp 1 * |t|) ^ ((rootedParentActiveSplitEquiv hleaf.1 v).elim x η).card
+        else 0))
+      = (if ∀ i, ∀ hi : i ∈ A.erase j,
+            PolymersIncompatible (η (rootedParentActiveChild hi))
+              (η (rootedParentActiveParent (hclosed.erase_leaf hleaf) hi)) then
+          ∏ w : RootedParentActive (A.erase j),
+            ((η w).card : ℝ) ^ k w.1 * (Real.exp 1 * |t|) ^ (η w).card
+        else 0)
+        * leafColumnSum G (η ⟨par j, hleaf.parent_mem_erase hclosed⟩) (k (Fin.succ j)) t :=
+  rootedGasParentActiveSum_leaf_inner (allPolymers G) hclosed hleaf k t η
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelBound.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelBound.lean
@@ -30,21 +30,25 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ℕ}
 
-/-- **The leaf-peel inequality.**  For a leaf `j` of an active-closed set `A` and
-`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the active sum over `A` is bounded by the leaf
-Kotecky--Preiss factor times the active sum over `A.erase j` with the moment exponent at
-the leaf's parent vertex bumped by one.  Each leaf column sum is bounded by
-`leafColumnSum_le`, and the resulting `|η ⟨par j, _⟩|` factor is absorbed into the
-remainder weight via `Function.update k (par j) (k (par j) + 1)`. -/
-theorem rootedParentActiveSum_leaf_peel_le (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+/-- **The leaf-peel inequality (gas form).**  For a leaf `j` of an active-closed set `A`,
+`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), and a support-cardinality bound `|supp P| ≤ c·|P|` for
+all `P ∈ 𝓟`, the active gas sum over `A` is bounded by `c` times the leaf Kotecky--Preiss
+factor times the active gas sum over `A.erase j` with the moment exponent at the leaf's
+parent vertex bumped by one.  Each leaf column gas sum is bounded by `leafGasColumnSum_le`,
+and the resulting `c·|η ⟨par j, _⟩|` factor is absorbed (the `|·|` part into the remainder
+weight via `Function.update k (par j) (k (par j) + 1)`, the `c` factored out).  The even
+gas (`allPolymers G`) takes `c = 1` in `rootedParentActiveSum_leaf_peel_le`. -/
+theorem rootedGasParentActiveSum_leaf_peel_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟)
+    {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
     (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
-    (k : Fin (n + 1) → ℕ) {t : ℝ}
+    (k : Fin (n + 1) → ℕ) {c : ℝ}
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
-    rootedParentActiveSum G par A hclosed k t
-      ≤ ((k (Fin.succ j)).factorial : ℝ)
-          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (k (Fin.succ j) + 1)
-        * rootedParentActiveSum G par (A.erase j) (hclosed.erase_leaf hleaf)
+    rootedGasParentActiveSum G 𝓟 par A hclosed k t
+      ≤ c * (((k (Fin.succ j)).factorial : ℝ)
+          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (k (Fin.succ j) + 1))
+        * rootedGasParentActiveSum G 𝓟 par (A.erase j) (hclosed.erase_leaf hleaf)
             (Function.update k (par j) (k (par j) + 1)) t := by
   classical
   set hclosed' : RootedParentActiveClosed par (A.erase j) := hclosed.erase_leaf hleaf with hhc'
@@ -102,25 +106,48 @@ theorem rootedParentActiveSum_leaf_peel_le (G : SimpleGraph ι) [DecidableRel G.
     · exact Finset.prod_nonneg fun w _ => by positivity
     · exact le_refl 0
   -- Assemble the inequality from the decomposition.
-  rw [rootedParentActiveSum_leaf_peel G hclosed hleaf k t]
+  rw [rootedGasParentActiveSum_leaf_peel G 𝓟 hclosed hleaf k t]
   calc
-    (∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
-        summand η k * leafColumnSum G (η w₀) (k (Fin.succ j)) t)
-        ≤ ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
-            summand η k' * C := by
+    (∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+        summand η k * leafGasColumnSum 𝓟 (η w₀) (k (Fin.succ j)) t)
+        ≤ ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+            c * summand η k' * C := by
           refine Finset.sum_le_sum fun η hη => ?_
-          have hηmem : η w₀ ∈ allPolymers G := Fintype.mem_piFinset.mp hη w₀
+          have hηmem : η w₀ ∈ 𝓟 := Fintype.mem_piFinset.mp hη w₀
           calc
-            summand η k * leafColumnSum G (η w₀) (k (Fin.succ j)) t
-                ≤ summand η k * ((η w₀).card : ℝ) * C := by
-                  rw [mul_assoc]
-                  refine mul_le_mul_of_nonneg_left ?_ (hsummand_nonneg η)
-                  exact leafColumnSum_le G hηmem (k (Fin.succ j)) hkp
-            _ = summand η k' * C := by rw [hbump η]
-    _ = C * ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
-          summand η k' := by rw [← Finset.sum_mul, mul_comm]
-    _ = C * rootedParentActiveSum G par (A.erase j) hclosed'
+            summand η k * leafGasColumnSum 𝓟 (η w₀) (k (Fin.succ j)) t
+                ≤ summand η k * (c * ((η w₀).card : ℝ) * C) :=
+                  mul_le_mul_of_nonneg_left
+                    (leafGasColumnSum_le G hgas (η w₀) (k (Fin.succ j)) (hsupp (η w₀) hηmem) hkp)
+                    (hsummand_nonneg η)
+            _ = c * summand η k' * C := by rw [← hbump η]; ring
+    _ = c * C * ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+          summand η k' := by
+        rw [Finset.mul_sum]
+        exact Finset.sum_congr rfl fun η _ => by ring
+    _ = c * C * rootedGasParentActiveSum G 𝓟 par (A.erase j) hclosed'
           (Function.update k (par j) (k (par j) + 1)) t := by
-        rw [rootedParentActiveSum]
+        rw [rootedGasParentActiveSum]
+
+/-- **The leaf-peel inequality.**  For a leaf `j` of an active-closed set `A` and
+`Δ²·e·|t| < 1` (`Δ = G.maxDegree`), the active sum over `A` is bounded by the leaf
+Kotecky--Preiss factor times the active sum over `A.erase j` with the moment exponent at
+the leaf's parent vertex bumped by one.  Even-gas (`c = 1`) instance of
+`rootedGasParentActiveSum_leaf_peel_le`, discharging the support bound via
+`polymerSupport_card_le_card_of_mem_allPolymers`. -/
+theorem rootedParentActiveSum_leaf_peel_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+    (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
+    (k : Fin (n + 1) → ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    rootedParentActiveSum G par A hclosed k t
+      ≤ ((k (Fin.succ j)).factorial : ℝ)
+          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (k (Fin.succ j) + 1)
+        * rootedParentActiveSum G par (A.erase j) (hclosed.erase_leaf hleaf)
+            (Function.update k (par j) (k (par j) + 1)) t := by
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP; rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  simpa using rootedGasParentActiveSum_leaf_peel_le G (evenPolymerGasData G) hclosed hleaf k
+    hsupp hkp
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelInduction.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelInduction.lean
@@ -76,27 +76,40 @@ section
 
 variable [DecidableEq ι]
 
-/-- **The child-count peel bound.**  The product of leaf Kotecky--Preiss factors over
-the active vertices, each at the child-count-shifted exponent `k (succ j) + child count`,
-times the root moment sum at exponent `k 0 + child count at the root`. -/
+omit [DecidableEq ι] in
+/-- **The child-count peel bound (gas form).**  The product of `c`-scaled leaf
+Kotecky--Preiss factors over the active vertices, each at the child-count-shifted exponent
+`k (succ j) + child count`, times the root moment sum over the gas `𝓟` at exponent
+`k 0 + child count at the root`.  The `c` factor per active vertex is the support-bump
+constant of the gas; the even gas (`allPolymers G`) takes `c = 1` in
+`rootedParentActivePeelBound`. -/
+noncomputable def rootedGasParentActivePeelBound (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (𝓟 : Finset (Finset (Sym2 ι))) (c : ℝ) (par : Fin n → Fin (n + 1))
+    (A : Finset (Fin n)) (k : Fin (n + 1) → ℕ) (t : ℝ) : ℝ :=
+  (∏ j ∈ A, c * rootedParentPeelFactor G t
+      (k (Fin.succ j) + rootedParentChildCount par A (Fin.succ j)))
+    * ∑ P ∈ 𝓟,
+        (P.card : ℝ) ^ (k 0 + rootedParentChildCount par A 0) * (Real.exp 1 * |t|) ^ P.card
+
+/-- **The child-count peel bound.**  Even-gas (`allPolymers G`, `c = 1`) instance of
+`rootedGasParentActivePeelBound`. -/
 noncomputable def rootedParentActivePeelBound (G : SimpleGraph ι) [DecidableRel G.Adj]
     [Fintype G.edgeSet] (par : Fin n → Fin (n + 1)) (A : Finset (Fin n))
     (k : Fin (n + 1) → ℕ) (t : ℝ) : ℝ :=
-  (∏ j ∈ A, rootedParentPeelFactor G t
-      (k (Fin.succ j) + rootedParentChildCount par A (Fin.succ j)))
-    * ∑ P ∈ allPolymers G,
-        (P.card : ℝ) ^ (k 0 + rootedParentChildCount par A 0) * (Real.exp 1 * |t|) ^ P.card
+  rootedGasParentActivePeelBound G (allPolymers G) 1 par A k t
 
-/-- **The peel-bound recursion identity.**  Extracting the leaf factor at `j` and
-bumping the exponent at `par j` (compensating the child-count drop from erasing `j`)
-recovers the peel bound for `A` from the peel bound for `A.erase j`. -/
-theorem rootedParentActivePeelBound_erase_update (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+omit [DecidableEq ι] in
+/-- **The peel-bound recursion identity (gas form).**  Extracting the `c`-scaled leaf
+factor at `j` and bumping the exponent at `par j` (compensating the child-count drop from
+erasing `j`) recovers the gas peel bound for `A` from the gas peel bound for `A.erase j`. -/
+theorem rootedGasParentActivePeelBound_erase_update (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (𝓟 : Finset (Finset (Sym2 ι))) (c : ℝ) {par : Fin n → Fin (n + 1)}
+    {A : Finset (Fin n)} {j : Fin n}
     (hleaf : RootedParentLeaf par A j) (k : Fin (n + 1) → ℕ) (t : ℝ) :
-    rootedParentPeelFactor G t (k (Fin.succ j))
-        * rootedParentActivePeelBound G par (A.erase j)
+    c * rootedParentPeelFactor G t (k (Fin.succ j))
+        * rootedGasParentActivePeelBound G 𝓟 c par (A.erase j)
             (Function.update k (par j) (k (par j) + 1)) t
-      = rootedParentActivePeelBound G par A k t := by
+      = rootedGasParentActivePeelBound G 𝓟 c par A k t := by
   have hexp : ∀ v, Function.update k (par j) (k (par j) + 1) v
       + rootedParentChildCount par (A.erase j) v = k v + rootedParentChildCount par A v := by
     intro v
@@ -104,17 +117,77 @@ theorem rootedParentActivePeelBound_erase_update (G : SimpleGraph ι) [Decidable
     by_cases h : v = par j
     · subst h; rw [Function.update_self, if_pos rfl]; omega
     · rw [Function.update_of_ne h, if_neg (fun e => h e.symm)]; omega
-  rw [rootedParentActivePeelBound, rootedParentActivePeelBound,
+  rw [rootedGasParentActivePeelBound, rootedGasParentActivePeelBound,
     Finset.prod_congr rfl (fun j' _ => by rw [hexp (Fin.succ j')]),
     Finset.sum_congr rfl (fun P _ => by rw [hexp 0])]
   rw [← mul_assoc, ← Finset.mul_prod_erase A _ hleaf.1]
   congr 2
   rw [rootedParentChildCount_leaf_succ hleaf, add_zero]
 
-/-- **The leaf-peel induction bound.**  For a parent function in which every nonempty
-active set has a leaf (e.g. a rank-decreasing parent), and `Δ²·e·|t| < 1`, the active
-sum is bounded by the child-count peel bound, obtained by iterating the leaf-peel
-inequality down to the empty active set. -/
+/-- **The peel-bound recursion identity.**  Even-gas (`c = 1`) instance of
+`rootedGasParentActivePeelBound_erase_update`. -/
+theorem rootedParentActivePeelBound_erase_update (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+    (hleaf : RootedParentLeaf par A j) (k : Fin (n + 1) → ℕ) (t : ℝ) :
+    rootedParentPeelFactor G t (k (Fin.succ j))
+        * rootedParentActivePeelBound G par (A.erase j)
+            (Function.update k (par j) (k (par j) + 1)) t
+      = rootedParentActivePeelBound G par A k t := by
+  rw [rootedParentActivePeelBound, rootedParentActivePeelBound,
+    ← rootedGasParentActivePeelBound_erase_update G (allPolymers G) 1 hleaf k t, one_mul]
+
+/-- **The leaf-peel induction bound (gas form).**  For a parent function in which every
+nonempty active set has a leaf (e.g. a rank-decreasing parent), `Δ²·e·|t| < 1`, a
+support-cardinality bound `|supp P| ≤ c·|P|` for all `P ∈ 𝓟`, and `0 ≤ c`, the active gas
+sum is bounded by the child-count gas peel bound, obtained by iterating the leaf-peel
+inequality down to the empty active set.  The even gas (`allPolymers G`) takes `c = 1` in
+`rootedParentActiveSum_le_childCount_bound`. -/
+theorem rootedGasParentActiveSum_le_childCount_bound (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟)
+    {par : Fin n → Fin (n + 1)}
+    (hleafExists : ∀ {B : Finset (Fin n)}, B.Nonempty → ∃ j, RootedParentLeaf par B j)
+    (A : Finset (Fin n)) (hclosed : RootedParentActiveClosed par A) (k : Fin (n + 1) → ℕ)
+    {c : ℝ} (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (hc : 0 ≤ c)
+    {t : ℝ} (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    rootedGasParentActiveSum G 𝓟 par A hclosed k t
+      ≤ rootedGasParentActivePeelBound G 𝓟 c par A k t := by
+  suffices H : ∀ m (A : Finset (Fin n)), A.card = m → ∀ (hclosed : RootedParentActiveClosed par A)
+      (k : Fin (n + 1) → ℕ), rootedGasParentActiveSum G 𝓟 par A hclosed k t
+        ≤ rootedGasParentActivePeelBound G 𝓟 c par A k t by
+    exact H A.card A rfl hclosed k
+  intro m
+  induction m using Nat.strong_induction_on with
+  | _ m IH =>
+    intro A hAcard hclosed k
+    rcases A.eq_empty_or_nonempty with rfl | hne
+    · rw [rootedGasParentActiveSum_empty]
+      refine le_of_eq ?_
+      have hcc : rootedParentChildCount par (∅ : Finset (Fin n)) 0 = 0 := by
+        simp [rootedParentChildCount]
+      rw [rootedGasParentActivePeelBound]
+      simp only [hcc, Finset.prod_empty, one_mul, Nat.add_zero]
+    · obtain ⟨j, hleaf⟩ := hleafExists hne
+      have hlt : (A.erase j).card < m := by
+        rw [← hAcard]; exact Finset.card_erase_lt_of_mem hleaf.1
+      calc
+        rootedGasParentActiveSum G 𝓟 par A hclosed k t
+            ≤ c * rootedParentPeelFactor G t (k (Fin.succ j))
+                * rootedGasParentActiveSum G 𝓟 par (A.erase j) (hclosed.erase_leaf hleaf)
+                    (Function.update k (par j) (k (par j) + 1)) t := by
+              rw [rootedParentPeelFactor]
+              exact rootedGasParentActiveSum_leaf_peel_le G hgas hclosed hleaf k hsupp hkp
+        _ ≤ c * rootedParentPeelFactor G t (k (Fin.succ j))
+              * rootedGasParentActivePeelBound G 𝓟 c par (A.erase j)
+                  (Function.update k (par j) (k (par j) + 1)) t := by
+              refine mul_le_mul_of_nonneg_left ?_
+                (mul_nonneg hc (rootedParentPeelFactor_nonneg G hkp _))
+              exact IH _ hlt (A.erase j) rfl (hclosed.erase_leaf hleaf) _
+        _ = rootedGasParentActivePeelBound G 𝓟 c par A k t :=
+              rootedGasParentActivePeelBound_erase_update G 𝓟 c hleaf k t
+
+/-- **The leaf-peel induction bound.**  Even-gas (`c = 1`) instance of
+`rootedGasParentActiveSum_le_childCount_bound`, discharging the support bound via
+`polymerSupport_card_le_card_of_mem_allPolymers`. -/
 theorem rootedParentActiveSum_le_childCount_bound (G : SimpleGraph ι) [DecidableRel G.Adj]
     [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)}
     (hleafExists : ∀ {B : Finset (Fin n)}, B.Nonempty → ∃ j, RootedParentLeaf par B j)
@@ -122,38 +195,10 @@ theorem rootedParentActiveSum_le_childCount_bound (G : SimpleGraph ι) [Decidabl
     {t : ℝ} (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
     rootedParentActiveSum G par A hclosed k t
       ≤ rootedParentActivePeelBound G par A k t := by
-  suffices H : ∀ m (A : Finset (Fin n)), A.card = m → ∀ (hclosed : RootedParentActiveClosed par A)
-      (k : Fin (n + 1) → ℕ), rootedParentActiveSum G par A hclosed k t
-        ≤ rootedParentActivePeelBound G par A k t by
-    exact H A.card A rfl hclosed k
-  intro m
-  induction m using Nat.strong_induction_on with
-  | _ m IH =>
-    intro A hAcard hclosed k
-    rcases A.eq_empty_or_nonempty with rfl | hne
-    · rw [rootedParentActiveSum_empty]
-      refine le_of_eq ?_
-      have hcc : rootedParentChildCount par (∅ : Finset (Fin n)) 0 = 0 := by
-        simp [rootedParentChildCount]
-      rw [rootedParentActivePeelBound]
-      simp only [hcc, Finset.prod_empty, one_mul, Nat.add_zero]
-    · obtain ⟨j, hleaf⟩ := hleafExists hne
-      have hlt : (A.erase j).card < m := by
-        rw [← hAcard]; exact Finset.card_erase_lt_of_mem hleaf.1
-      calc
-        rootedParentActiveSum G par A hclosed k t
-            ≤ rootedParentPeelFactor G t (k (Fin.succ j))
-                * rootedParentActiveSum G par (A.erase j) (hclosed.erase_leaf hleaf)
-                    (Function.update k (par j) (k (par j) + 1)) t := by
-              rw [rootedParentPeelFactor]
-              exact rootedParentActiveSum_leaf_peel_le G hclosed hleaf k hkp
-        _ ≤ rootedParentPeelFactor G t (k (Fin.succ j))
-              * rootedParentActivePeelBound G par (A.erase j)
-                  (Function.update k (par j) (k (par j) + 1)) t := by
-              refine mul_le_mul_of_nonneg_left ?_ (rootedParentPeelFactor_nonneg G hkp _)
-              exact IH _ hlt (A.erase j) rfl (hclosed.erase_leaf hleaf) _
-        _ = rootedParentActivePeelBound G par A k t :=
-              rootedParentActivePeelBound_erase_update G hleaf k t
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP; rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  exact rootedGasParentActiveSum_le_childCount_bound G (evenPolymerGasData G) hleafExists A hclosed
+    k hsupp zero_le_one hkp
 
 end
 

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelStep.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelStep.lean
@@ -28,12 +28,32 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ℕ}
 
-/-- **The leaf-peel decomposition of the active sum.**  For a leaf `j` of an
-active-closed set `A`, the active sum over `A` decomposes as a sum over the remainder
-labellings `η` of the active vertices of `A.erase j`, each weighted by the leaf column
+/-- **The leaf-peel decomposition of the active gas sum.**  For a leaf `j` of an
+active-closed set `A`, the active gas sum over `A` decomposes as a sum over the remainder
+labellings `η` of the active vertices of `A.erase j`, each weighted by the leaf column gas
 sum at the remainder value `η ⟨par j, _⟩` assigned to the leaf's parent vertex.  The
-remainder summand is exactly the `rootedParentActiveSum` summand for `A.erase j` at
-`η`. -/
+remainder summand is exactly the `rootedGasParentActiveSum` summand for `A.erase j` at
+`η`.  The even gas (`allPolymers G`) is recovered by `rootedParentActiveSum_leaf_peel`. -/
+theorem rootedGasParentActiveSum_leaf_peel (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+    (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
+    (k : Fin (n + 1) → ℕ) (t : ℝ) :
+    rootedGasParentActiveSum G 𝓟 par A hclosed k t
+      = ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+          (if ∀ i, ∀ hi : i ∈ A.erase j,
+              PolymersIncompatible (η (rootedParentActiveChild hi))
+                (η (rootedParentActiveParent (hclosed.erase_leaf hleaf) hi)) then
+            ∏ w : RootedParentActive (A.erase j),
+              ((η w).card : ℝ) ^ k w.1 * (Real.exp 1 * |t|) ^ (η w).card
+          else 0)
+          * leafGasColumnSum 𝓟 (η ⟨par j, hleaf.parent_mem_erase hclosed⟩) (k (Fin.succ j)) t := by
+  rw [rootedGasParentActiveSum,
+    sum_piFinset_const_optionEquiv (rootedParentActiveSplitEquiv hleaf.1) 𝓟,
+    Finset.sum_comm]
+  exact Finset.sum_congr rfl fun η _ => rootedGasParentActiveSum_leaf_inner 𝓟 hclosed hleaf k t η
+
+/-- **The leaf-peel decomposition of the active sum.**  Even-gas (`allPolymers G`) instance
+of `rootedGasParentActiveSum_leaf_peel`. -/
 theorem rootedParentActiveSum_leaf_peel (G : SimpleGraph ι) [DecidableRel G.Adj]
     [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
     (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
@@ -46,10 +66,7 @@ theorem rootedParentActiveSum_leaf_peel (G : SimpleGraph ι) [DecidableRel G.Adj
             ∏ w : RootedParentActive (A.erase j),
               ((η w).card : ℝ) ^ k w.1 * (Real.exp 1 * |t|) ^ (η w).card
           else 0)
-          * leafColumnSum G (η ⟨par j, hleaf.parent_mem_erase hclosed⟩) (k (Fin.succ j)) t := by
-  rw [rootedParentActiveSum,
-    sum_piFinset_const_optionEquiv (rootedParentActiveSplitEquiv hleaf.1) (allPolymers G),
-    Finset.sum_comm]
-  exact Finset.sum_congr rfl fun η _ => rootedParentActiveSum_leaf_inner G hclosed hleaf k t η
+          * leafColumnSum G (η ⟨par j, hleaf.parent_mem_erase hclosed⟩) (k (Fin.succ j)) t :=
+  rootedGasParentActiveSum_leaf_peel G (allPolymers G) hclosed hleaf k t
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelTailBound.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelTailBound.lean
@@ -32,22 +32,26 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ℕ}
 
-/-- **The sharpened (tail) leaf-peel inequality.**  For a leaf `j` of an active-closed
-set `A` and `Δ²e|t| < 1`, the active sum over `A` is bounded by `Δ²e|t|` times the leaf
-Kotecky--Preiss factor times the active sum over `A.erase j` with the moment exponent at
-the leaf's parent vertex bumped by one.  Identical to `rootedParentActiveSum_leaf_peel_le`
-but using the tail leaf-column bound `leafColumnSum_tail_le`, which contributes the extra
-`Δ²e|t|` factor. -/
-theorem rootedParentActiveSum_leaf_peel_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+/-- **The sharpened (tail) leaf-peel inequality (gas form).**  For a leaf `j` of an
+active-closed set `A`, `Δ²e|t| < 1`, and a support-cardinality bound `|supp P| ≤ c·|P|`
+for all `P ∈ 𝓟`, the active gas sum over `A` is bounded by `c·Δ²e|t|` times the leaf
+Kotecky--Preiss factor times the active gas sum over `A.erase j` with the moment exponent
+at the leaf's parent vertex bumped by one.  Identical to
+`rootedGasParentActiveSum_leaf_peel_le` but using the tail leaf-column bound
+`leafGasColumnSum_tail_le`, which contributes the extra `Δ²e|t|` factor.  The even gas
+(`allPolymers G`) takes `c = 1` in `rootedParentActiveSum_leaf_peel_tail_le`. -/
+theorem rootedGasParentActiveSum_leaf_peel_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟)
+    {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
     (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
-    (k : Fin (n + 1) → ℕ) {t : ℝ}
+    (k : Fin (n + 1) → ℕ) {c : ℝ}
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
-    rootedParentActiveSum G par A hclosed k t
-      ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+    rootedGasParentActiveSum G 𝓟 par A hclosed k t
+      ≤ c * (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
           * (((k (Fin.succ j)).factorial : ℝ)
-              / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (k (Fin.succ j) + 1))
-        * rootedParentActiveSum G par (A.erase j) (hclosed.erase_leaf hleaf)
+              / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (k (Fin.succ j) + 1)))
+        * rootedGasParentActiveSum G 𝓟 par (A.erase j) (hclosed.erase_leaf hleaf)
             (Function.update k (par j) (k (par j) + 1)) t := by
   classical
   set hclosed' : RootedParentActiveClosed par (A.erase j) := hclosed.erase_leaf hleaf with hhc'
@@ -105,25 +109,49 @@ theorem rootedParentActiveSum_leaf_peel_tail_le (G : SimpleGraph ι) [DecidableR
     · exact Finset.prod_nonneg fun w _ => by positivity
     · exact le_refl 0
   -- Assemble the inequality from the decomposition, using the tail leaf-column bound.
-  rw [rootedParentActiveSum_leaf_peel G hclosed hleaf k t]
+  rw [rootedGasParentActiveSum_leaf_peel G 𝓟 hclosed hleaf k t]
   calc
-    (∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
-        summand η k * leafColumnSum G (η w₀) (k (Fin.succ j)) t)
-        ≤ ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
-            summand η k' * Ct := by
+    (∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+        summand η k * leafGasColumnSum 𝓟 (η w₀) (k (Fin.succ j)) t)
+        ≤ ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+            c * summand η k' * Ct := by
           refine Finset.sum_le_sum fun η hη => ?_
-          have hηmem : η w₀ ∈ allPolymers G := Fintype.mem_piFinset.mp hη w₀
+          have hηmem : η w₀ ∈ 𝓟 := Fintype.mem_piFinset.mp hη w₀
           calc
-            summand η k * leafColumnSum G (η w₀) (k (Fin.succ j)) t
-                ≤ summand η k * (((η w₀).card : ℝ) * Ct) := by
-                  refine mul_le_mul_of_nonneg_left ?_ (hsummand_nonneg η)
-                  exact leafColumnSum_tail_le G hηmem (k (Fin.succ j)) hkp
-            _ = summand η k * ((η w₀).card : ℝ) * Ct := by ring
-            _ = summand η k' * Ct := by rw [hbump η]
-    _ = Ct * ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
-          summand η k' := by rw [← Finset.sum_mul, mul_comm]
-    _ = Ct * rootedParentActiveSum G par (A.erase j) hclosed'
+            summand η k * leafGasColumnSum 𝓟 (η w₀) (k (Fin.succ j)) t
+                ≤ summand η k * (c * ((η w₀).card : ℝ) * Ct) :=
+                  mul_le_mul_of_nonneg_left
+                    (leafGasColumnSum_tail_le G hgas (η w₀) (k (Fin.succ j)) (hsupp (η w₀) hηmem)
+                      hkp)
+                    (hsummand_nonneg η)
+            _ = c * summand η k' * Ct := by rw [← hbump η]; ring
+    _ = c * Ct * ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+          summand η k' := by
+        rw [Finset.mul_sum]
+        exact Finset.sum_congr rfl fun η _ => by ring
+    _ = c * Ct * rootedGasParentActiveSum G 𝓟 par (A.erase j) hclosed'
           (Function.update k (par j) (k (par j) + 1)) t := by
-        rw [rootedParentActiveSum]
+        rw [rootedGasParentActiveSum]
+
+/-- **The sharpened (tail) leaf-peel inequality.**  For a leaf `j` of an active-closed
+set `A` and `Δ²e|t| < 1`, the active sum over `A` is bounded by `Δ²e|t|` times the leaf
+Kotecky--Preiss factor times the active sum over `A.erase j` with the moment exponent at
+the leaf's parent vertex bumped by one.  Even-gas (`c = 1`) instance of
+`rootedGasParentActiveSum_leaf_peel_tail_le`. -/
+theorem rootedParentActiveSum_leaf_peel_tail_le (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+    (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
+    (k : Fin (n + 1) → ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    rootedParentActiveSum G par A hclosed k t
+      ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+          * (((k (Fin.succ j)).factorial : ℝ)
+              / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (k (Fin.succ j) + 1))
+        * rootedParentActiveSum G par (A.erase j) (hclosed.erase_leaf hleaf)
+            (Function.update k (par j) (k (par j) + 1)) t := by
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP; rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  simpa using rootedGasParentActiveSum_leaf_peel_tail_le G (evenPolymerGasData G) hclosed hleaf k
+    hsupp hkp
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelTailInduction.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelTailInduction.lean
@@ -27,12 +27,70 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ℕ}
 
-/-- **The sharpened (tail) leaf-peel induction bound.**  For a parent function in which
-every nonempty active set has a leaf and `Δ²e|t| < 1`, the active sum is bounded by
-`(Δ²e|t|)^{|A|}` times the child-count peel bound, obtained by iterating the tail
+/-- **The sharpened (tail) leaf-peel induction bound (gas form).**  For a parent function
+in which every nonempty active set has a leaf, `Δ²e|t| < 1`, a support-cardinality bound
+`|supp P| ≤ c·|P|` for all `P ∈ 𝓟`, and `0 ≤ c`, the active gas sum is bounded by
+`(Δ²e|t|)^{|A|}` times the child-count gas peel bound, obtained by iterating the tail
 leaf-peel inequality down to the empty active set.  The extra `(Δ²e|t|)^{|A|}` factor
 (one `Δ²e|t|` per peeled non-root vertex) is the source of the geometric `(4r)^n` decay in
-the cluster-expansion convergence. -/
+the cluster-expansion convergence.  The even gas (`allPolymers G`) takes `c = 1` in
+`rootedParentActiveSum_le_pow_mul_childCount_bound`. -/
+theorem rootedGasParentActiveSum_le_pow_mul_childCount_bound (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) {par : Fin n → Fin (n + 1)}
+    (hleafExists : ∀ {B : Finset (Fin n)}, B.Nonempty → ∃ j, RootedParentLeaf par B j)
+    (A : Finset (Fin n)) (hclosed : RootedParentActiveClosed par A) (k : Fin (n + 1) → ℕ)
+    {c : ℝ} (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (hc : 0 ≤ c)
+    {t : ℝ} (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    rootedGasParentActiveSum G 𝓟 par A hclosed k t
+      ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ A.card
+          * rootedGasParentActivePeelBound G 𝓟 c par A k t := by
+  set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
+  have hrr0 : (0 : ℝ) ≤ rr := by rw [hrr]; positivity
+  suffices H : ∀ m (A : Finset (Fin n)), A.card = m → ∀ (hclosed : RootedParentActiveClosed par A)
+      (k : Fin (n + 1) → ℕ), rootedGasParentActiveSum G 𝓟 par A hclosed k t
+        ≤ rr ^ A.card * rootedGasParentActivePeelBound G 𝓟 c par A k t by
+    exact H A.card A rfl hclosed k
+  intro m
+  induction m using Nat.strong_induction_on with
+  | _ m IH =>
+    intro A hAcard hclosed k
+    rcases A.eq_empty_or_nonempty with rfl | hne
+    · rw [Finset.card_empty, pow_zero, one_mul, rootedGasParentActiveSum_empty]
+      refine le_of_eq ?_
+      have hcc : rootedParentChildCount par (∅ : Finset (Fin n)) 0 = 0 := by
+        simp [rootedParentChildCount]
+      rw [rootedGasParentActivePeelBound]
+      simp only [hcc, Finset.prod_empty, one_mul, Nat.add_zero]
+    · obtain ⟨j, hleaf⟩ := hleafExists hne
+      have hlt : (A.erase j).card < m := by
+        rw [← hAcard]; exact Finset.card_erase_lt_of_mem hleaf.1
+      have hcard : A.card = (A.erase j).card + 1 := by
+        rw [Finset.card_erase_of_mem hleaf.1, Nat.sub_add_cancel (Finset.card_pos.mpr hne)]
+      calc
+        rootedGasParentActiveSum G 𝓟 par A hclosed k t
+            ≤ c * (rr * rootedParentPeelFactor G t (k (Fin.succ j)))
+                * rootedGasParentActiveSum G 𝓟 par (A.erase j) (hclosed.erase_leaf hleaf)
+                    (Function.update k (par j) (k (par j) + 1)) t := by
+              rw [hrr, rootedParentPeelFactor]
+              exact rootedGasParentActiveSum_leaf_peel_tail_le G hgas hclosed hleaf k hsupp hkp
+        _ ≤ c * (rr * rootedParentPeelFactor G t (k (Fin.succ j)))
+              * (rr ^ (A.erase j).card * rootedGasParentActivePeelBound G 𝓟 c par (A.erase j)
+                  (Function.update k (par j) (k (par j) + 1)) t) := by
+              refine mul_le_mul_of_nonneg_left ?_
+                (mul_nonneg hc (mul_nonneg hrr0 (rootedParentPeelFactor_nonneg G hkp _)))
+              exact IH _ hlt (A.erase j) rfl (hclosed.erase_leaf hleaf) _
+        _ = rr ^ A.card
+              * (c * rootedParentPeelFactor G t (k (Fin.succ j))
+                  * rootedGasParentActivePeelBound G 𝓟 c par (A.erase j)
+                    (Function.update k (par j) (k (par j) + 1)) t) := by
+              rw [hcard, pow_succ]; ring
+        _ = rr ^ A.card * rootedGasParentActivePeelBound G 𝓟 c par A k t := by
+              rw [rootedGasParentActivePeelBound_erase_update G 𝓟 c hleaf k t]
+
+/-- **The sharpened (tail) leaf-peel induction bound.**  Even-gas (`c = 1`) instance of
+`rootedGasParentActiveSum_le_pow_mul_childCount_bound`, discharging the support bound via
+`polymerSupport_card_le_card_of_mem_allPolymers`. -/
 theorem rootedParentActiveSum_le_pow_mul_childCount_bound (G : SimpleGraph ι)
     [DecidableRel G.Adj] [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)}
     (hleafExists : ∀ {B : Finset (Fin n)}, B.Nonempty → ∃ j, RootedParentLeaf par B j)
@@ -41,47 +99,9 @@ theorem rootedParentActiveSum_le_pow_mul_childCount_bound (G : SimpleGraph ι)
     rootedParentActiveSum G par A hclosed k t
       ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ A.card
           * rootedParentActivePeelBound G par A k t := by
-  set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
-  have hrr0 : (0 : ℝ) ≤ rr := by rw [hrr]; positivity
-  suffices H : ∀ m (A : Finset (Fin n)), A.card = m → ∀ (hclosed : RootedParentActiveClosed par A)
-      (k : Fin (n + 1) → ℕ), rootedParentActiveSum G par A hclosed k t
-        ≤ rr ^ A.card * rootedParentActivePeelBound G par A k t by
-    exact H A.card A rfl hclosed k
-  intro m
-  induction m using Nat.strong_induction_on with
-  | _ m IH =>
-    intro A hAcard hclosed k
-    rcases A.eq_empty_or_nonempty with rfl | hne
-    · rw [Finset.card_empty, pow_zero, one_mul, rootedParentActiveSum_empty]
-      refine le_of_eq ?_
-      have hcc : rootedParentChildCount par (∅ : Finset (Fin n)) 0 = 0 := by
-        simp [rootedParentChildCount]
-      rw [rootedParentActivePeelBound]
-      simp only [hcc, Finset.prod_empty, one_mul, Nat.add_zero]
-    · obtain ⟨j, hleaf⟩ := hleafExists hne
-      have hlt : (A.erase j).card < m := by
-        rw [← hAcard]; exact Finset.card_erase_lt_of_mem hleaf.1
-      have hcard : A.card = (A.erase j).card + 1 := by
-        rw [Finset.card_erase_of_mem hleaf.1, Nat.sub_add_cancel (Finset.card_pos.mpr hne)]
-      calc
-        rootedParentActiveSum G par A hclosed k t
-            ≤ rr * rootedParentPeelFactor G t (k (Fin.succ j))
-                * rootedParentActiveSum G par (A.erase j) (hclosed.erase_leaf hleaf)
-                    (Function.update k (par j) (k (par j) + 1)) t := by
-              rw [hrr, rootedParentPeelFactor]
-              exact rootedParentActiveSum_leaf_peel_tail_le G hclosed hleaf k hkp
-        _ ≤ rr * rootedParentPeelFactor G t (k (Fin.succ j))
-              * (rr ^ (A.erase j).card * rootedParentActivePeelBound G par (A.erase j)
-                  (Function.update k (par j) (k (par j) + 1)) t) := by
-              refine mul_le_mul_of_nonneg_left ?_
-                (mul_nonneg hrr0 (rootedParentPeelFactor_nonneg G hkp _))
-              exact IH _ hlt (A.erase j) rfl (hclosed.erase_leaf hleaf) _
-        _ = rr ^ A.card
-              * (rootedParentPeelFactor G t (k (Fin.succ j))
-                  * rootedParentActivePeelBound G par (A.erase j)
-                    (Function.update k (par j) (k (par j) + 1)) t) := by
-              rw [hcard, pow_succ]; ring
-        _ = rr ^ A.card * rootedParentActivePeelBound G par A k t := by
-              rw [rootedParentActivePeelBound_erase_update G hleaf k t]
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP; rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  exact rootedGasParentActiveSum_le_pow_mul_childCount_bound G (evenPolymerGasData G) hleafExists A
+    hclosed k hsupp zero_le_one hkp
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActivePeelBoundFactorial.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActivePeelBoundFactorial.lean
@@ -31,20 +31,24 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ℕ}
 
-/-- **The peel bound in factorial-product form.**  For the full active set, exponent `0`,
-and `0 < 1 − Δ²e|t|`, the child-count peel bound is at most
-`(|V|·∏_v (childCount v)!)/(1 − Δ²e|t|)^{2n+1}`.  The root moment factor is bounded by
-`sum_allPolymers_cardPow_expWeighted_le` (#4127), and the per-vertex `(1 − Δ²e|t|)` powers
-`childCount v + 1` sum to `2n + 1` because the child counts sum to `n` (one parent-edge
-per non-root vertex). -/
-theorem rootedParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div
-    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (par : Fin n → Fin (n + 1))
+omit [DecidableEq ι] in
+/-- **The gas peel bound in factorial-product form.**  For the full active set, exponent
+`0`, `0 < 1 − Δ²e|t|`, and `0 ≤ c`, the child-count gas peel bound is at most
+`c^n·(|V|·∏_v (childCount v)!)/(1 − Δ²e|t|)^{2n+1}`.  The root moment factor is bounded by
+`sum_gasPolymers_cardPow_expWeighted_le`, the `c` factors collect into `c^n` (one per
+non-root vertex), and the per-vertex `(1 − Δ²e|t|)` powers `childCount v + 1` sum to
+`2n + 1` because the child counts sum to `n`.  The even gas (`allPolymers G`) takes `c = 1`
+in `rootedParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div`. -/
+theorem rootedGasParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) (c : ℝ) (hc : 0 ≤ c)
+    (par : Fin n → Fin (n + 1))
     {t : ℝ} (hpos : 0 < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) :
-    rootedParentActivePeelBound G par (Finset.univ : Finset (Fin n)) (fun _ => 0) t
-      ≤ ((Fintype.card ι : ℝ)
+    rootedGasParentActivePeelBound G 𝓟 c par (Finset.univ : Finset (Fin n)) (fun _ => 0) t
+      ≤ c ^ n * (((Fintype.card ι : ℝ)
           * ∏ v : Fin (n + 1),
               ((rootedParentChildCount par (Finset.univ : Finset (Fin n)) v).factorial : ℝ))
-          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1) := by
+          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1)) := by
   classical
   set q : ℝ := 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hq
   set d : Fin (n + 1) → ℕ :=
@@ -64,10 +68,10 @@ theorem rootedParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factor
     simp only [rootedParentPeelFactor, ← hq]
     rw [Finset.prod_div_distrib, Finset.prod_pow_eq_pow_sum]
   -- The root moment factor.
-  have hroot : (∑ P ∈ allPolymers G, (P.card : ℝ) ^ d 0 * (Real.exp 1 * |t|) ^ P.card)
+  have hroot : (∑ P ∈ 𝓟, (P.card : ℝ) ^ d 0 * (Real.exp 1 * |t|) ^ P.card)
       ≤ (Fintype.card ι : ℝ) * ((d 0).factorial : ℝ) / q ^ (d 0 + 1) := by
     rw [mul_div_assoc]
-    exact sum_allPolymers_cardPow_expWeighted_le G (d 0) hkp
+    exact sum_gasPolymers_cardPow_expWeighted_le G hgas (d 0) hkp
   -- Exponent arithmetic: ∑_j (childCount(succ j)+1) + (childCount 0 + 1) = 2n + 1.
   have hexp : (∑ j : Fin n, (d (Fin.succ j) + 1)) + (d 0 + 1) = 2 * n + 1 := by
     have hsplit : d 0 + ∑ j : Fin n, d (Fin.succ j) = n := by
@@ -79,19 +83,45 @@ theorem rootedParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factor
   have hnum : ((d 0).factorial : ℝ) * (∏ j : Fin n, ((d (Fin.succ j)).factorial : ℝ))
       = ∏ v : Fin (n + 1), ((d v).factorial : ℝ) :=
     (Fin.prod_univ_succ (fun v : Fin (n + 1) => ((d v).factorial : ℝ))).symm
+  -- The even-shaped fraction identity (root moment fraction times the peel-factor product).
+  have heven : (∏ j : Fin n, rootedParentPeelFactor G t (d (Fin.succ j)))
+        * ((Fintype.card ι : ℝ) * ((d 0).factorial : ℝ) / q ^ (d 0 + 1))
+      = ((Fintype.card ι : ℝ) * ∏ v : Fin (n + 1), ((d v).factorial : ℝ)) / q ^ (2 * n + 1) := by
+    rw [hprod, ← hnum, ← hexp, pow_add]
+    field_simp
+    ring
+  -- The `c` factors collect into `c ^ n`.
+  have hprodc : (∏ j : Fin n, c * rootedParentPeelFactor G t (d (Fin.succ j)))
+      = c ^ n * ∏ j : Fin n, rootedParentPeelFactor G t (d (Fin.succ j)) := by
+    rw [Finset.prod_mul_distrib, Finset.prod_const, Finset.card_univ, Fintype.card_fin]
   -- Assemble.
-  rw [rootedParentActivePeelBound]
+  rw [rootedGasParentActivePeelBound]
   simp only [Nat.zero_add, ← hd]
   calc
-    (∏ j : Fin n, rootedParentPeelFactor G t (d (Fin.succ j)))
-        * ∑ P ∈ allPolymers G, (P.card : ℝ) ^ d 0 * (Real.exp 1 * |t|) ^ P.card
-        ≤ (∏ j : Fin n, rootedParentPeelFactor G t (d (Fin.succ j)))
+    (∏ j : Fin n, c * rootedParentPeelFactor G t (d (Fin.succ j)))
+        * ∑ P ∈ 𝓟, (P.card : ℝ) ^ d 0 * (Real.exp 1 * |t|) ^ P.card
+        ≤ (∏ j : Fin n, c * rootedParentPeelFactor G t (d (Fin.succ j)))
             * ((Fintype.card ι : ℝ) * ((d 0).factorial : ℝ) / q ^ (d 0 + 1)) := by
           refine mul_le_mul_of_nonneg_left hroot ?_
-          exact Finset.prod_nonneg fun j _ => rootedParentPeelFactor_nonneg G hkp _
-    _ = ((Fintype.card ι : ℝ) * ∏ v : Fin (n + 1), ((d v).factorial : ℝ)) / q ^ (2 * n + 1) := by
-          rw [hprod, ← hnum, ← hexp, pow_add]
-          field_simp
-          ring
+          exact Finset.prod_nonneg fun j _ => mul_nonneg hc (rootedParentPeelFactor_nonneg G hkp _)
+    _ = c ^ n * (((Fintype.card ι : ℝ) * ∏ v : Fin (n + 1), ((d v).factorial : ℝ))
+          / q ^ (2 * n + 1)) := by
+          rw [hprodc, mul_assoc, heven]
+
+/-- **The peel bound in factorial-product form.**  For the full active set, exponent `0`,
+and `0 < 1 − Δ²e|t|`, the child-count peel bound is at most
+`(|V|·∏_v (childCount v)!)/(1 − Δ²e|t|)^{2n+1}`.  Even-gas (`c = 1`) instance of
+`rootedGasParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div`. -/
+theorem rootedParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (par : Fin n → Fin (n + 1))
+    {t : ℝ} (hpos : 0 < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) :
+    rootedParentActivePeelBound G par (Finset.univ : Finset (Fin n)) (fun _ => 0) t
+      ≤ ((Fintype.card ι : ℝ)
+          * ∏ v : Fin (n + 1),
+              ((rootedParentChildCount par (Finset.univ : Finset (Fin n)) v).factorial : ℝ))
+          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1) := by
+  rw [rootedParentActivePeelBound]
+  simpa using rootedGasParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div
+    G (evenPolymerGasData G) 1 zero_le_one par hpos
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveSum.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveSum.lean
@@ -43,20 +43,28 @@ def rootedParentActiveParent {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)}
     RootedParentActive A :=
   ⟨par j, hclosed j hj⟩
 
-/-- **The moment-weighted constrained active sum.**  The sum over labellings of the
-active vertices of `A` by polymers of `G`, of the moment-weighted activity
+/-- **The moment-weighted constrained active gas sum.**  The sum over labellings of the
+active vertices of `A` by polymers of the gas `𝓟`, of the moment-weighted activity
 `∏_v |ω v|^{k v}·(e|t|)^{|ω v|}`, restricted to the labellings with
-`ω (succ j) ∼ ω (par j)` for every active `j ∈ A`. -/
-noncomputable def rootedParentActiveSum (G : SimpleGraph ι) [Fintype G.edgeSet]
-    (par : Fin n → Fin (n + 1)) (A : Finset (Fin n))
+`ω (succ j) ∼ ω (par j)` for every active `j ∈ A`.  The even gas (`allPolymers G`) is
+recovered by `rootedParentActiveSum`. -/
+noncomputable def rootedGasParentActiveSum (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) (par : Fin n → Fin (n + 1)) (A : Finset (Fin n))
     (hclosed : RootedParentActiveClosed par A) (k : Fin (n + 1) → ℕ) (t : ℝ) : ℝ :=
-  ∑ ω ∈ Fintype.piFinset (fun _ : RootedParentActive A => allPolymers G),
+  ∑ ω ∈ Fintype.piFinset (fun _ : RootedParentActive A => 𝓟),
     (if ∀ j : Fin n, ∀ hj : j ∈ A,
         PolymersIncompatible (ω (rootedParentActiveChild hj))
           (ω (rootedParentActiveParent hclosed hj)) then
       ∏ v : RootedParentActive A,
         ((ω v).card : ℝ) ^ k v.1 * (Real.exp 1 * |t|) ^ (ω v).card
     else 0)
+
+/-- **The moment-weighted constrained active sum.**  The even-gas (`allPolymers G`)
+instance of `rootedGasParentActiveSum`. -/
+noncomputable def rootedParentActiveSum (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (par : Fin n → Fin (n + 1)) (A : Finset (Fin n))
+    (hclosed : RootedParentActiveClosed par A) (k : Fin (n + 1) → ℕ) (t : ℝ) : ℝ :=
+  rootedGasParentActiveSum G (allPolymers G) par A hclosed k t
 
 /-- The active vertices of the empty active set are just the root `{0}`. -/
 @[simp]
@@ -83,16 +91,16 @@ instance : Unique (RootedParentActive (∅ : Finset (Fin n))) where
     rw [rootedParentActiveVertices_empty, Finset.mem_singleton] at hv
     exact Subtype.ext hv
 
-/-- **Base case of the active sum.**  On the empty active set there are no
-constraints and only the root vertex `0`, so the active sum reduces to the
-root-only moment-weighted activity `∑_P |P|^{k 0}·(e|t|)^{|P|}`. -/
-theorem rootedParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.edgeSet]
-    (par : Fin n → Fin (n + 1))
+/-- **Base case of the active gas sum.**  On the empty active set there are no
+constraints and only the root vertex `0`, so the active gas sum reduces to the
+root-only moment-weighted activity `∑_{P ∈ 𝓟} |P|^{k 0}·(e|t|)^{|P|}`. -/
+theorem rootedGasParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) (par : Fin n → Fin (n + 1))
     (hclosed : RootedParentActiveClosed par (∅ : Finset (Fin n)))
     (k : Fin (n + 1) → ℕ) (t : ℝ) :
-    rootedParentActiveSum G par ∅ hclosed k t
-      = ∑ P ∈ allPolymers G, (P.card : ℝ) ^ k 0 * (Real.exp 1 * |t|) ^ P.card := by
-  rw [rootedParentActiveSum]
+    rootedGasParentActiveSum G 𝓟 par ∅ hclosed k t
+      = ∑ P ∈ 𝓟, (P.card : ℝ) ^ k 0 * (Real.exp 1 * |t|) ^ P.card := by
+  rw [rootedGasParentActiveSum]
   refine Finset.sum_bij' (fun ω _ => ω default) (fun P _ => fun _ => P)
     (fun ω hω => ?_) (fun P hP => ?_) (fun ω hω => ?_) (fun P hP => ?_) (fun ω hω => ?_)
   · exact (Fintype.mem_piFinset.mp hω) default
@@ -101,5 +109,17 @@ theorem rootedParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.edgeSet]
   · rfl
   · rw [if_pos (by simp), Fintype.prod_unique]
     rfl
+
+/-- **Base case of the active sum.**  On the empty active set there are no
+constraints and only the root vertex `0`, so the active sum reduces to the
+root-only moment-weighted activity `∑_P |P|^{k 0}·(e|t|)^{|P|}`.  Even-gas instance of
+`rootedGasParentActiveSum_empty`. -/
+theorem rootedParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (par : Fin n → Fin (n + 1))
+    (hclosed : RootedParentActiveClosed par (∅ : Finset (Fin n)))
+    (k : Fin (n + 1) → ℕ) (t : ℝ) :
+    rootedParentActiveSum G par ∅ hclosed k t
+      = ∑ P ∈ allPolymers G, (P.card : ℝ) ^ k 0 * (Real.exp 1 * |t|) ^ P.card :=
+  rootedGasParentActiveSum_empty G (allPolymers G) par hclosed k t
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveUnivForm.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveUnivForm.lean
@@ -24,23 +24,24 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ℕ}
 
-/-- **The univ rooted-tree active sum as a `Fin (n + 1)`-labelling sum.**  For the full
-active set and any parent function, the rooted-tree active sum at exponent `0` is the
-sum over polymer sequences `ω : Fin (n + 1) → allPolymers G` of the activity product
+/-- **The univ rooted-tree active gas sum as a `Fin (n + 1)`-labelling sum.**  For the full
+active set and any parent function, the rooted-tree active gas sum at exponent `0` is the
+sum over polymer sequences `ω : Fin (n + 1) → 𝓟` of the activity product
 `∏_v (e|t|)^{|ω v|}`, restricted to the parent-edge incompatibility constraint
 `ω (Fin.succ i) ∼ ω (par i)` for every `i`.  (The labellings are reindexed from the
 active-vertex subtype to `Fin (n + 1)` via `rootedParentActiveUnivEquiv`; the exponent
-`0` makes the moment factors trivial.) -/
-theorem rootedParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fintype G.edgeSet]
-    (par : Fin n → Fin (n + 1)) (t : ℝ) :
-    rootedParentActiveSum G par (Finset.univ : Finset (Fin n))
+`0` makes the moment factors trivial.)  The even gas (`allPolymers G`) is recovered by
+`rootedParentActiveSum_univ_zero_eq`. -/
+theorem rootedGasParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) (par : Fin n → Fin (n + 1)) (t : ℝ) :
+    rootedGasParentActiveSum G 𝓟 par (Finset.univ : Finset (Fin n))
         (rootedParentActiveClosed_univ par) (fun _ => 0) t
-      = ∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+      = ∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟),
           if ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i)) (ω (par i)) then
             ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card
           else 0 := by
-  rw [rootedParentActiveSum,
-    sum_piFinset_const_domEquiv rootedParentActiveUnivEquiv (allPolymers G)]
+  rw [rootedGasParentActiveSum,
+    sum_piFinset_const_domEquiv rootedParentActiveUnivEquiv 𝓟]
   refine Finset.sum_congr rfl fun ω _ => ?_
   refine if_congr ?_ ?_ rfl
   · constructor
@@ -56,5 +57,17 @@ theorem rootedParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fintype G.edgeS
       (fun a => (Real.exp 1 * |t|) ^ (ω a).card)]
     refine Finset.prod_congr rfl fun v _ => ?_
     simp [rootedParentActiveUnivEquiv_apply]
+
+/-- **The univ rooted-tree active sum as a `Fin (n + 1)`-labelling sum.**  Even-gas
+(`allPolymers G`) instance of `rootedGasParentActiveSum_univ_zero_eq`. -/
+theorem rootedParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (par : Fin n → Fin (n + 1)) (t : ℝ) :
+    rootedParentActiveSum G par (Finset.univ : Finset (Fin n))
+        (rootedParentActiveClosed_univ par) (fun _ => 0) t
+      = ∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+          if ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i)) (ω (par i)) then
+            ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card
+          else 0 :=
+  rootedGasParentActiveSum_univ_zero_eq G (allPolymers G) par t
 
 end IsingModel


### PR DESCRIPTION
## Purpose

Foundation R2 of the field-CE minimal route (#4433). Builds on R1 (moment-core now parameterized over `PolymerGasData G 𝓟`). R2 threads the abstract polymer set `𝓟` through the peel-chain lemmas still hardcoded to `allPolymers` — the `RootedParentActive*` leaf-peel induction family (`rootedParentActiveSum`, `rootedParentActivePeelBound`, `leafColumnSum`, and the tree-peel bound / tail-summability consumers) — so the connected gas (F1) can later instantiate them. Per scoping, these proofs are MECHANICAL threading (the peel induction is NOT even-gas-dependent).

## Design & Scoping

Detailed design/scoping reference: `.self-local/reports/scope-kp-parameterization-surface-2026-07-05.md`.

- **β route recovery**: β peel-chain capstones are recovered verbatim by `𝓟 := allPolymers G` (`evenPolymerGasData G`) instantiation wrappers; existing β statements are preserved.
- **Test-first regression guard**: β peel-chain capstones build green + axiom-free before/after.
- **Scope discipline (過大化 prevention)**: R2 = peel-chain threading ONLY; do NOT do R3 (rest + wrappers) or F1 (connected-gas instantiation). Pair-only.

## Checklist

- [ ] All threaded lemmas compile green
- [ ] Axiom-free verification passes (β route + new `𝓟`-parameterized versions)
- [ ] No scope creep: R2 boundaries enforced
- [ ] Codex-reviewed (if design amended from scope document)

Refs #4433.
