### PR TITLE
refactor(kp): thread abstract polymer set 𝓟 through the tree-bridge layer (field-CE F1 foundation R3) — #4433

### DIFF
--- a/IsingModel/ClusterExpansion/MayerTermPeelBoundTail.lean
+++ b/IsingModel/ClusterExpansion/MayerTermPeelBoundTail.lean
@@ -25,11 +25,42 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
+/-- **A quantity bridged to the Penrose tree sum over an abstract polymer set is bounded by
+the `(Δ²e|t|)^n`-weighted summed gas peel bound.**  Given `Δ²e|t| < 1`, a support-cardinality
+bound `|supp P| ≤ c·|P|` on all `P ∈ 𝓟` with `0 ≤ c`, and a *bridge* `hbridge` bounding a
+quantity `X` by `(n + 1)!⁻¹` times the Penrose tree-graph sum over `𝓟`, the quantity `X` is
+at most `(n + 1)!⁻¹` times the sum, over complete-graph spanning-tree shapes `T`, of
+`(Δ²e|t|)^n` times the child-count gas peel bound.  The bridge itself (from a Mayer-type term
+to the tree sum) is supplied by the caller; here we only chain it with the tail leaf-peel
+bridge `penroseGasTreeSum_le_sum_pow_peelBound`.  The even gas (`allPolymers G`, `c = 1`)
+recovers `mayerExpansionTerm_succ_abs_le_sum_pow_peelBound`. -/
+theorem le_sum_pow_rootedGasParentActivePeelBound_of_le_penroseTreeSum (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))}
+    (hgas : PolymerGasData G 𝓟) (n : ℕ) {c : ℝ}
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (hc : 0 ≤ c) {t : ℝ}
+    {X : ℝ}
+    (hbridge : X ≤ ((n + 1).factorial : ℝ)⁻¹
+      * ∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟),
+          ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω),
+            |t| ^ (ω 0).card
+              * ∏ i : Fin n, Real.exp 1 ^ (ω (Fin.succ i)).card * |t| ^ (ω (Fin.succ i)).card)
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    X ≤ ((n + 1).factorial : ℝ)⁻¹
+        * ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
+            S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
+          ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+            * rootedGasParentActivePeelBound G 𝓟 c (Penrose.completeGraphTreeParentCode n T)
+                (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
+  refine hbridge.trans ?_
+  exact mul_le_mul_of_nonneg_left
+    (penroseGasTreeSum_le_sum_pow_peelBound G hgas n hsupp hc hkp) (by positivity)
+
 /-- **The Mayer term bounded by the `(Δ²e|t|)^n`-weighted summed peel bound.**  For
 `Δ²e|t| < 1`, `|mayerExpansionTerm G (n + 1) t|` is at most `(n + 1)!⁻¹` times the sum,
 over complete-graph spanning-tree shapes `T`, of `(Δ²e|t|)^n` times the child-count peel
-bound.  Composes the Penrose tree-graph bound (#4095) with the tail leaf-peel bridge
-(#4132). -/
+bound.  Even-gas (`allPolymers G`, `c = 1`) instance of
+`le_sum_pow_rootedGasParentActivePeelBound_of_le_penroseTreeSum`, with the Mayer→tree bridge
+supplied by #4095. -/
 theorem mayerExpansionTerm_succ_abs_le_sum_pow_peelBound (G : SimpleGraph ι)
     [DecidableRel G.Adj] [Fintype G.edgeSet] (n : ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
@@ -40,7 +71,9 @@ theorem mayerExpansionTerm_succ_abs_le_sum_pow_peelBound (G : SimpleGraph ι)
           ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
             * rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
                 (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
-  refine (mayerExpansionTerm_succ_abs_le_treeSum_rootedExpActivity G n t).trans ?_
-  exact mul_le_mul_of_nonneg_left (penroseTreeSum_le_sum_pow_peelBound G n hkp) (by positivity)
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP; rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  exact le_sum_pow_rootedGasParentActivePeelBound_of_le_penroseTreeSum G (evenPolymerGasData G) n
+    hsupp zero_le_one (mayerExpansionTerm_succ_abs_le_treeSum_rootedExpActivity G n t) hkp
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelTailTree.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveLeafPeelTailTree.lean
@@ -27,10 +27,38 @@ open Finset SimpleGraph
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
 /-- **The sharpened (tail) leaf-peel bound for the complete-graph spanning-tree parent
-code.**  For the full active set (cardinality `n`) and the parent code of a spanning tree
-`T` of the complete graph on `Fin (n + 1)`, with `Δ²e|t| < 1`, the rooted-tree active sum
-at exponent `0` is bounded by `(Δ²e|t|)^n` times the child-count peel bound.  The leaf
-existence is discharged by `completeGraphTreeParentCode_exists_active_leaf`. -/
+code (gas form).**  For the full active set (cardinality `n`) and the parent code of a
+spanning tree `T` of the complete graph on `Fin (n + 1)`, with `Δ²e|t| < 1`, a
+support-cardinality bound `|supp P| ≤ c·|P|` for all `P ∈ 𝓟`, and `0 ≤ c`, the rooted-tree
+active gas sum at exponent `0` is bounded by `(Δ²e|t|)^n` times the child-count gas peel
+bound.  The leaf existence is discharged by `completeGraphTreeParentCode_exists_active_leaf`.
+The even gas (`allPolymers G`) takes `c = 1` in
+`rootedParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound`. -/
+theorem rootedGasParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) (n : ℕ)
+    (T : {S : Finset (Sym2 (Fin (n + 1))) //
+      S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))}) {c : ℝ}
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (hc : 0 ≤ c) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    rootedGasParentActiveSum G 𝓟 (Penrose.completeGraphTreeParentCode n T)
+        (Finset.univ : Finset (Fin n))
+        (rootedParentActiveClosed_univ (Penrose.completeGraphTreeParentCode n T))
+        (fun _ => 0) t
+      ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+          * rootedGasParentActivePeelBound G 𝓟 c (Penrose.completeGraphTreeParentCode n T)
+              (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
+  have h := rootedGasParentActiveSum_le_pow_mul_childCount_bound G hgas
+    (fun hB => completeGraphTreeParentCode_exists_active_leaf hB T)
+    (Finset.univ : Finset (Fin n))
+    (rootedParentActiveClosed_univ (Penrose.completeGraphTreeParentCode n T)) (fun _ => 0)
+    hsupp hc hkp
+  rwa [Finset.card_univ, Fintype.card_fin] at h
+
+/-- **The sharpened (tail) leaf-peel bound for the complete-graph spanning-tree parent
+code.**  Even-gas (`allPolymers G`, `c = 1`) instance of
+`rootedGasParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound`,
+discharging the support bound via `polymerSupport_card_le_card_of_mem_allPolymers`. -/
 theorem rootedParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound
     (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (n : ℕ)
     (T : {S : Finset (Sym2 (Fin (n + 1))) //
@@ -43,10 +71,9 @@ theorem rootedParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_p
       ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
           * rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
               (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
-  have h := rootedParentActiveSum_le_pow_mul_childCount_bound G
-    (fun hB => completeGraphTreeParentCode_exists_active_leaf hB T)
-    (Finset.univ : Finset (Fin n))
-    (rootedParentActiveClosed_univ (Penrose.completeGraphTreeParentCode n T)) (fun _ => 0) hkp
-  rwa [Finset.card_univ, Fintype.card_fin] at h
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP; rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  exact rootedGasParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound G
+    (evenPolymerGasData G) n T hsupp zero_le_one hkp
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveTreeBridge.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveTreeBridge.lean
@@ -29,23 +29,26 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **Fubini swap of the Penrose tree sum, with parent-constraint relaxation.**  The
-Penrose double sum over polymer sequences and spanning trees of the incompatibility
-graph is bounded by the sum, over complete-graph spanning-tree shapes `T`, of the weight
-over the sequences satisfying the per-edge parent incompatibility for `T`.  The spanning
-trees of `incompat ω` are spanning trees of the complete graph, so the two sums swap;
-the inner constraint is then relaxed by #4096. -/
-theorem penroseTreeSum_le_subtype_parentConstraint (G : SimpleGraph ι) [Fintype G.edgeSet]
+/-- **Fubini swap of the Penrose tree sum over an abstract polymer set, with
+parent-constraint relaxation.**  The Penrose double sum over polymer sequences drawn from
+the abstract polymer set `𝓟` and spanning trees of the incompatibility graph is bounded by
+the sum, over complete-graph spanning-tree shapes `T`, of the weight over the sequences
+satisfying the per-edge parent incompatibility for `T`.  The spanning trees of `incompat ω`
+are spanning trees of the complete graph, so the two sums swap; the inner constraint is
+then relaxed by #4096.  This step is purely combinatorial (Fubini + tree monotonicity) and
+uses no gas hypotheses; the even gas (`allPolymers G`) is recovered by
+`penroseTreeSum_le_subtype_parentConstraint`. -/
+theorem penroseGasTreeSum_le_subtype_parentConstraint (𝓟 : Finset (Finset (Sym2 ι)))
     (n : ℕ) (W : (Fin (n + 1) → Finset (Sym2 ι)) → ℝ) (hW : ∀ ω, 0 ≤ W ω) :
-    (∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+    (∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟),
         ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω), W ω)
       ≤ ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
             S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
-          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
             (fun ω => ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
               (ω (Penrose.completeGraphTreeParentCode n T i))), W ω := by
   classical
-  set P := Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G) with hP
+  set P := Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟) with hP
   -- Rewrite each inner spanning-tree sum as a subtype sum over complete-graph trees.
   have hinner : ∀ ω, (∑ _T ∈ Penrose.spanningTreeEdgeSubsets
         (polymerSeqIncompatibilityGraph ω), W ω)
@@ -79,5 +82,18 @@ theorem penroseTreeSum_le_subtype_parentConstraint (G : SimpleGraph ι) [Fintype
             (ω (Penrose.completeGraphTreeParentCode n T i))), W ω :=
           Finset.sum_le_sum fun T _ =>
             sum_filter_treeIncompat_le_filter_parentConstraint n T P W hW
+
+/-- **Fubini swap of the Penrose tree sum, with parent-constraint relaxation.**  Even-gas
+(`allPolymers G`) instance of `penroseGasTreeSum_le_subtype_parentConstraint`. -/
+theorem penroseTreeSum_le_subtype_parentConstraint (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (n : ℕ) (W : (Fin (n + 1) → Finset (Sym2 ι)) → ℝ) (hW : ∀ ω, 0 ≤ W ω) :
+    (∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+        ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω), W ω)
+      ≤ ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
+            S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
+          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+            (fun ω => ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
+              (ω (Penrose.completeGraphTreeParentCode n T i))), W ω :=
+  penroseGasTreeSum_le_subtype_parentConstraint (allPolymers G) n W hW
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/RootedParentActiveTreePeelBoundTail.lean
+++ b/IsingModel/ClusterExpansion/RootedParentActiveTreePeelBoundTail.lean
@@ -26,21 +26,25 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **The Penrose tree sum is bounded by the `(Δ²e|t|)^n`-weighted summed peel bound.**
-The tail sharpening of `penroseTreeSum_le_sum_peelBound`: per shape, the rooted-tree active
-sum is bounded by `(Δ²e|t|)^n` times the child-count peel bound (the tail leaf-peel
-induction #4130), giving the Penrose tree-graph sum a `(Δ²e|t|)^n` factor per shape. -/
-theorem penroseTreeSum_le_sum_pow_peelBound (G : SimpleGraph ι) [DecidableRel G.Adj]
-    [Fintype G.edgeSet] (n : ℕ) {t : ℝ}
-    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
-    (∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+/-- **The Penrose tree sum over an abstract polymer set is bounded by the
+`(Δ²e|t|)^n`-weighted summed gas peel bound.**  The tail sharpening of
+`penroseTreeSum_le_sum_peelBound` in gas form: for a support-cardinality bound
+`|supp P| ≤ c·|P|` on all `P ∈ 𝓟` and `0 ≤ c`, per shape the rooted-tree active gas sum is
+bounded by `(Δ²e|t|)^n` times the child-count gas peel bound (the tail leaf-peel induction
+#4130), giving the Penrose tree-graph sum over `𝓟` a `(Δ²e|t|)^n` factor per shape.  The
+even gas (`allPolymers G`) takes `c = 1` in `penroseTreeSum_le_sum_pow_peelBound`. -/
+theorem penroseGasTreeSum_le_sum_pow_peelBound (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) (n : ℕ)
+    {c : ℝ} (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (hc : 0 ≤ c)
+    {t : ℝ} (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟),
         ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω),
           |t| ^ (ω 0).card
             * ∏ i : Fin n, Real.exp 1 ^ (ω (Fin.succ i)).card * |t| ^ (ω (Fin.succ i)).card)
       ≤ ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
             S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
           ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
-            * rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
+            * rootedGasParentActivePeelBound G 𝓟 c (Penrose.completeGraphTreeParentCode n T)
                 (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
   -- The Penrose summand is dominated by the uniform activity product.
   have hWle : ∀ ω : Fin (n + 1) → Finset (Sym2 ι),
@@ -54,35 +58,56 @@ theorem penroseTreeSum_le_sum_pow_peelBound (G : SimpleGraph ι) [DecidableRel G
     refine mul_le_mul_of_nonneg_right ?_ (by positivity)
     refine pow_le_pow_left₀ (abs_nonneg t) ?_ _
     exact le_mul_of_one_le_left (abs_nonneg t) (Real.one_le_exp_iff.mpr zero_le_one)
-  refine (penroseTreeSum_le_subtype_parentConstraint G n
+  refine (penroseGasTreeSum_le_subtype_parentConstraint 𝓟 n
     (fun ω => |t| ^ (ω 0).card
       * ∏ i : Fin n, Real.exp 1 ^ (ω (Fin.succ i)).card * |t| ^ (ω (Fin.succ i)).card)
     (fun ω => by positivity)).trans ?_
   refine Finset.sum_le_sum fun T _ => ?_
   calc
-    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
         (fun ω => ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
           (ω (Penrose.completeGraphTreeParentCode n T i))),
         |t| ^ (ω 0).card
           * ∏ i : Fin n, Real.exp 1 ^ (ω (Fin.succ i)).card * |t| ^ (ω (Fin.succ i)).card)
-        ≤ ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+        ≤ ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
             (fun ω => ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
               (ω (Penrose.completeGraphTreeParentCode n T i))),
             ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card :=
           Finset.sum_le_sum fun ω _ => hWle ω
-    _ = ∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+    _ = ∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟),
           if ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
               (ω (Penrose.completeGraphTreeParentCode n T i)) then
             ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card else 0 :=
           Finset.sum_filter _ _
-    _ = rootedParentActiveSum G (Penrose.completeGraphTreeParentCode n T)
+    _ = rootedGasParentActiveSum G 𝓟 (Penrose.completeGraphTreeParentCode n T)
           (Finset.univ : Finset (Fin n))
           (rootedParentActiveClosed_univ (Penrose.completeGraphTreeParentCode n T))
           (fun _ => 0) t :=
-          (rootedParentActiveSum_univ_zero_eq G (Penrose.completeGraphTreeParentCode n T) t).symm
+          (rootedGasParentActiveSum_univ_zero_eq G 𝓟
+            (Penrose.completeGraphTreeParentCode n T) t).symm
     _ ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
-          * rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
+          * rootedGasParentActivePeelBound G 𝓟 c (Penrose.completeGraphTreeParentCode n T)
               (Finset.univ : Finset (Fin n)) (fun _ => 0) t :=
-          rootedParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound G n T hkp
+          rootedGasParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound G
+            hgas n T hsupp hc hkp
+
+/-- **The Penrose tree sum is bounded by the `(Δ²e|t|)^n`-weighted summed peel bound.**
+Even-gas (`allPolymers G`, `c = 1`) instance of `penroseGasTreeSum_le_sum_pow_peelBound`,
+discharging the support bound via `polymerSupport_card_le_card_of_mem_allPolymers`. -/
+theorem penroseTreeSum_le_sum_pow_peelBound (G : SimpleGraph ι) [DecidableRel G.Adj]
+    [Fintype G.edgeSet] (n : ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+        ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω),
+          |t| ^ (ω 0).card
+            * ∏ i : Fin n, Real.exp 1 ^ (ω (Fin.succ i)).card * |t| ^ (ω (Fin.succ i)).card)
+      ≤ ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
+            S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
+          ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+            * rootedParentActivePeelBound G (Penrose.completeGraphTreeParentCode n T)
+                (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP; rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  exact penroseGasTreeSum_le_sum_pow_peelBound G (evenPolymerGasData G) n hsupp zero_le_one hkp
 
 end IsingModel


### PR DESCRIPTION
## Summary

R3 (final refactor before F1) of the field-CE minimal route: thread the abstract polymer set `𝓟` through the remaining **tree-bridge layer** that is currently hardcoded to `allPolymers`/even `rootedParentActiveSum`. Foundation for F1's connected-gas instance and field-Mayer→Penrose-tree bridge.

## Scope & Pattern

**4 lemmas to parameterize** (all hardcoded on `allPolymers` currently):
- `penroseTreeSum_le_subtype_parentConstraint` (`RootedParentActiveTreeBridge.lean:38`)
- `RootedParentActiveLeafPeelTailTree.lean:34` lemma
- `penroseTreeSum_le_sum_pow_peelBound` (`RootedParentActiveTreePeelBoundTail.lean:33`)
- `MayerTermPeelBoundTail.lean:33` lemma

Mirror R1/R2 pattern: add `PolymerGasData G 𝓟`-versioned lemmas with `hsupp`/`c` support hypothesis; recover existing β versions as `allPolymers`/`c=1` thin wrappers (verbatim, no code change).

**Use R2 gas siblings**: where tree-bridge lemmas currently call `rootedParentActiveSum`/`rootedParentActivePeelBound`, replace with their gas equivalents `rootedGasParentActiveSum_le_pow_mul_childCount_bound` / `sum_pow_rootedGasParentActivePeelBound_le`.

## Validation

- Test-first: β tree-bridge capstones + downstream Mayer consumers build ✓ axiom-free before/after.
- Scope discipline: **R3 = 4 tree-bridge lemmas ONLY**. Do NOT build connected-gas instance or field-Mayer→Penrose-tree bridge (F1 work). Pair-only. β versions verbatim.

## References

- Research: `.self-local/reports/research-field-ce-R3-vs-F1-path-2026-07-06.md`
- Scoping/pattern: `.self-local/reports/scope-kp-parameterization-surface-2026-07-05.md`
- R1/R2 precedent: PR #4447 (R1 moment-core), PR #4448 (R2 peel-chain)

## Test Plan

- [ ] β tree-bridge capstones compile green
- [ ] Downstream Mayer consumers (MayerTermPeelBound.lean capstones) build green
- [ ] `#print axioms` zero (`propext`/`Classical.choice`/`Quot.sound` only)
- [ ] No linter warnings in touched files

---

Refs #4433
