### PR TITLE
refactor(kp): gas-parametrize fixed-vertex touching chain over PolymerGasData (field-CE F3 prerequisite F3-pre) — #4433

### DIFF
--- a/IsingModel/ClusterExpansion/FixedVertexChainEnds.lean
+++ b/IsingModel/ClusterExpansion/FixedVertexChainEnds.lean
@@ -17,17 +17,20 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
-/-- **Root-filtered shifted term-absolute tree-sum bound.** This is the direct
+/-- **Root-filtered shifted term-absolute tree-sum bound (gas form).** The gas-parametrized
 fixed-root-filtered clone of `termAbsSum_succ_le_treeSum_rootedExpActivity`: the outer
-polymer-sequence sum is restricted to sequences whose root polymer `ω 0` contains the fixed
-vertex `v`, while the per-sequence Penrose tree bound is unchanged. -/
-theorem fixedVertexRoot_termAbsSum_succ_le_treeSum_rootedExpActivity
-    (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) (n : ℕ) {t : ℝ} (ht : 0 ≤ t) :
-    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+polymer-sequence sum ranges over sequences from an abstract gas `𝓟` whose root polymer `ω 0`
+contains the fixed vertex `v`, while the per-sequence Penrose tree bound is unchanged. This
+step is purely structural (Ursell/activity), so it needs no gas hypotheses; the even gas
+(`allPolymers G`) is recovered by `fixedVertexRoot_termAbsSum_succ_le_treeSum_rootedExpActivity`. -/
+theorem fixedVertexGasRoot_termAbsSum_succ_le_treeSum_rootedExpActivity
+    (𝓟 : Finset (Finset (Sym2 ι))) (v : ι) (n : ℕ)
+    {t : ℝ} (ht : 0 ≤ t) :
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => v ∈ polymerSupport (ω 0)),
         |ursellCoefficient ω| * clusterSeqActivity t ω)
       ≤ (((n + 1).factorial : ℝ)⁻¹)
-        * ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+        * ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
             (fun ω => v ∈ polymerSupport (ω 0)),
             ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω),
               |t| ^ (ω 0).card
@@ -64,26 +67,51 @@ theorem fixedVertexRoot_termAbsSum_succ_le_treeSum_rootedExpActivity
         refine le_mul_of_one_le_left (by positivity) ?_
         exact one_le_pow₀ (Real.one_le_exp_iff.mpr zero_le_one)
 
-/-- **Fixed-vertex `(Δ²e|t|)^n`-weighted summed peel bound.** This is the fixed-root clone of
-`sum_pow_rootedParentActivePeelBound_le`: the active peel bound is replaced by
-`fixedVertexRootedParentActivePeelBound G root`, and #4249 gives the factorial-product bound
-without the global factor `Fintype.card ι`. -/
-theorem sum_pow_fixedVertexRootedParentActivePeelBound_le
-    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι) (n : ℕ) {t : ℝ}
+/-- **Root-filtered shifted term-absolute tree-sum bound.** This is the direct
+fixed-root-filtered clone of `termAbsSum_succ_le_treeSum_rootedExpActivity`: the outer
+polymer-sequence sum is restricted to sequences whose root polymer `ω 0` contains the fixed
+vertex `v`, while the per-sequence Penrose tree bound is unchanged. Even-gas
+(`allPolymers G`) instance of `fixedVertexGasRoot_termAbsSum_succ_le_treeSum_rootedExpActivity`. -/
+theorem fixedVertexRoot_termAbsSum_succ_le_treeSum_rootedExpActivity
+    (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) (n : ℕ) {t : ℝ} (ht : 0 ≤ t) :
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (fun ω => v ∈ polymerSupport (ω 0)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+      ≤ (((n + 1).factorial : ℝ)⁻¹)
+        * ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+            (fun ω => v ∈ polymerSupport (ω 0)),
+            ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω),
+              |t| ^ (ω 0).card
+                * ∏ i : Fin n,
+                    Real.exp 1 ^ (ω (Fin.succ i)).card
+                      * |t| ^ (ω (Fin.succ i)).card :=
+  fixedVertexGasRoot_termAbsSum_succ_le_treeSum_rootedExpActivity (allPolymers G) v n ht
+
+/-- **Fixed-vertex `(Δ²e|t|)^n`-weighted summed gas peel bound.** This is the gas-parametrized
+fixed-root clone of `sum_pow_rootedGasParentActivePeelBound_le`: the active peel bound is the
+fixed-vertex gas peel bound `fixedVertexRootedGasParentActivePeelBound G 𝓟 c root`, whose
+factorial-product bound carries the support-bump factor `c^n` (from the `c` per active
+vertex) and no global factor `Fintype.card ι` (the root is fixed). The even gas takes
+`c = 1` in `sum_pow_fixedVertexRootedParentActivePeelBound_le`. -/
+theorem sum_pow_fixedVertexRootedGasParentActivePeelBound_le
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) (c : ℝ) (hc : 0 ≤ c) (root : ι)
+    (n : ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
     (∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
         S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
         ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
-          * fixedVertexRootedParentActivePeelBound G root
+          * fixedVertexRootedGasParentActivePeelBound G 𝓟 c root
               (Penrose.completeGraphTreeParentCode n T) (Finset.univ : Finset (Fin n))
               (fun _ => 0) t)
-      ≤ (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n * (4 : ℝ) ^ n
+      ≤ (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n * c ^ n * (4 : ℝ) ^ n
             * (n.factorial : ℝ))
           / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1) := by
   set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
   set q : ℝ := 1 - rr with hq
   have hqpos : 0 < q := by rw [hq]; linarith [hkp]
   have hrr0 : 0 ≤ rr := by rw [hrr]; positivity
+  have hcn0 : 0 ≤ c ^ n := pow_nonneg hc n
   have hcast : (∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
         S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
         ∏ v : Fin (n + 1),
@@ -108,41 +136,61 @@ theorem sum_pow_fixedVertexRootedParentActivePeelBound_le
   rw [← Finset.mul_sum]
   have hpeel : (∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
         S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
-        fixedVertexRootedParentActivePeelBound G root
+        fixedVertexRootedGasParentActivePeelBound G 𝓟 c root
           (Penrose.completeGraphTreeParentCode n T) (Finset.univ : Finset (Fin n))
           (fun _ => 0) t)
-      ≤ ((1 : ℝ) / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ)) := by
+      ≤ (c ^ n / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ)) := by
     calc
-      (∑ T, fixedVertexRootedParentActivePeelBound G root
+      (∑ T, fixedVertexRootedGasParentActivePeelBound G 𝓟 c root
           (Penrose.completeGraphTreeParentCode n T) (Finset.univ : Finset (Fin n))
           (fun _ => 0) t)
-          ≤ ∑ T, (∏ v : Fin (n + 1),
+          ≤ ∑ T, c ^ n * ((∏ v : Fin (n + 1),
               ((rootedParentChildCount (Penrose.completeGraphTreeParentCode n T)
                 (Finset.univ : Finset (Fin n)) v).factorial : ℝ))
-              / q ^ (2 * n + 1) := by
+              / q ^ (2 * n + 1)) := by
             refine Finset.sum_le_sum fun T _ => ?_
-            exact fixedVertexRootedParentActivePeelBound_univ_zero_le_prod_childCount_factorial_div
-              G root (Penrose.completeGraphTreeParentCode n T) hqpos
-      _ = ((1 : ℝ) / q ^ (2 * n + 1))
+            exact
+              fixedVertexRootedGasParentActivePeelBound_univ_zero_le_prod_childCount_factorial_div
+                G hgas c hc root (Penrose.completeGraphTreeParentCode n T) hqpos
+      _ = (c ^ n / q ^ (2 * n + 1))
             * ∑ T, ∏ v : Fin (n + 1),
                 ((rootedParentChildCount (Penrose.completeGraphTreeParentCode n T)
                   (Finset.univ : Finset (Fin n)) v).factorial : ℝ) := by
             rw [Finset.mul_sum]
             refine Finset.sum_congr rfl fun T _ => ?_
-            rw [one_div, div_eq_inv_mul]
-      _ ≤ ((1 : ℝ) / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ)) := by
+            ring
+      _ ≤ (c ^ n / q ^ (2 * n + 1)) * ((4 : ℝ) ^ n * (n.factorial : ℝ)) := by
             refine mul_le_mul_of_nonneg_left hcast ?_
-            exact div_nonneg zero_le_one (le_of_lt (pow_pos hqpos _))
+            exact div_nonneg hcn0 (le_of_lt (pow_pos hqpos _))
   calc
     rr ^ n
-        * ∑ T, fixedVertexRootedParentActivePeelBound G root
+        * ∑ T, fixedVertexRootedGasParentActivePeelBound G 𝓟 c root
             (Penrose.completeGraphTreeParentCode n T) (Finset.univ : Finset (Fin n))
             (fun _ => 0) t
-        ≤ rr ^ n * (((1 : ℝ) / q ^ (2 * n + 1))
+        ≤ rr ^ n * ((c ^ n / q ^ (2 * n + 1))
             * ((4 : ℝ) ^ n * (n.factorial : ℝ))) :=
           mul_le_mul_of_nonneg_left hpeel (pow_nonneg hrr0 n)
-    _ = (rr ^ n * (4 : ℝ) ^ n * (n.factorial : ℝ)) / q ^ (2 * n + 1) := by
-          rw [one_div]
-          ring
+    _ = (rr ^ n * c ^ n * (4 : ℝ) ^ n * (n.factorial : ℝ)) / q ^ (2 * n + 1) := by ring
+
+/-- **Fixed-vertex `(Δ²e|t|)^n`-weighted summed peel bound.** This is the fixed-root clone of
+`sum_pow_rootedParentActivePeelBound_le`: the active peel bound is replaced by
+`fixedVertexRootedParentActivePeelBound G root`, and #4249 gives the factorial-product bound
+without the global factor `Fintype.card ι`. Even-gas (`c = 1`) instance of
+`sum_pow_fixedVertexRootedGasParentActivePeelBound_le`. -/
+theorem sum_pow_fixedVertexRootedParentActivePeelBound_le
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι) (n : ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
+        S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
+        ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+          * fixedVertexRootedParentActivePeelBound G root
+              (Penrose.completeGraphTreeParentCode n T) (Finset.univ : Finset (Fin n))
+              (fun _ => 0) t)
+      ≤ (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n * (4 : ℝ) ^ n
+            * (n.factorial : ℝ))
+          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1) := by
+  have h := sum_pow_fixedVertexRootedGasParentActivePeelBound_le G (evenPolymerGasData G) 1
+    zero_le_one root n hkp
+  simpa [fixedVertexRootedParentActivePeelBound] using h
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/FixedVertexChainMid.lean
+++ b/IsingModel/ClusterExpansion/FixedVertexChainMid.lean
@@ -6,8 +6,11 @@ import IsingModel.ClusterExpansion.RootedParentActiveLeafPeelTailTree
 
 This file supplies the root-filtered middle part of the fixed-vertex Route B chain.  The
 root coordinate is kept inside the active-sum recursion all the way to the empty active
-set, so the base root moment is over `rootedPolymers G root` rather than over
-`allPolymers G`.
+set, so the base root moment is over `rootedGasPolymers 𝓟 root` rather than over the whole
+gas `𝓟`.  Everything is gas-parametrized over an abstract polymer set `𝓟` carrying
+`PolymerGasData G 𝓟`, with a support-cardinality constant `c` (`|supp P| ≤ c·|P|`) threaded
+through the leaf-peel step; the even gas (`allPolymers G`, `c = 1`) is recovered by thin
+wrappers.
 -/
 
 namespace IsingModel
@@ -25,12 +28,14 @@ def rootedParentActiveRoot (A : Finset (Fin n)) : RootedParentActive A :=
 theorem rootedParentActiveRoot_coe (A : Finset (Fin n)) :
     (rootedParentActiveRoot A : Fin (n + 1)) = 0 := rfl
 
-/-- The fixed-root-filtered active sum.  It is the usual active sum with the additional
-condition that the root active coordinate contains the prescribed vertex `root`. -/
-noncomputable def fixedVertexRootedParentActiveSum (G : SimpleGraph ι) [Fintype G.edgeSet]
-    (root : ι) (par : Fin n → Fin (n + 1)) (A : Finset (Fin n))
+/-- The fixed-root-filtered active gas sum.  It is the usual active gas sum (labellings by
+polymers of `𝓟`) with the additional condition that the root active coordinate contains the
+prescribed vertex `root`.  The even gas (`allPolymers G`) is recovered by
+`fixedVertexRootedParentActiveSum`. -/
+noncomputable def fixedVertexRootedGasParentActiveSum (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) (root : ι) (par : Fin n → Fin (n + 1)) (A : Finset (Fin n))
     (hclosed : RootedParentActiveClosed par A) (k : Fin (n + 1) → ℕ) (t : ℝ) : ℝ :=
-  ∑ ω ∈ Fintype.piFinset (fun _ : RootedParentActive A => allPolymers G),
+  ∑ ω ∈ Fintype.piFinset (fun _ : RootedParentActive A => 𝓟),
     (if root ∈ polymerSupport (ω (rootedParentActiveRoot A)) ∧
         ∀ j : Fin n, ∀ hj : j ∈ A,
           PolymersIncompatible (ω (rootedParentActiveChild hj))
@@ -39,18 +44,24 @@ noncomputable def fixedVertexRootedParentActiveSum (G : SimpleGraph ι) [Fintype
         ((ω v).card : ℝ) ^ k v.1 * (Real.exp 1 * |t|) ^ (ω v).card
     else 0)
 
-/-- Empty-active-set base case for the fixed-root active sum. -/
-theorem fixedVertexRootedParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.edgeSet]
-    (root : ι) (par : Fin n → Fin (n + 1))
+/-- The fixed-root-filtered active sum.  Even-gas (`allPolymers G`) instance of
+`fixedVertexRootedGasParentActiveSum`. -/
+noncomputable def fixedVertexRootedParentActiveSum (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (root : ι) (par : Fin n → Fin (n + 1)) (A : Finset (Fin n))
+    (hclosed : RootedParentActiveClosed par A) (k : Fin (n + 1) → ℕ) (t : ℝ) : ℝ :=
+  fixedVertexRootedGasParentActiveSum G (allPolymers G) root par A hclosed k t
+
+/-- Empty-active-set base case for the fixed-root active gas sum. -/
+theorem fixedVertexRootedGasParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) (root : ι) (par : Fin n → Fin (n + 1))
     (hclosed : RootedParentActiveClosed par (∅ : Finset (Fin n)))
     (k : Fin (n + 1) → ℕ) (t : ℝ) :
-    fixedVertexRootedParentActiveSum G root par ∅ hclosed k t
-      = ∑ P ∈ rootedPolymers G root,
+    fixedVertexRootedGasParentActiveSum G 𝓟 root par ∅ hclosed k t
+      = ∑ P ∈ rootedGasPolymers 𝓟 root,
           (P.card : ℝ) ^ k 0 * (Real.exp 1 * |t|) ^ P.card := by
-  rw [fixedVertexRootedParentActiveSum]
+  rw [fixedVertexRootedGasParentActiveSum]
   calc
-    (∑ ω ∈ Fintype.piFinset (fun _ : RootedParentActive (∅ : Finset (Fin n)) =>
-          allPolymers G),
+    (∑ ω ∈ Fintype.piFinset (fun _ : RootedParentActive (∅ : Finset (Fin n)) => 𝓟),
         (if root ∈ polymerSupport (ω (rootedParentActiveRoot ∅)) ∧
             ∀ j : Fin n, ∀ hj : j ∈ (∅ : Finset (Fin n)),
               PolymersIncompatible (ω (rootedParentActiveChild hj))
@@ -58,7 +69,7 @@ theorem fixedVertexRootedParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.e
           ∏ v : RootedParentActive (∅ : Finset (Fin n)),
             ((ω v).card : ℝ) ^ k v.1 * (Real.exp 1 * |t|) ^ (ω v).card
         else 0))
-        = ∑ P ∈ allPolymers G,
+        = ∑ P ∈ 𝓟,
             if root ∈ polymerSupport P then
               (P.card : ℝ) ^ k 0 * (Real.exp 1 * |t|) ^ P.card
             else 0 := by
@@ -82,20 +93,32 @@ theorem fixedVertexRootedParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.e
                         (rootedParentActiveRoot (∅ : Finset (Fin n)))).symm
                 _ = 0 := rfl
             simp [hroot, hdefault]
-    _ = ∑ P ∈ rootedPolymers G root,
+    _ = ∑ P ∈ rootedGasPolymers 𝓟 root,
           (P.card : ℝ) ^ k 0 * (Real.exp 1 * |t|) ^ P.card := by
-          rw [rootedPolymers, rootedGasPolymers, Finset.sum_filter]
+          rw [rootedGasPolymers, Finset.sum_filter]
 
-/-- The fixed-root peel bound satisfies the same erase/update recursion as the unfiltered
-peel bound. -/
-theorem fixedVertexRootedParentActivePeelBound_erase_update
-    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι)
+/-- Empty-active-set base case for the fixed-root active sum.  Even-gas instance of
+`fixedVertexRootedGasParentActiveSum_empty`. -/
+theorem fixedVertexRootedParentActiveSum_empty (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (root : ι) (par : Fin n → Fin (n + 1))
+    (hclosed : RootedParentActiveClosed par (∅ : Finset (Fin n)))
+    (k : Fin (n + 1) → ℕ) (t : ℝ) :
+    fixedVertexRootedParentActiveSum G root par ∅ hclosed k t
+      = ∑ P ∈ rootedPolymers G root,
+          (P.card : ℝ) ^ k 0 * (Real.exp 1 * |t|) ^ P.card :=
+  fixedVertexRootedGasParentActiveSum_empty G (allPolymers G) root par hclosed k t
+
+/-- The fixed-root gas peel bound satisfies the same erase/update recursion as the
+unfiltered gas peel bound. -/
+theorem fixedVertexRootedGasParentActivePeelBound_erase_update
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) (c : ℝ) (root : ι)
     {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
     (hleaf : RootedParentLeaf par A j) (k : Fin (n + 1) → ℕ) (t : ℝ) :
-    rootedParentPeelFactor G t (k (Fin.succ j))
-        * fixedVertexRootedParentActivePeelBound G root par (A.erase j)
+    c * rootedParentPeelFactor G t (k (Fin.succ j))
+        * fixedVertexRootedGasParentActivePeelBound G 𝓟 c root par (A.erase j)
             (Function.update k (par j) (k (par j) + 1)) t
-      = fixedVertexRootedParentActivePeelBound G root par A k t := by
+      = fixedVertexRootedGasParentActivePeelBound G 𝓟 c root par A k t := by
   have hexp : ∀ v, Function.update k (par j) (k (par j) + 1) v
       + rootedParentChildCount par (A.erase j) v
         = k v + rootedParentChildCount par A v := by
@@ -107,14 +130,79 @@ theorem fixedVertexRootedParentActivePeelBound_erase_update
       omega
     · rw [Function.update_of_ne h, if_neg (fun e => h e.symm)]
       omega
-  rw [fixedVertexRootedParentActivePeelBound, fixedVertexRootedParentActivePeelBound,
+  rw [fixedVertexRootedGasParentActivePeelBound, fixedVertexRootedGasParentActivePeelBound,
     Finset.prod_congr rfl (fun j' _ => by rw [hexp (Fin.succ j')]),
     Finset.sum_congr rfl (fun P _ => by rw [hexp 0])]
   rw [← mul_assoc, ← Finset.mul_prod_erase A _ hleaf.1]
   congr 2
   rw [rootedParentChildCount_leaf_succ hleaf, add_zero]
 
-/-- Per-labelling leaf isolation with the fixed root filter threaded through the remainder. -/
+/-- The fixed-root peel bound satisfies the same erase/update recursion as the unfiltered
+peel bound.  Even-gas (`c = 1`) instance of
+`fixedVertexRootedGasParentActivePeelBound_erase_update`. -/
+theorem fixedVertexRootedParentActivePeelBound_erase_update
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι)
+    {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n}
+    (hleaf : RootedParentLeaf par A j) (k : Fin (n + 1) → ℕ) (t : ℝ) :
+    rootedParentPeelFactor G t (k (Fin.succ j))
+        * fixedVertexRootedParentActivePeelBound G root par (A.erase j)
+            (Function.update k (par j) (k (par j) + 1)) t
+      = fixedVertexRootedParentActivePeelBound G root par A k t := by
+  rw [fixedVertexRootedParentActivePeelBound, fixedVertexRootedParentActivePeelBound,
+    ← fixedVertexRootedGasParentActivePeelBound_erase_update G (allPolymers G) 1 root hleaf k t,
+    one_mul]
+
+/-- Per-labelling leaf isolation with the fixed root filter threaded through the remainder
+(gas form). -/
+theorem fixedVertexRootedGasParentActiveSum_leaf_inner
+    (𝓟 : Finset (Finset (Sym2 ι))) {par : Fin n → Fin (n + 1)}
+    {A : Finset (Fin n)} {j : Fin n} (root : ι)
+    (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
+    (k : Fin (n + 1) → ℕ) (t : ℝ)
+    (η : RootedParentActive (A.erase j) → Finset (Sym2 ι)) :
+    (∑ x ∈ 𝓟,
+        (if root ∈ polymerSupport
+              ((rootedParentActiveSplitEquiv hleaf.1 (rootedParentActiveRoot A)).elim x η) ∧
+            ∀ i, ∀ hi : i ∈ A,
+              PolymersIncompatible
+                ((rootedParentActiveSplitEquiv hleaf.1 (rootedParentActiveChild hi)).elim x η)
+                ((rootedParentActiveSplitEquiv hleaf.1
+                  (rootedParentActiveParent hclosed hi)).elim x η) then
+          ∏ v : RootedParentActive A,
+            (((rootedParentActiveSplitEquiv hleaf.1 v).elim x η).card : ℝ) ^ k v.1
+              * (Real.exp 1 * |t|) ^ ((rootedParentActiveSplitEquiv hleaf.1 v).elim x η).card
+        else 0))
+      = (if root ∈ polymerSupport (η (rootedParentActiveRoot (A.erase j))) ∧
+            ∀ i, ∀ hi : i ∈ A.erase j,
+              PolymersIncompatible (η (rootedParentActiveChild hi))
+                (η (rootedParentActiveParent (hclosed.erase_leaf hleaf) hi)) then
+          ∏ w : RootedParentActive (A.erase j),
+            ((η w).card : ℝ) ^ k w.1 * (Real.exp 1 * |t|) ^ (η w).card
+        else 0)
+        * leafGasColumnSum 𝓟 (η ⟨par j, hleaf.parent_mem_erase hclosed⟩)
+            (k (Fin.succ j)) t := by
+  classical
+  have hrootRecon : ∀ x : Finset (Sym2 ι),
+      root ∈ polymerSupport
+          ((rootedParentActiveSplitEquiv hleaf.1 (rootedParentActiveRoot A)).elim x η)
+        ↔ root ∈ polymerSupport (η (rootedParentActiveRoot (A.erase j))) := by
+    intro x
+    have hmem : ((rootedParentActiveRoot A : RootedParentActive A) : Fin (n + 1))
+        ∈ rootedParentActiveVertices (A.erase j) := by
+      simp [rootedParentActiveRoot]
+    rw [rootedParentActiveSplitEquiv_recon_some hleaf.1 x η hmem]
+    have heq :
+        (⟨(rootedParentActiveRoot A : RootedParentActive A), hmem⟩ :
+            RootedParentActive (A.erase j))
+          = rootedParentActiveRoot (A.erase j) := Subtype.ext rfl
+    rw [heq]
+  by_cases hroot : root ∈ polymerSupport (η (rootedParentActiveRoot (A.erase j)))
+  · simpa [hrootRecon, hroot] using
+      rootedGasParentActiveSum_leaf_inner 𝓟 hclosed hleaf k t η
+  · simp [hrootRecon, hroot]
+
+/-- Per-labelling leaf isolation with the fixed root filter threaded through the remainder.
+Even-gas (`allPolymers G`) instance of `fixedVertexRootedGasParentActiveSum_leaf_inner`. -/
 theorem fixedVertexRootedParentActiveSum_leaf_inner
     (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)}
     {A : Finset (Fin n)} {j : Fin n} (root : ι)
@@ -141,28 +229,35 @@ theorem fixedVertexRootedParentActiveSum_leaf_inner
             ((η w).card : ℝ) ^ k w.1 * (Real.exp 1 * |t|) ^ (η w).card
         else 0)
         * leafColumnSum G (η ⟨par j, hleaf.parent_mem_erase hclosed⟩)
-            (k (Fin.succ j)) t := by
-  classical
-  have hrootRecon : ∀ x : Finset (Sym2 ι),
-      root ∈ polymerSupport
-          ((rootedParentActiveSplitEquiv hleaf.1 (rootedParentActiveRoot A)).elim x η)
-        ↔ root ∈ polymerSupport (η (rootedParentActiveRoot (A.erase j))) := by
-    intro x
-    have hmem : ((rootedParentActiveRoot A : RootedParentActive A) : Fin (n + 1))
-        ∈ rootedParentActiveVertices (A.erase j) := by
-      simp [rootedParentActiveRoot]
-    rw [rootedParentActiveSplitEquiv_recon_some hleaf.1 x η hmem]
-    have heq :
-        (⟨(rootedParentActiveRoot A : RootedParentActive A), hmem⟩ :
-            RootedParentActive (A.erase j))
-          = rootedParentActiveRoot (A.erase j) := Subtype.ext rfl
-    rw [heq]
-  by_cases hroot : root ∈ polymerSupport (η (rootedParentActiveRoot (A.erase j)))
-  · simpa [hrootRecon, hroot] using
-      rootedParentActiveSum_leaf_inner G hclosed hleaf k t η
-  · simp [hrootRecon, hroot]
+            (k (Fin.succ j)) t :=
+  fixedVertexRootedGasParentActiveSum_leaf_inner (allPolymers G) root hclosed hleaf k t η
 
-/-- Leaf-peel decomposition for the fixed-root active sum. -/
+/-- Leaf-peel decomposition for the fixed-root active gas sum. -/
+theorem fixedVertexRootedGasParentActiveSum_leaf_peel
+    (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) {par : Fin n → Fin (n + 1)}
+    {A : Finset (Fin n)} {j : Fin n} (root : ι)
+    (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
+    (k : Fin (n + 1) → ℕ) (t : ℝ) :
+    fixedVertexRootedGasParentActiveSum G 𝓟 root par A hclosed k t
+      = ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+          (if root ∈ polymerSupport (η (rootedParentActiveRoot (A.erase j))) ∧
+              ∀ i, ∀ hi : i ∈ A.erase j,
+                PolymersIncompatible (η (rootedParentActiveChild hi))
+                  (η (rootedParentActiveParent (hclosed.erase_leaf hleaf) hi)) then
+            ∏ w : RootedParentActive (A.erase j),
+              ((η w).card : ℝ) ^ k w.1 * (Real.exp 1 * |t|) ^ (η w).card
+          else 0)
+          * leafGasColumnSum 𝓟 (η ⟨par j, hleaf.parent_mem_erase hclosed⟩)
+              (k (Fin.succ j)) t := by
+  rw [fixedVertexRootedGasParentActiveSum,
+    sum_piFinset_const_optionEquiv (rootedParentActiveSplitEquiv hleaf.1) 𝓟,
+    Finset.sum_comm]
+  exact Finset.sum_congr rfl fun η _ =>
+    fixedVertexRootedGasParentActiveSum_leaf_inner 𝓟 root hclosed hleaf k t η
+
+/-- Leaf-peel decomposition for the fixed-root active sum.  Even-gas instance of
+`fixedVertexRootedGasParentActiveSum_leaf_peel`. -/
 theorem fixedVertexRootedParentActiveSum_leaf_peel
     (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)}
     {A : Finset (Fin n)} {j : Fin n} (root : ι)
@@ -178,25 +273,24 @@ theorem fixedVertexRootedParentActiveSum_leaf_peel
               ((η w).card : ℝ) ^ k w.1 * (Real.exp 1 * |t|) ^ (η w).card
           else 0)
           * leafColumnSum G (η ⟨par j, hleaf.parent_mem_erase hclosed⟩)
-              (k (Fin.succ j)) t := by
-  rw [fixedVertexRootedParentActiveSum,
-    sum_piFinset_const_optionEquiv (rootedParentActiveSplitEquiv hleaf.1) (allPolymers G),
-    Finset.sum_comm]
-  exact Finset.sum_congr rfl fun η _ =>
-    fixedVertexRootedParentActiveSum_leaf_inner G root hclosed hleaf k t η
+              (k (Fin.succ j)) t :=
+  fixedVertexRootedGasParentActiveSum_leaf_peel G (allPolymers G) root hclosed hleaf k t
 
-/-- Tail leaf-peel inequality for the fixed-root active sum. -/
-theorem fixedVertexRootedParentActiveSum_leaf_peel_tail_le
-    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] {par : Fin n → Fin (n + 1)}
-    {A : Finset (Fin n)} {j : Fin n} (root : ι)
+/-- Tail leaf-peel inequality for the fixed-root active gas sum. -/
+theorem fixedVertexRootedGasParentActiveSum_leaf_peel_tail_le
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) {c : ℝ}
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ))
+    {par : Fin n → Fin (n + 1)} {A : Finset (Fin n)} {j : Fin n} (root : ι)
     (hclosed : RootedParentActiveClosed par A) (hleaf : RootedParentLeaf par A j)
     (k : Fin (n + 1) → ℕ) {t : ℝ}
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
-    fixedVertexRootedParentActiveSum G root par A hclosed k t
-      ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+    fixedVertexRootedGasParentActiveSum G 𝓟 root par A hclosed k t
+      ≤ c * (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
           * (((k (Fin.succ j)).factorial : ℝ)
-              / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (k (Fin.succ j) + 1))
-        * fixedVertexRootedParentActiveSum G root par (A.erase j) (hclosed.erase_leaf hleaf)
+              / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (k (Fin.succ j) + 1)))
+        * fixedVertexRootedGasParentActiveSum G 𝓟 root par (A.erase j)
+            (hclosed.erase_leaf hleaf)
             (Function.update k (par j) (k (par j) + 1)) t := by
   classical
   set hclosed' : RootedParentActiveClosed par (A.erase j) := hclosed.erase_leaf hleaf with hhc'
@@ -205,9 +299,9 @@ theorem fixedVertexRootedParentActiveSum_leaf_peel_tail_le
     hleaf.parent_mem_erase hclosed
   set w₀ : RootedParentActive (A.erase j) := ⟨par j, hparent⟩ with hw₀
   set k' : Fin (n + 1) → ℕ := Function.update k (par j) (k (par j) + 1) with hk'
-  set Ct : ℝ := ((G.maxDegree : ℝ) ^ 2 * q)
+  set Ct : ℝ := c * (((G.maxDegree : ℝ) ^ 2 * q)
     * (((k (Fin.succ j)).factorial : ℝ)
-        / (1 - (G.maxDegree : ℝ) ^ 2 * q) ^ (k (Fin.succ j) + 1)) with hCt
+        / (1 - (G.maxDegree : ℝ) ^ 2 * q) ^ (k (Fin.succ j) + 1))) with hCt
   set summand : (RootedParentActive (A.erase j) → Finset (Sym2 ι)) →
       (Fin (n + 1) → ℕ) → ℝ :=
     fun η K =>
@@ -256,28 +350,117 @@ theorem fixedVertexRootedParentActiveSum_leaf_peel_tail_le
     split_ifs
     · exact Finset.prod_nonneg fun w _ => by positivity
     · exact le_refl 0
-  rw [fixedVertexRootedParentActiveSum_leaf_peel G root hclosed hleaf k t]
+  rw [fixedVertexRootedGasParentActiveSum_leaf_peel G 𝓟 root hclosed hleaf k t]
   calc
-    (∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
-        summand η k * leafColumnSum G (η w₀) (k (Fin.succ j)) t)
-        ≤ ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
+    (∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
+        summand η k * leafGasColumnSum 𝓟 (η w₀) (k (Fin.succ j)) t)
+        ≤ ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
             summand η k' * Ct := by
           refine Finset.sum_le_sum fun η hη => ?_
-          have hηmem : η w₀ ∈ allPolymers G := Fintype.mem_piFinset.mp hη w₀
+          have hηmem : η w₀ ∈ 𝓟 := Fintype.mem_piFinset.mp hη w₀
           calc
-            summand η k * leafColumnSum G (η w₀) (k (Fin.succ j)) t
+            summand η k * leafGasColumnSum 𝓟 (η w₀) (k (Fin.succ j)) t
                 ≤ summand η k * (((η w₀).card : ℝ) * Ct) := by
                   refine mul_le_mul_of_nonneg_left ?_ (hsummand_nonneg η)
-                  exact leafColumnSum_tail_le G hηmem (k (Fin.succ j)) hkp
+                  have h := leafGasColumnSum_tail_le G hgas (η w₀) (k (Fin.succ j))
+                    (hsupp (η w₀) hηmem) hkp
+                  calc
+                    leafGasColumnSum 𝓟 (η w₀) (k (Fin.succ j)) t
+                        ≤ c * ((η w₀).card : ℝ)
+                            * (((G.maxDegree : ℝ) ^ 2 * q)
+                              * (((k (Fin.succ j)).factorial : ℝ)
+                                  / (1 - (G.maxDegree : ℝ) ^ 2 * q) ^ (k (Fin.succ j) + 1))) := by
+                          rw [hq]; exact h
+                    _ = ((η w₀).card : ℝ) * Ct := by rw [hCt]; ring
             _ = summand η k * ((η w₀).card : ℝ) * Ct := by ring
             _ = summand η k' * Ct := by rw [hbump η]
-    _ = Ct * ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => allPolymers G),
+    _ = Ct * ∑ η ∈ Fintype.piFinset (fun _ : RootedParentActive (A.erase j) => 𝓟),
           summand η k' := by rw [← Finset.sum_mul, mul_comm]
-    _ = Ct * fixedVertexRootedParentActiveSum G root par (A.erase j) hclosed'
+    _ = Ct * fixedVertexRootedGasParentActiveSum G 𝓟 root par (A.erase j) hclosed'
           (Function.update k (par j) (k (par j) + 1)) t := by
-        rw [fixedVertexRootedParentActiveSum]
+        rw [fixedVertexRootedGasParentActiveSum]
 
-/-- Tail leaf-peel induction for the fixed-root active sum. -/
+/-- Tail leaf-peel induction for the fixed-root active gas sum. -/
+theorem fixedVertexRootedGasParentActiveSum_le_pow_mul_childCount_bound
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) {c : ℝ} (hc : 0 ≤ c)
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (root : ι)
+    {par : Fin n → Fin (n + 1)}
+    (hleafExists : ∀ {B : Finset (Fin n)}, B.Nonempty → ∃ j, RootedParentLeaf par B j)
+    (A : Finset (Fin n)) (hclosed : RootedParentActiveClosed par A)
+    (k : Fin (n + 1) → ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    fixedVertexRootedGasParentActiveSum G 𝓟 root par A hclosed k t
+      ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ A.card
+          * fixedVertexRootedGasParentActivePeelBound G 𝓟 c root par A k t := by
+  set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
+  have hrr0 : (0 : ℝ) ≤ rr := by rw [hrr]; positivity
+  suffices H : ∀ m (A : Finset (Fin n)), A.card = m →
+      ∀ (hclosed : RootedParentActiveClosed par A) (k : Fin (n + 1) → ℕ),
+        fixedVertexRootedGasParentActiveSum G 𝓟 root par A hclosed k t
+          ≤ rr ^ A.card * fixedVertexRootedGasParentActivePeelBound G 𝓟 c root par A k t by
+    exact H A.card A rfl hclosed k
+  intro m
+  induction m using Nat.strong_induction_on with
+  | _ m IH =>
+    intro A hAcard hclosed k
+    rcases A.eq_empty_or_nonempty with rfl | hne
+    · rw [Finset.card_empty, pow_zero, one_mul,
+        fixedVertexRootedGasParentActiveSum_empty]
+      refine le_of_eq ?_
+      have hcc : rootedParentChildCount par (∅ : Finset (Fin n)) 0 = 0 := by
+        simp [rootedParentChildCount]
+      rw [fixedVertexRootedGasParentActivePeelBound]
+      simp only [hcc, Finset.prod_empty, one_mul, Nat.add_zero]
+    · obtain ⟨j, hleaf⟩ := hleafExists hne
+      have hlt : (A.erase j).card < m := by
+        rw [← hAcard]
+        exact Finset.card_erase_lt_of_mem hleaf.1
+      have hcard : A.card = (A.erase j).card + 1 := by
+        rw [Finset.card_erase_of_mem hleaf.1, Nat.sub_add_cancel (Finset.card_pos.mpr hne)]
+      calc
+        fixedVertexRootedGasParentActiveSum G 𝓟 root par A hclosed k t
+            ≤ c * (rr * rootedParentPeelFactor G t (k (Fin.succ j)))
+                * fixedVertexRootedGasParentActiveSum G 𝓟 root par (A.erase j)
+                    (hclosed.erase_leaf hleaf) (Function.update k (par j) (k (par j) + 1))
+                    t := by
+              have h := fixedVertexRootedGasParentActiveSum_leaf_peel_tail_le G hgas hsupp
+                root hclosed hleaf k hkp
+              rw [hrr, rootedParentPeelFactor]
+              calc
+                fixedVertexRootedGasParentActiveSum G 𝓟 root par A hclosed k t
+                    ≤ c * (((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+                        * (((k (Fin.succ j)).factorial : ℝ)
+                            / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+                                ^ (k (Fin.succ j) + 1)))
+                      * fixedVertexRootedGasParentActiveSum G 𝓟 root par (A.erase j)
+                          (hclosed.erase_leaf hleaf)
+                          (Function.update k (par j) (k (par j) + 1)) t := h
+                _ = c * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)
+                        * (((k (Fin.succ j)).factorial : ℝ)
+                            / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+                                ^ (k (Fin.succ j) + 1)))
+                      * fixedVertexRootedGasParentActiveSum G 𝓟 root par (A.erase j)
+                          (hclosed.erase_leaf hleaf)
+                          (Function.update k (par j) (k (par j) + 1)) t := by ring
+        _ ≤ c * (rr * rootedParentPeelFactor G t (k (Fin.succ j)))
+              * (rr ^ (A.erase j).card
+                  * fixedVertexRootedGasParentActivePeelBound G 𝓟 c root par (A.erase j)
+                    (Function.update k (par j) (k (par j) + 1)) t) := by
+              refine mul_le_mul_of_nonneg_left ?_
+                (mul_nonneg hc (mul_nonneg hrr0 (rootedParentPeelFactor_nonneg G hkp _)))
+              exact IH _ hlt (A.erase j) rfl (hclosed.erase_leaf hleaf) _
+        _ = rr ^ A.card
+              * (c * rootedParentPeelFactor G t (k (Fin.succ j))
+                  * fixedVertexRootedGasParentActivePeelBound G 𝓟 c root par (A.erase j)
+                    (Function.update k (par j) (k (par j) + 1)) t) := by
+              rw [hcard, pow_succ]
+              ring
+        _ = rr ^ A.card * fixedVertexRootedGasParentActivePeelBound G 𝓟 c root par A k t := by
+              rw [fixedVertexRootedGasParentActivePeelBound_erase_update G 𝓟 c root hleaf k t]
+
+/-- Tail leaf-peel induction for the fixed-root active sum.  Even-gas (`c = 1`) instance of
+`fixedVertexRootedGasParentActiveSum_le_pow_mul_childCount_bound`. -/
 theorem fixedVertexRootedParentActiveSum_le_pow_mul_childCount_bound
     (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι)
     {par : Fin n → Fin (n + 1)}
@@ -288,70 +471,27 @@ theorem fixedVertexRootedParentActiveSum_le_pow_mul_childCount_bound
     fixedVertexRootedParentActiveSum G root par A hclosed k t
       ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ A.card
           * fixedVertexRootedParentActivePeelBound G root par A k t := by
-  set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
-  have hrr0 : (0 : ℝ) ≤ rr := by rw [hrr]; positivity
-  suffices H : ∀ m (A : Finset (Fin n)), A.card = m →
-      ∀ (hclosed : RootedParentActiveClosed par A) (k : Fin (n + 1) → ℕ),
-        fixedVertexRootedParentActiveSum G root par A hclosed k t
-          ≤ rr ^ A.card * fixedVertexRootedParentActivePeelBound G root par A k t by
-    exact H A.card A rfl hclosed k
-  intro m
-  induction m using Nat.strong_induction_on with
-  | _ m IH =>
-    intro A hAcard hclosed k
-    rcases A.eq_empty_or_nonempty with rfl | hne
-    · rw [Finset.card_empty, pow_zero, one_mul,
-        fixedVertexRootedParentActiveSum_empty]
-      refine le_of_eq ?_
-      have hcc : rootedParentChildCount par (∅ : Finset (Fin n)) 0 = 0 := by
-        simp [rootedParentChildCount]
-      rw [fixedVertexRootedParentActivePeelBound]
-      simp only [hcc, Finset.prod_empty, one_mul, Nat.add_zero]
-    · obtain ⟨j, hleaf⟩ := hleafExists hne
-      have hlt : (A.erase j).card < m := by
-        rw [← hAcard]
-        exact Finset.card_erase_lt_of_mem hleaf.1
-      have hcard : A.card = (A.erase j).card + 1 := by
-        rw [Finset.card_erase_of_mem hleaf.1, Nat.sub_add_cancel (Finset.card_pos.mpr hne)]
-      calc
-        fixedVertexRootedParentActiveSum G root par A hclosed k t
-            ≤ rr * rootedParentPeelFactor G t (k (Fin.succ j))
-                * fixedVertexRootedParentActiveSum G root par (A.erase j)
-                    (hclosed.erase_leaf hleaf) (Function.update k (par j) (k (par j) + 1))
-                    t := by
-              rw [hrr, rootedParentPeelFactor]
-              exact fixedVertexRootedParentActiveSum_leaf_peel_tail_le G root hclosed
-                hleaf k hkp
-        _ ≤ rr * rootedParentPeelFactor G t (k (Fin.succ j))
-              * (rr ^ (A.erase j).card
-                  * fixedVertexRootedParentActivePeelBound G root par (A.erase j)
-                    (Function.update k (par j) (k (par j) + 1)) t) := by
-              refine mul_le_mul_of_nonneg_left ?_
-                (mul_nonneg hrr0 (rootedParentPeelFactor_nonneg G hkp _))
-              exact IH _ hlt (A.erase j) rfl (hclosed.erase_leaf hleaf) _
-        _ = rr ^ A.card
-              * (rootedParentPeelFactor G t (k (Fin.succ j))
-                  * fixedVertexRootedParentActivePeelBound G root par (A.erase j)
-                    (Function.update k (par j) (k (par j) + 1)) t) := by
-              rw [hcard, pow_succ]
-              ring
-        _ = rr ^ A.card * fixedVertexRootedParentActivePeelBound G root par A k t := by
-              rw [fixedVertexRootedParentActivePeelBound_erase_update G root hleaf k t]
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  simpa [fixedVertexRootedParentActiveSum, fixedVertexRootedParentActivePeelBound] using
+    fixedVertexRootedGasParentActiveSum_le_pow_mul_childCount_bound G (evenPolymerGasData G)
+      zero_le_one hsupp root hleafExists A hclosed k hkp
 
-/-- The univ fixed-root active sum in `Fin (n+1)` labelling form. -/
-theorem fixedVertexRootedParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fintype G.edgeSet]
-    (root : ι) (par : Fin n → Fin (n + 1)) (t : ℝ) :
-    fixedVertexRootedParentActiveSum G root par (Finset.univ : Finset (Fin n))
+/-- The univ fixed-root active gas sum in `Fin (n+1)` labelling form. -/
+theorem fixedVertexRootedGasParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (𝓟 : Finset (Finset (Sym2 ι))) (root : ι) (par : Fin n → Fin (n + 1)) (t : ℝ) :
+    fixedVertexRootedGasParentActiveSum G 𝓟 root par (Finset.univ : Finset (Fin n))
         (rootedParentActiveClosed_univ par) (fun _ => 0) t
-      = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+      = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => root ∈ polymerSupport (ω 0)),
           if ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i)) (ω (par i)) then
             ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card
           else 0 := by
-  rw [fixedVertexRootedParentActiveSum,
-    sum_piFinset_const_domEquiv rootedParentActiveUnivEquiv (allPolymers G)]
+  rw [fixedVertexRootedGasParentActiveSum,
+    sum_piFinset_const_domEquiv rootedParentActiveUnivEquiv 𝓟]
   calc
-    (∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+    (∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟),
         (if root ∈ polymerSupport
               ((fun a => ω (rootedParentActiveUnivEquiv a))
                 (rootedParentActiveRoot (Finset.univ : Finset (Fin n)))) ∧
@@ -365,7 +505,7 @@ theorem fixedVertexRootedParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fint
               * (Real.exp 1 * |t|) ^
                 ((fun a => ω (rootedParentActiveUnivEquiv a)) v).card
         else 0))
-        = ∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G),
+        = ∑ ω ∈ Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟),
             if root ∈ polymerSupport (ω 0) then
               if ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i)) (ω (par i)) then
                 ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card
@@ -420,14 +560,52 @@ theorem fixedVertexRootedParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fint
                 if_neg (fun h => hconstraint' (hconstraint.mpr h))]
           · rw [if_neg (fun h => hroot' h.1),
               if_neg (fun h => hroot' (hroot.mpr h))]
-    _ = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+    _ = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => root ∈ polymerSupport (ω 0)),
           if ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i)) (ω (par i)) then
             ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card
           else 0 := by
           rw [Finset.sum_filter]
 
-/-- The complete-tree fixed-root active sum is bounded by the weighted fixed-root peel bound. -/
+/-- The univ fixed-root active sum in `Fin (n+1)` labelling form.  Even-gas instance of
+`fixedVertexRootedGasParentActiveSum_univ_zero_eq`. -/
+theorem fixedVertexRootedParentActiveSum_univ_zero_eq (G : SimpleGraph ι) [Fintype G.edgeSet]
+    (root : ι) (par : Fin n → Fin (n + 1)) (t : ℝ) :
+    fixedVertexRootedParentActiveSum G root par (Finset.univ : Finset (Fin n))
+        (rootedParentActiveClosed_univ par) (fun _ => 0) t
+      = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (fun ω => root ∈ polymerSupport (ω 0)),
+          if ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i)) (ω (par i)) then
+            ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card
+          else 0 :=
+  fixedVertexRootedGasParentActiveSum_univ_zero_eq G (allPolymers G) root par t
+
+/-- The complete-tree fixed-root active gas sum is bounded by the weighted fixed-root gas
+peel bound. -/
+theorem fixedVertexRootedGasParentActiveSum_completeTree_univ_zero_le_pow_mul_peelBound
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) {c : ℝ} (hc : 0 ≤ c)
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (root : ι) (n : ℕ)
+    (T : {S : Finset (Sym2 (Fin (n + 1))) //
+      S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))}) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    fixedVertexRootedGasParentActiveSum G 𝓟 root (Penrose.completeGraphTreeParentCode n T)
+        (Finset.univ : Finset (Fin n))
+        (rootedParentActiveClosed_univ (Penrose.completeGraphTreeParentCode n T))
+        (fun _ => 0) t
+      ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+          * fixedVertexRootedGasParentActivePeelBound G 𝓟 c root
+              (Penrose.completeGraphTreeParentCode n T)
+              (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
+  have h := fixedVertexRootedGasParentActiveSum_le_pow_mul_childCount_bound G hgas hc hsupp root
+    (fun hB => completeGraphTreeParentCode_exists_active_leaf hB T)
+    (Finset.univ : Finset (Fin n))
+    (rootedParentActiveClosed_univ (Penrose.completeGraphTreeParentCode n T)) (fun _ => 0) hkp
+  rwa [Finset.card_univ, Fintype.card_fin] at h
+
+/-- The complete-tree fixed-root active sum is bounded by the weighted fixed-root peel bound.
+Even-gas (`c = 1`) instance of
+`fixedVertexRootedGasParentActiveSum_completeTree_univ_zero_le_pow_mul_peelBound`. -/
 theorem fixedVertexRootedParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound
     (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι) (n : ℕ)
     (T : {S : Finset (Sym2 (Fin (n + 1))) //
@@ -441,27 +619,28 @@ theorem fixedVertexRootedParentActiveSum_completeGraphTreeParentCode_univ_zero_l
           * fixedVertexRootedParentActivePeelBound G root
               (Penrose.completeGraphTreeParentCode n T)
               (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
-  have h := fixedVertexRootedParentActiveSum_le_pow_mul_childCount_bound G root
-    (fun hB => completeGraphTreeParentCode_exists_active_leaf hB T)
-    (Finset.univ : Finset (Fin n))
-    (rootedParentActiveClosed_univ (Penrose.completeGraphTreeParentCode n T)) (fun _ => 0) hkp
-  rwa [Finset.card_univ, Fintype.card_fin] at h
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  simpa [fixedVertexRootedParentActiveSum, fixedVertexRootedParentActivePeelBound] using
+    fixedVertexRootedGasParentActiveSum_completeTree_univ_zero_le_pow_mul_peelBound G
+      (evenPolymerGasData G) zero_le_one hsupp root n T hkp
 
-/-- Fubini swap of the fixed-root Penrose tree sum, retaining the root filter. -/
-theorem fixedVertexRoot_penroseTreeSum_le_subtype_parentConstraint
-    (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) (n : ℕ)
+/-- Fubini swap of the fixed-root Penrose tree gas sum, retaining the root filter. -/
+theorem fixedVertexGasRoot_penroseTreeSum_le_subtype_parentConstraint
+    (𝓟 : Finset (Finset (Sym2 ι))) (v : ι) (n : ℕ)
     (W : (Fin (n + 1) → Finset (Sym2 ι)) → ℝ) (hW : ∀ ω, 0 ≤ W ω) :
-    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => v ∈ polymerSupport (ω 0)),
         ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω), W ω)
       ≤ ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
             S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
-          ∑ ω ∈ ((Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          ∑ ω ∈ ((Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
               (fun ω => v ∈ polymerSupport (ω 0))).filter
             (fun ω => ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
               (ω (Penrose.completeGraphTreeParentCode n T i))), W ω := by
   classical
-  set P := (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+  set P := (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
     (fun ω => v ∈ polymerSupport (ω 0)) with hP
   have hinner : ∀ ω, (∑ _T ∈ Penrose.spanningTreeEdgeSubsets
         (polymerSeqIncompatibilityGraph ω), W ω)
@@ -497,11 +676,31 @@ theorem fixedVertexRoot_penroseTreeSum_le_subtype_parentConstraint
           Finset.sum_le_sum fun T _ =>
             sum_filter_treeIncompat_le_filter_parentConstraint n T P W hW
 
-/-- The fixed-root Penrose tree sum is bounded by the weighted fixed-root peel bound. -/
-theorem fixedVertexRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound
-    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) (n : ℕ) {t : ℝ}
-    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+/-- Fubini swap of the fixed-root Penrose tree sum, retaining the root filter.  Even-gas
+instance of `fixedVertexGasRoot_penroseTreeSum_le_subtype_parentConstraint`. -/
+theorem fixedVertexRoot_penroseTreeSum_le_subtype_parentConstraint
+    (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) (n : ℕ)
+    (W : (Fin (n + 1) → Finset (Sym2 ι)) → ℝ) (hW : ∀ ω, 0 ≤ W ω) :
     (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (fun ω => v ∈ polymerSupport (ω 0)),
+        ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω), W ω)
+      ≤ ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
+            S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
+          ∑ ω ∈ ((Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+              (fun ω => v ∈ polymerSupport (ω 0))).filter
+            (fun ω => ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
+              (ω (Penrose.completeGraphTreeParentCode n T i))), W ω :=
+  fixedVertexGasRoot_penroseTreeSum_le_subtype_parentConstraint (allPolymers G) v n W hW
+
+/-- The fixed-root Penrose tree gas sum is bounded by the weighted fixed-root gas peel
+bound. -/
+theorem fixedVertexGasRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) {c : ℝ} (hc : 0 ≤ c)
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (v : ι) (n : ℕ)
+    {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => v ∈ polymerSupport (ω 0)),
         ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω),
           |t| ^ (ω 0).card
@@ -510,7 +709,7 @@ theorem fixedVertexRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound
       ≤ ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
             S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
           ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
-            * fixedVertexRootedParentActivePeelBound G v
+            * fixedVertexRootedGasParentActivePeelBound G 𝓟 c v
                 (Penrose.completeGraphTreeParentCode n T) (Finset.univ : Finset (Fin n))
                 (fun _ => 0) t := by
   have hWle : ∀ ω : Fin (n + 1) → Finset (Sym2 ι),
@@ -526,48 +725,119 @@ theorem fixedVertexRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound
     refine mul_le_mul_of_nonneg_right ?_ (by positivity)
     refine pow_le_pow_left₀ (abs_nonneg t) ?_ _
     exact le_mul_of_one_le_left (abs_nonneg t) (Real.one_le_exp_iff.mpr zero_le_one)
-  refine (fixedVertexRoot_penroseTreeSum_le_subtype_parentConstraint G v n
+  refine (fixedVertexGasRoot_penroseTreeSum_le_subtype_parentConstraint 𝓟 v n
     (fun ω => |t| ^ (ω 0).card
       * ∏ i : Fin n, Real.exp 1 ^ (ω (Fin.succ i)).card
         * |t| ^ (ω (Fin.succ i)).card)
     (fun ω => by positivity)).trans ?_
   refine Finset.sum_le_sum fun T _ => ?_
   calc
-    (∑ ω ∈ ((Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+    (∑ ω ∈ ((Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
         (fun ω => v ∈ polymerSupport (ω 0))).filter
         (fun ω => ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
           (ω (Penrose.completeGraphTreeParentCode n T i))),
         |t| ^ (ω 0).card
           * ∏ i : Fin n, Real.exp 1 ^ (ω (Fin.succ i)).card
             * |t| ^ (ω (Fin.succ i)).card)
-        ≤ ∑ ω ∈ ((Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+        ≤ ∑ ω ∈ ((Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
             (fun ω => v ∈ polymerSupport (ω 0))).filter
             (fun ω => ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
               (ω (Penrose.completeGraphTreeParentCode n T i))),
             ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card :=
           Finset.sum_le_sum fun ω _ => hWle ω
-    _ = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+    _ = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
             (fun ω => v ∈ polymerSupport (ω 0)),
           if ∀ i : Fin n, PolymersIncompatible (ω (Fin.succ i))
               (ω (Penrose.completeGraphTreeParentCode n T i)) then
             ∏ v : Fin (n + 1), (Real.exp 1 * |t|) ^ (ω v).card
           else 0 := by
           rw [Finset.sum_filter]
-    _ = fixedVertexRootedParentActiveSum G v (Penrose.completeGraphTreeParentCode n T)
+    _ = fixedVertexRootedGasParentActiveSum G 𝓟 v (Penrose.completeGraphTreeParentCode n T)
           (Finset.univ : Finset (Fin n))
           (rootedParentActiveClosed_univ (Penrose.completeGraphTreeParentCode n T))
           (fun _ => 0) t :=
-          (fixedVertexRootedParentActiveSum_univ_zero_eq G v
+          (fixedVertexRootedGasParentActiveSum_univ_zero_eq G 𝓟 v
             (Penrose.completeGraphTreeParentCode n T) t).symm
     _ ≤ ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
-          * fixedVertexRootedParentActivePeelBound G v
+          * fixedVertexRootedGasParentActivePeelBound G 𝓟 c v
               (Penrose.completeGraphTreeParentCode n T)
               (Finset.univ : Finset (Fin n)) (fun _ => 0) t := by
       exact
-        fixedVertexRootedParentActiveSum_completeGraphTreeParentCode_univ_zero_le_pow_mul_peelBound
-          G v n T hkp
+        fixedVertexRootedGasParentActiveSum_completeTree_univ_zero_le_pow_mul_peelBound
+          G hgas hc hsupp v n T hkp
 
-/-- Fixed-root per-order geometric bound for the root-at-`0` term-absolute sum. -/
+/-- The fixed-root Penrose tree sum is bounded by the weighted fixed-root peel bound.
+Even-gas (`c = 1`) instance of
+`fixedVertexGasRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound`. -/
+theorem fixedVertexRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) (n : ℕ) {t : ℝ}
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (fun ω => v ∈ polymerSupport (ω 0)),
+        ∑ _T ∈ Penrose.spanningTreeEdgeSubsets (polymerSeqIncompatibilityGraph ω),
+          |t| ^ (ω 0).card
+            * ∏ i : Fin n, Real.exp 1 ^ (ω (Fin.succ i)).card
+              * |t| ^ (ω (Fin.succ i)).card)
+      ≤ ∑ T : {S : Finset (Sym2 (Fin (n + 1))) //
+            S ∈ Penrose.spanningTreeEdgeSubsets (⊤ : SimpleGraph (Fin (n + 1)))},
+          ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ n
+            * fixedVertexRootedParentActivePeelBound G v
+                (Penrose.completeGraphTreeParentCode n T) (Finset.univ : Finset (Fin n))
+                (fun _ => 0) t := by
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  simpa [fixedVertexRootedParentActivePeelBound] using
+    fixedVertexGasRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound G (evenPolymerGasData G)
+      zero_le_one hsupp v n hkp
+
+/-- Fixed-root per-order geometric bound for the root-at-`0` term-absolute gas sum. -/
+theorem fixedVertexGasRoot_termAbsSum_succ_le_div_mul_geometric
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) {c : ℝ} (hc : 0 ≤ c)
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (v : ι) (n : ℕ)
+    {t : ℝ} (ht : 0 ≤ t)
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+          (fun ω => v ∈ polymerSupport (ω 0)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+      ≤ (1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
+        * (4 * c * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+            / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2) ^ n := by
+  set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
+  set q : ℝ := 1 - rr with hq
+  have hqpos : 0 < q := by rw [hq]; linarith [hkp]
+  have hrr0 : 0 ≤ rr := by rw [hrr]; positivity
+  refine (fixedVertexGasRoot_termAbsSum_succ_le_treeSum_rootedExpActivity 𝓟 v n ht).trans ?_
+  refine (mul_le_mul_of_nonneg_left
+    (fixedVertexGasRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound G hgas hc hsupp v n hkp)
+    (by positivity)).trans ?_
+  refine (mul_le_mul_of_nonneg_left
+    (sum_pow_fixedVertexRootedGasParentActivePeelBound_le G hgas c hc v n hkp)
+    (by positivity)).trans ?_
+  have hfact : ((n + 1).factorial : ℝ)⁻¹ * (n.factorial : ℝ) ≤ 1 := by
+    rw [← div_eq_inv_mul, div_le_one (by positivity)]
+    exact_mod_cast Nat.factorial_le (Nat.le_succ n)
+  have hq2 : q ^ (2 * n + 1) = (q ^ 2) ^ n * q := by
+    rw [pow_succ, pow_mul]
+  have hgoal_nonneg : (0 : ℝ) ≤ (1 / q) * (4 * c * rr / q ^ 2) ^ n := by positivity
+  have hLHS : ((n + 1).factorial : ℝ)⁻¹
+        * ((rr ^ n * c ^ n * (4 : ℝ) ^ n * (n.factorial : ℝ)) / q ^ (2 * n + 1))
+      = (((n + 1).factorial : ℝ)⁻¹ * (n.factorial : ℝ))
+          * ((1 : ℝ) / q * (4 * c * rr / q ^ 2) ^ n) := by
+    rw [div_pow, mul_pow, mul_pow, hq2]
+    field_simp
+    ring
+  rw [hLHS]
+  calc
+    (((n + 1).factorial : ℝ)⁻¹ * (n.factorial : ℝ))
+        * ((1 : ℝ) / q * (4 * c * rr / q ^ 2) ^ n)
+        ≤ 1 * ((1 : ℝ) / q * (4 * c * rr / q ^ 2) ^ n) :=
+          mul_le_mul_of_nonneg_right hfact hgoal_nonneg
+    _ = (1 : ℝ) / q * (4 * c * rr / q ^ 2) ^ n := one_mul _
+
+/-- Fixed-root per-order geometric bound for the root-at-`0` term-absolute sum.  Even-gas
+(`c = 1`) instance of `fixedVertexGasRoot_termAbsSum_succ_le_div_mul_geometric`. -/
 theorem fixedVertexRoot_termAbsSum_succ_le_div_mul_geometric
     (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) (n : ℕ) {t : ℝ}
     (ht : 0 ≤ t)
@@ -578,35 +848,11 @@ theorem fixedVertexRoot_termAbsSum_succ_le_div_mul_geometric
       ≤ (1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
         * (4 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
             / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2) ^ n := by
-  set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
-  set q : ℝ := 1 - rr with hq
-  have hqpos : 0 < q := by rw [hq]; linarith [hkp]
-  have hrr0 : 0 ≤ rr := by rw [hrr]; positivity
-  refine (fixedVertexRoot_termAbsSum_succ_le_treeSum_rootedExpActivity G v n ht).trans ?_
-  refine (mul_le_mul_of_nonneg_left
-    (fixedVertexRoot_penroseTreeSum_le_sum_pow_fixedVertexPeelBound G v n hkp)
-    (by positivity)).trans ?_
-  refine (mul_le_mul_of_nonneg_left
-    (sum_pow_fixedVertexRootedParentActivePeelBound_le G v n hkp) (by positivity)).trans ?_
-  have hfact : ((n + 1).factorial : ℝ)⁻¹ * (n.factorial : ℝ) ≤ 1 := by
-    rw [← div_eq_inv_mul, div_le_one (by positivity)]
-    exact_mod_cast Nat.factorial_le (Nat.le_succ n)
-  have hq2 : q ^ (2 * n + 1) = (q ^ 2) ^ n * q := by
-    rw [pow_succ, pow_mul]
-  have hgoal_nonneg : (0 : ℝ) ≤ (1 / q) * (4 * rr / q ^ 2) ^ n := by positivity
-  have hLHS : ((n + 1).factorial : ℝ)⁻¹
-        * ((rr ^ n * (4 : ℝ) ^ n * (n.factorial : ℝ)) / q ^ (2 * n + 1))
-      = (((n + 1).factorial : ℝ)⁻¹ * (n.factorial : ℝ))
-          * ((1 : ℝ) / q * (4 * rr / q ^ 2) ^ n) := by
-    rw [div_pow, mul_pow, hq2]
-    field_simp
-    ring
-  rw [hLHS]
-  calc
-    (((n + 1).factorial : ℝ)⁻¹ * (n.factorial : ℝ))
-        * ((1 : ℝ) / q * (4 * rr / q ^ 2) ^ n)
-        ≤ 1 * ((1 : ℝ) / q * (4 * rr / q ^ 2) ^ n) :=
-          mul_le_mul_of_nonneg_right hfact hgoal_nonneg
-    _ = (1 : ℝ) / q * (4 * rr / q ^ 2) ^ n := one_mul _
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  have h := fixedVertexGasRoot_termAbsSum_succ_le_div_mul_geometric G (evenPolymerGasData G)
+    zero_le_one hsupp v n ht hkp
+  simpa using h
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/FixedVertexPeelBound.lean
+++ b/IsingModel/ClusterExpansion/FixedVertexPeelBound.lean
@@ -16,32 +16,46 @@ open Finset
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ℕ}
 
+/-- **The fixed-vertex child-count gas peel bound.** The gas-parametrized fixed-root peel
+bound: the non-root active vertices each carry a support-bump factor `c` (as in
+`rootedGasParentActivePeelBound`), and the root moment is restricted to gas polymers (from
+`𝓟`) whose support contains the fixed vertex `root`. The even gas (`allPolymers G`) takes
+`c = 1` in `fixedVertexRootedParentActivePeelBound`. -/
+noncomputable def fixedVertexRootedGasParentActivePeelBound (G : SimpleGraph ι)
+    [DecidableRel G.Adj] [Fintype G.edgeSet] (𝓟 : Finset (Finset (Sym2 ι))) (c : ℝ)
+    (root : ι) (par : Fin n → Fin (n + 1))
+    (A : Finset (Fin n)) (k : Fin (n + 1) → ℕ) (t : ℝ) : ℝ :=
+  (∏ j ∈ A, c * rootedParentPeelFactor G t
+      (k (Fin.succ j) + rootedParentChildCount par A (Fin.succ j)))
+    * ∑ P ∈ rootedGasPolymers 𝓟 root,
+        (P.card : ℝ) ^ (k 0 + rootedParentChildCount par A 0) * (Real.exp 1 * |t|) ^ P.card
+
 /-- **The fixed-vertex child-count peel bound.** This is the same expression as
 `rootedParentActivePeelBound`, except that the root moment is restricted to polymers whose
-support contains the fixed vertex `root`. -/
+support contains the fixed vertex `root`. Even-gas (`allPolymers G`, `c = 1`) instance of
+`fixedVertexRootedGasParentActivePeelBound`. -/
 noncomputable def fixedVertexRootedParentActivePeelBound (G : SimpleGraph ι)
     [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι) (par : Fin n → Fin (n + 1))
     (A : Finset (Fin n)) (k : Fin (n + 1) → ℕ) (t : ℝ) : ℝ :=
-  (∏ j ∈ A, rootedParentPeelFactor G t
-      (k (Fin.succ j) + rootedParentChildCount par A (Fin.succ j)))
-    * ∑ P ∈ rootedPolymers G root,
-        (P.card : ℝ) ^ (k 0 + rootedParentChildCount par A 0) * (Real.exp 1 * |t|) ^ P.card
+  fixedVertexRootedGasParentActivePeelBound G (allPolymers G) 1 root par A k t
 
-/-- **Fixed-vertex factorial-product peel bound.** For the full active set, exponent `0`,
-and `0 < 1 − Δ²e|t|`, the fixed-vertex child-count peel bound is at most
-`(∏_v (childCount v)!)/(1 − Δ²e|t|)^{2n+1}`. Compared with
-`rootedParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div`, the only
-change is the root-moment estimate: `rootedPolymerActivity_cardPow_le` is used for the fixed
-vertex `root`, so no factor `Fintype.card ι` appears. -/
-theorem fixedVertexRootedParentActivePeelBound_univ_zero_le_prod_childCount_factorial_div
-    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι)
+/-- **Fixed-vertex factorial-product gas peel bound.** For the full active set, exponent
+`0`, `0 < 1 − Δ²e|t|`, and `0 ≤ c`, the fixed-vertex child-count gas peel bound is at most
+`c^n·(∏_v (childCount v)!)/(1 − Δ²e|t|)^{2n+1}`. Compared with
+`rootedGasParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div`, the
+only change is the root-moment estimate: `rootedGasPolymerActivity_cardPow_le` is used for
+the fixed vertex `root`, so no factor `Fintype.card ι` appears. The even gas takes `c = 1`
+in `fixedVertexRootedParentActivePeelBound_univ_zero_le_prod_childCount_factorial_div`. -/
+theorem fixedVertexRootedGasParentActivePeelBound_univ_zero_le_prod_childCount_factorial_div
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) (c : ℝ) (hc : 0 ≤ c) (root : ι)
     (par : Fin n → Fin (n + 1)) {t : ℝ}
     (hpos : 0 < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) :
-    fixedVertexRootedParentActivePeelBound G root par (Finset.univ : Finset (Fin n))
+    fixedVertexRootedGasParentActivePeelBound G 𝓟 c root par (Finset.univ : Finset (Fin n))
         (fun _ => 0) t
-      ≤ (∏ v : Fin (n + 1),
+      ≤ c ^ n * ((∏ v : Fin (n + 1),
               ((rootedParentChildCount par (Finset.univ : Finset (Fin n)) v).factorial : ℝ))
-          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1) := by
+          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1)) := by
   classical
   set q : ℝ := 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hq
   set d : Fin (n + 1) → ℕ :=
@@ -57,11 +71,11 @@ theorem fixedVertexRootedParentActivePeelBound_univ_zero_le_prod_childCount_fact
           / q ^ (∑ j : Fin n, (d (Fin.succ j) + 1)) := by
     simp only [rootedParentPeelFactor, ← hq]
     rw [Finset.prod_div_distrib, Finset.prod_pow_eq_pow_sum]
-  have hroot : (∑ P ∈ rootedPolymers G root,
+  have hroot : (∑ P ∈ rootedGasPolymers 𝓟 root,
         (P.card : ℝ) ^ d 0 * (Real.exp 1 * |t|) ^ P.card)
       ≤ ((d 0).factorial : ℝ) / q ^ (d 0 + 1) := by
     simpa [hq] using
-      rootedPolymerActivity_cardPow_le G root (d 0) (by positivity)
+      rootedGasPolymerActivity_cardPow_le G hgas root (d 0) (by positivity)
         (u := Real.exp 1 * |t|) hkp
   have hexp : (∑ j : Fin n, (d (Fin.succ j) + 1)) + (d 0 + 1) = 2 * n + 1 := by
     have hsplit : d 0 + ∑ j : Fin n, d (Fin.succ j) = n := by
@@ -72,18 +86,46 @@ theorem fixedVertexRootedParentActivePeelBound_univ_zero_le_prod_childCount_fact
   have hnum : ((d 0).factorial : ℝ) * (∏ j : Fin n, ((d (Fin.succ j)).factorial : ℝ))
       = ∏ v : Fin (n + 1), ((d v).factorial : ℝ) :=
     (Fin.prod_univ_succ (fun v : Fin (n + 1) => ((d v).factorial : ℝ))).symm
-  rw [fixedVertexRootedParentActivePeelBound]
+  have heven : (∏ j : Fin n, rootedParentPeelFactor G t (d (Fin.succ j)))
+        * (((d 0).factorial : ℝ) / q ^ (d 0 + 1))
+      = (∏ v : Fin (n + 1), ((d v).factorial : ℝ)) / q ^ (2 * n + 1) := by
+    rw [hprod, ← hnum, ← hexp, pow_add]
+    field_simp
+    ring
+  have hprodc : (∏ j : Fin n, c * rootedParentPeelFactor G t (d (Fin.succ j)))
+      = c ^ n * ∏ j : Fin n, rootedParentPeelFactor G t (d (Fin.succ j)) := by
+    rw [Finset.prod_mul_distrib, Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+  rw [fixedVertexRootedGasParentActivePeelBound]
   simp only [Nat.zero_add, ← hd]
   calc
-    (∏ j : Fin n, rootedParentPeelFactor G t (d (Fin.succ j)))
-        * ∑ P ∈ rootedPolymers G root, (P.card : ℝ) ^ d 0 * (Real.exp 1 * |t|) ^ P.card
-        ≤ (∏ j : Fin n, rootedParentPeelFactor G t (d (Fin.succ j)))
+    (∏ j : Fin n, c * rootedParentPeelFactor G t (d (Fin.succ j)))
+        * ∑ P ∈ rootedGasPolymers 𝓟 root, (P.card : ℝ) ^ d 0 * (Real.exp 1 * |t|) ^ P.card
+        ≤ (∏ j : Fin n, c * rootedParentPeelFactor G t (d (Fin.succ j)))
             * (((d 0).factorial : ℝ) / q ^ (d 0 + 1)) := by
           refine mul_le_mul_of_nonneg_left hroot ?_
-          exact Finset.prod_nonneg fun j _ => rootedParentPeelFactor_nonneg G hkp _
-    _ = (∏ v : Fin (n + 1), ((d v).factorial : ℝ)) / q ^ (2 * n + 1) := by
-          rw [hprod, ← hnum, ← hexp, pow_add]
-          field_simp
-          ring
+          exact Finset.prod_nonneg fun j _ =>
+            mul_nonneg hc (rootedParentPeelFactor_nonneg G hkp _)
+    _ = c ^ n * ((∏ v : Fin (n + 1), ((d v).factorial : ℝ)) / q ^ (2 * n + 1)) := by
+          rw [hprodc, mul_assoc, heven]
+
+/-- **Fixed-vertex factorial-product peel bound.** For the full active set, exponent `0`,
+and `0 < 1 − Δ²e|t|`, the fixed-vertex child-count peel bound is at most
+`(∏_v (childCount v)!)/(1 − Δ²e|t|)^{2n+1}`. Compared with
+`rootedParentActivePeelBound_univ_zero_le_card_mul_prod_childCount_factorial_div`, the only
+change is the root-moment estimate: `rootedPolymerActivity_cardPow_le` is used for the fixed
+vertex `root`, so no factor `Fintype.card ι` appears. Even-gas (`c = 1`) instance of
+`fixedVertexRootedGasParentActivePeelBound_univ_zero_le_prod_childCount_factorial_div`. -/
+theorem fixedVertexRootedParentActivePeelBound_univ_zero_le_prod_childCount_factorial_div
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (root : ι)
+    (par : Fin n → Fin (n + 1)) {t : ℝ}
+    (hpos : 0 < 1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) :
+    fixedVertexRootedParentActivePeelBound G root par (Finset.univ : Finset (Fin n))
+        (fun _ => 0) t
+      ≤ (∏ v : Fin (n + 1),
+              ((rootedParentChildCount par (Finset.univ : Finset (Fin n)) v).factorial : ℝ))
+          / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ (2 * n + 1) := by
+  have h := fixedVertexRootedGasParentActivePeelBound_univ_zero_le_prod_childCount_factorial_div
+    G (evenPolymerGasData G) 1 zero_le_one root par hpos
+  simpa [fixedVertexRootedParentActivePeelBound] using h
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/FixedVertexTouchingPerOrder.lean
+++ b/IsingModel/ClusterExpansion/FixedVertexTouchingPerOrder.lean
@@ -46,19 +46,21 @@ theorem clusterSeqActivity_comp_equiv {n : ℕ} (t : ℝ)
   exact Equiv.prod_comp e (fun i => t ^ (ω i).card)
 
 open Classical in
-/-- **A fixed coordinate touching `v` has the same term-absolute sum as the root coordinate.**
-The proof reindexes the constant `piFinset` by the transposition swapping `0` and `i`; the Ursell
-coefficient and activity are invariant under this coordinate permutation. -/
-theorem fixedVertexCoordRoot_termAbsSum_succ_eq
-    (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) (n : ℕ) (t : ℝ) (i : Fin (n + 1)) :
-    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+/-- **A fixed coordinate touching `v` has the same term-absolute gas sum as the root
+coordinate.**  The proof reindexes the constant `piFinset` (over the abstract gas `𝓟`) by the
+transposition swapping `0` and `i`; the Ursell coefficient and activity are invariant under
+this coordinate permutation.  This step is purely structural, so it needs no gas hypotheses;
+the even gas (`allPolymers G`) is recovered by `fixedVertexCoordRoot_termAbsSum_succ_eq`. -/
+theorem fixedVertexGasCoordRoot_termAbsSum_succ_eq
+    (𝓟 : Finset (Finset (Sym2 ι))) (v : ι) (n : ℕ) (t : ℝ) (i : Fin (n + 1)) :
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => v ∈ polymerSupport (ω i)),
         |ursellCoefficient ω| * clusterSeqActivity t ω)
-      = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+      = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => v ∈ polymerSupport (ω 0)),
         |ursellCoefficient ω| * clusterSeqActivity t ω := by
   classical
-  let S := Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)
+  let S := Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)
   let e : Fin (n + 1) ≃ Fin (n + 1) := Equiv.swap 0 i
   let a : (Fin (n + 1) → Finset (Sym2 ι)) → ℝ :=
     fun ω => |ursellCoefficient ω| * clusterSeqActivity t ω
@@ -72,11 +74,11 @@ theorem fixedVertexCoordRoot_termAbsSum_succ_eq
     intro ω
     dsimp [e]
     simp
-  have hreindex := sum_piFinset_const_domEquiv e (allPolymers G)
+  have hreindex := sum_piFinset_const_domEquiv e 𝓟
     (fun ω : Fin (n + 1) → Finset (Sym2 ι) =>
       if v ∈ polymerSupport (ω i) then a ω else 0)
   calc
-    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => v ∈ polymerSupport (ω i)),
         |ursellCoefficient ω| * clusterSeqActivity t ω)
         = ∑ ω ∈ S, if v ∈ polymerSupport (ω i) then a ω else 0 := by
@@ -92,16 +94,82 @@ theorem fixedVertexCoordRoot_termAbsSum_succ_eq
           by_cases h : v ∈ polymerSupport (ω 0)
           · rw [if_pos h, if_pos ((hpred ω).mpr h), hterm]
           · rw [if_neg h, if_neg (fun h' => h ((hpred ω).mp h'))]
-    _ = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+    _ = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => v ∈ polymerSupport (ω 0)),
         |ursellCoefficient ω| * clusterSeqActivity t ω := by
           dsimp [S, a]
           rw [Finset.sum_filter]
 
+/-- **A fixed coordinate touching `v` has the same term-absolute sum as the root coordinate.**
+Even-gas (`allPolymers G`) instance of `fixedVertexGasCoordRoot_termAbsSum_succ_eq`. -/
+theorem fixedVertexCoordRoot_termAbsSum_succ_eq
+    (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) (n : ℕ) (t : ℝ) (i : Fin (n + 1)) :
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (fun ω => v ∈ polymerSupport (ω i)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+      = ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (fun ω => v ∈ polymerSupport (ω 0)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω :=
+  fixedVertexGasCoordRoot_termAbsSum_succ_eq (allPolymers G) v n t i
+
 open Classical in
+/-- **Fixed-vertex touching per-order gas bound.**  The touching sum (over the abstract gas
+`𝓟`) is bounded by the coordinate union bound, each coordinate-rooted sum is reindexed to the
+root coordinate, and the fixed-root Kotecky--Preiss estimate supplies the common geometric
+bound with support-bump constant `c` (so the geometric ratio is `4·c·Δ²e|t|/(1−Δ²e|t|)²`).
+The even gas (`allPolymers G`, `c = 1`) is recovered by
+`fixedVertexTouching_termAbsSum_succ_le_nat_mul_geometric`. -/
+theorem fixedVertexGasTouching_termAbsSum_succ_le_nat_mul_geometric
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) {c : ℝ} (hc : 0 ≤ c)
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (v : ι) (n : ℕ)
+    {t : ℝ} (ht : 0 ≤ t)
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1) :
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+      ≤ ((n + 1 : ℕ) : ℝ)
+        * ((1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
+          * (4 * c * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+              / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2) ^ n) := by
+  classical
+  let B : ℝ := (1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
+    * (4 * c * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+        / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2) ^ n
+  have htouch :
+      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+            (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+          |ursellCoefficient ω| * clusterSeqActivity t ω)
+        ≤ ∑ i : Fin (n + 1),
+          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+              (fun ω => v ∈ polymerSupport (ω i)),
+            |ursellCoefficient ω| * clusterSeqActivity t ω := by
+    have h := fixedVertexGasTouching_termAbsSum_succ_le_sum_coord_rooted 𝓟 v n (t : ℂ)
+    simpa [Complex.norm_real, Real.norm_eq_abs, clusterSeqActivity, abs_of_nonneg ht] using h
+  have hcoord :
+      (∑ i : Fin (n + 1),
+          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+              (fun ω => v ∈ polymerSupport (ω i)),
+            |ursellCoefficient ω| * clusterSeqActivity t ω)
+        ≤ ∑ _i : Fin (n + 1), B := by
+    refine Finset.sum_le_sum fun i _ => ?_
+    rw [fixedVertexGasCoordRoot_termAbsSum_succ_eq 𝓟 v n t i]
+    exact fixedVertexGasRoot_termAbsSum_succ_le_div_mul_geometric G hgas hc hsupp v n ht hkp
+  calc
+    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+        ≤ ∑ i : Fin (n + 1),
+          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+              (fun ω => v ∈ polymerSupport (ω i)),
+            |ursellCoefficient ω| * clusterSeqActivity t ω := htouch
+    _ ≤ ∑ _i : Fin (n + 1), B := hcoord
+    _ = ((n + 1 : ℕ) : ℝ) * B := by simp [B]
+
 /-- **Fixed-vertex touching per-order bound.**  The touching sum is bounded by the coordinate
 union bound, each coordinate-rooted sum is reindexed to the root coordinate, and the fixed-root
-Kotecky--Preiss estimate supplies the common geometric bound. -/
+Kotecky--Preiss estimate supplies the common geometric bound.  Even-gas (`c = 1`) instance of
+`fixedVertexGasTouching_termAbsSum_succ_le_nat_mul_geometric`. -/
 theorem fixedVertexTouching_termAbsSum_succ_le_nat_mul_geometric
     (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) (n : ℕ) {t : ℝ}
     (ht : 0 ≤ t)
@@ -113,38 +181,11 @@ theorem fixedVertexTouching_termAbsSum_succ_le_nat_mul_geometric
         * ((1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
           * (4 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
               / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2) ^ n) := by
-  classical
-  let B : ℝ := (1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
-    * (4 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
-        / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2) ^ n
-  have htouch :
-      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
-            (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
-          |ursellCoefficient ω| * clusterSeqActivity t ω)
-        ≤ ∑ i : Fin (n + 1),
-          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
-              (fun ω => v ∈ polymerSupport (ω i)),
-            |ursellCoefficient ω| * clusterSeqActivity t ω := by
-    have h := fixedVertexTouching_termAbsSum_succ_le_sum_coord_rooted G v n (t : ℂ)
-    simpa [Complex.norm_real, Real.norm_eq_abs, clusterSeqActivity, abs_of_nonneg ht] using h
-  have hcoord :
-      (∑ i : Fin (n + 1),
-          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
-              (fun ω => v ∈ polymerSupport (ω i)),
-            |ursellCoefficient ω| * clusterSeqActivity t ω)
-        ≤ ∑ _i : Fin (n + 1), B := by
-    refine Finset.sum_le_sum fun i _ => ?_
-    rw [fixedVertexCoordRoot_termAbsSum_succ_eq G v n t i]
-    exact fixedVertexRoot_termAbsSum_succ_le_div_mul_geometric G v n ht hkp
-  calc
-    (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
-          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
-        |ursellCoefficient ω| * clusterSeqActivity t ω)
-        ≤ ∑ i : Fin (n + 1),
-          ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
-              (fun ω => v ∈ polymerSupport (ω i)),
-            |ursellCoefficient ω| * clusterSeqActivity t ω := htouch
-    _ ≤ ∑ _i : Fin (n + 1), B := hcoord
-    _ = ((n + 1 : ℕ) : ℝ) * B := by simp [B]
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  have h := fixedVertexGasTouching_termAbsSum_succ_le_nat_mul_geometric G (evenPolymerGasData G)
+    zero_le_one hsupp v n ht hkp
+  simpa using h
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/FixedVertexTouchingUnion.lean
+++ b/IsingModel/ClusterExpansion/FixedVertexTouchingUnion.lean
@@ -27,22 +27,25 @@ open Finset
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
 open Classical in
-/-- **Coordinate union bound for fixed-vertex touching cluster sequences.**  The absolute Mayer sum
-over cluster sequences in which *some* coordinate touches the vertex `v` is bounded by the sum over
-coordinates `i` of the absolute Mayer sum over sequences whose `i`-th coordinate touches `v`. -/
-theorem fixedVertexTouching_termAbsSum_succ_le_sum_coord_rooted
-    (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) (n : ℕ) (z : ℂ) :
+/-- **Coordinate union bound for fixed-vertex touching cluster sequences (gas form).**  The
+absolute Mayer sum over cluster sequences of an abstract gas `𝓟` in which *some* coordinate
+touches the vertex `v` is bounded by the sum over coordinates `i` of the absolute Mayer sum
+over sequences whose `i`-th coordinate touches `v`.  This step is purely structural, so it
+needs no gas hypotheses; the even gas (`allPolymers G`) is recovered by
+`fixedVertexTouching_termAbsSum_succ_le_sum_coord_rooted`. -/
+theorem fixedVertexGasTouching_termAbsSum_succ_le_sum_coord_rooted
+    (𝓟 : Finset (Finset (Sym2 ι))) (v : ι) (n : ℕ) (z : ℂ) :
     (∑ ω ∈
-        (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+        (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
         ‖(ursellCoefficient ω : ℂ)‖ * ∏ i, ‖z‖ ^ (ω i).card)
       ≤ ∑ i : Fin (n + 1),
         ∑ ω ∈
-          (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
             (fun ω => v ∈ polymerSupport (ω i)),
           ‖(ursellCoefficient ω : ℂ)‖ * ∏ j, ‖z‖ ^ (ω j).card := by
   classical
-  set S := Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G) with hS
+  set S := Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟) with hS
   set a : (Fin (n + 1) → Finset (Sym2 ι)) → ℝ :=
     fun ω => ‖(ursellCoefficient ω : ℂ)‖ * ∏ j, ‖z‖ ^ (ω j).card with ha
   have hanonneg : ∀ ω, 0 ≤ a ω := by
@@ -71,5 +74,23 @@ theorem fixedVertexTouching_termAbsSum_succ_le_sum_coord_rooted
             change (0 : ℝ) ≤ if v ∈ polymerSupport (ω k) then a ω else 0
             split_ifs with h; exacts [hanonneg ω, le_refl 0])
           (Finset.mem_univ i)
+
+/-- **Coordinate union bound for fixed-vertex touching cluster sequences.**  The absolute Mayer sum
+over cluster sequences in which *some* coordinate touches the vertex `v` is bounded by the sum over
+coordinates `i` of the absolute Mayer sum over sequences whose `i`-th coordinate touches `v`.
+Even-gas (`allPolymers G`) instance of the gas version
+`fixedVertexGasTouching_termAbsSum_succ_le_sum_coord_rooted`. -/
+theorem fixedVertexTouching_termAbsSum_succ_le_sum_coord_rooted
+    (G : SimpleGraph ι) [Fintype G.edgeSet] (v : ι) (n : ℕ) (z : ℂ) :
+    (∑ ω ∈
+        (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+        ‖(ursellCoefficient ω : ℂ)‖ * ∏ i, ‖z‖ ^ (ω i).card)
+      ≤ ∑ i : Fin (n + 1),
+        ∑ ω ∈
+          (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+            (fun ω => v ∈ polymerSupport (ω i)),
+          ‖(ursellCoefficient ω : ℂ)‖ * ∏ j, ‖z‖ ^ (ω j).card :=
+  fixedVertexGasTouching_termAbsSum_succ_le_sum_coord_rooted (allPolymers G) v n z
 
 end IsingModel

--- a/IsingModel/ClusterExpansion/MayerSumDiffSupportBound.lean
+++ b/IsingModel/ClusterExpansion/MayerSumDiffSupportBound.lean
@@ -30,28 +30,31 @@ theorem tsum_nat_succ_mul_geometric_eq_inv_sq {ρ : ℝ} (hρ0 : 0 ≤ ρ) (hρ 
   field_simp [h1]
   ring
 
-/-- **Summability of the fixed-vertex touching majorant.**  The per-order fixed-vertex touching
-bound is dominated by `(1-rr)⁻¹ (n+1)ρ^n`, hence is summable when `ρ < 1`. -/
-theorem summable_fixedVertexTouching_termAbsSum_succ
-    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) {t : ℝ}
+/-- **Summability of the fixed-vertex touching gas majorant.**  The per-order fixed-vertex
+touching bound (over the abstract gas `𝓟`) is dominated by `(1-rr)⁻¹ (n+1)ρ^n` with
+`ρ = 4·c·rr/(1-rr)²`, hence is summable when `ρ < 1`.  The even gas (`allPolymers G`,
+`c = 1`) is recovered by `summable_fixedVertexTouching_termAbsSum_succ`. -/
+theorem summable_fixedVertexGasTouching_termAbsSum_succ
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) {c : ℝ} (hc : 0 ≤ c)
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (v : ι) {t : ℝ}
     (ht : 0 ≤ t)
     (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1)
-    (hρ : 4 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+    (hρ : 4 * c * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
         / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2 < 1) :
     Summable fun n : ℕ =>
-      ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+      ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
         |ursellCoefficient ω| * clusterSeqActivity t ω := by
   classical
   set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
-  set ρ : ℝ := 4 * rr / (1 - rr) ^ 2 with hρdef
+  set ρ : ℝ := 4 * c * rr / (1 - rr) ^ 2 with hρdef
   set K : ℝ := 1 / (1 - rr) with hK
   have hρlt : ρ < 1 := by
     rw [hρdef, hrr]
     exact hρ
   have hρ0 : 0 ≤ ρ := by
-    rw [hρdef]
-    positivity
+    rw [hρdef, hrr]; positivity
   have hsuccSumm : Summable fun n : ℕ => ((n + 1 : ℕ) : ℝ) * ρ ^ n := by
     have hnorm : ‖ρ‖ < 1 := by
       rw [Real.norm_eq_abs, abs_of_nonneg hρ0]
@@ -68,16 +71,16 @@ theorem summable_fixedVertexTouching_termAbsSum_succ
   have hdom : Summable fun n : ℕ => K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) :=
     hsuccSumm.mul_left K
   have hterm : ∀ n : ℕ,
-      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
         |ursellCoefficient ω| * clusterSeqActivity t ω)
         ≤ K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) := by
     intro n
-    have h := fixedVertexTouching_termAbsSum_succ_le_nat_mul_geometric
-      (G := G) (v := v) (n := n) (t := t) ht hkp
+    have h := fixedVertexGasTouching_termAbsSum_succ_le_nat_mul_geometric G hgas hc hsupp v n
+      ht hkp
     rw [← hrr, ← hρdef, ← hK] at h
     calc
-      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
           (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
         |ursellCoefficient ω| * clusterSeqActivity t ω)
           ≤ ((n + 1 : ℕ) : ℝ) * (K * ρ ^ n) := h
@@ -86,9 +89,104 @@ theorem summable_fixedVertexTouching_termAbsSum_succ
   refine Finset.sum_nonneg fun ω _ => ?_
   exact mul_nonneg (abs_nonneg _) (clusterSeqActivity_nonneg ht ω)
 
+/-- **Summability of the fixed-vertex touching majorant.**  Even-gas (`c = 1`) instance of
+`summable_fixedVertexGasTouching_termAbsSum_succ`. -/
+theorem summable_fixedVertexTouching_termAbsSum_succ
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) {t : ℝ}
+    (ht : 0 ≤ t)
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1)
+    (hρ : 4 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+        / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2 < 1) :
+    Summable fun n : ℕ =>
+      ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
+          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω := by
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  have hρc : 4 * 1 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+      / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2 < 1 := by
+    rw [mul_one]; exact hρ
+  exact summable_fixedVertexGasTouching_termAbsSum_succ G (evenPolymerGasData G) zero_le_one
+    hsupp v ht hkp hρc
+
+/-- **Fixed-vertex touching gas clusters are summably bounded.**  Summing the per-order
+fixed-vertex gas bound gives the local KP constant `(1-rr)⁻¹(1-ρ)⁻²`, with `rr = Δ² e |t|`
+and `ρ = 4·c·rr/(1-rr)²`.  The even gas (`allPolymers G`, `c = 1`) is recovered by
+`fixedVertexTouching_tsum_le`. -/
+theorem fixedVertexGasTouching_tsum_le
+    (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet]
+    {𝓟 : Finset (Finset (Sym2 ι))} (hgas : PolymerGasData G 𝓟) {c : ℝ} (hc : 0 ≤ c)
+    (hsupp : ∀ P ∈ 𝓟, ((polymerSupport P).card : ℝ) ≤ c * (P.card : ℝ)) (v : ι) {t : ℝ}
+    (ht : 0 ≤ t)
+    (hkp : (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) < 1)
+    (hρ : 4 * c * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+        / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2 < 1) :
+    (∑' n : ℕ,
+      ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+      ≤ (1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
+          * (1 - 4 * c * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+            / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2)⁻¹ ^ 2 := by
+  classical
+  set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
+  set ρ : ℝ := 4 * c * rr / (1 - rr) ^ 2 with hρdef
+  set K : ℝ := 1 / (1 - rr) with hK
+  have hρlt : ρ < 1 := by
+    rw [hρdef, hrr]
+    exact hρ
+  have hρ0 : 0 ≤ ρ := by
+    rw [hρdef, hrr]; positivity
+  have hsuccSumm : Summable fun n : ℕ => ((n + 1 : ℕ) : ℝ) * ρ ^ n := by
+    have hnorm : ‖ρ‖ < 1 := by
+      rw [Real.norm_eq_abs, abs_of_nonneg hρ0]
+      exact hρlt
+    have hn : Summable fun n : ℕ => (n : ℝ) * ρ ^ n :=
+      (hasSum_coe_mul_geometric_of_norm_lt_one hnorm).summable
+    have hg : Summable fun n : ℕ => ρ ^ n := summable_geometric_of_lt_one hρ0 hρlt
+    have hsplit : (fun n : ℕ => ((n + 1 : ℕ) : ℝ) * ρ ^ n)
+        = fun n : ℕ => (n : ℝ) * ρ ^ n + ρ ^ n := by
+      funext n
+      norm_num [Nat.cast_add, add_mul]
+    rw [hsplit]
+    exact hn.add hg
+  have hdom : Summable fun n : ℕ => K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) :=
+    hsuccSumm.mul_left K
+  have hterm : ∀ n : ℕ,
+      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+        ≤ K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) := by
+    intro n
+    have h := fixedVertexGasTouching_termAbsSum_succ_le_nat_mul_geometric G hgas hc hsupp v n
+      ht hkp
+    rw [← hrr, ← hρdef, ← hK] at h
+    calc
+      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+          ≤ ((n + 1 : ℕ) : ℝ) * (K * ρ ^ n) := h
+      _ = K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) := by ring
+  have hleft := summable_fixedVertexGasTouching_termAbsSum_succ G hgas hc hsupp v ht hkp hρ
+  calc
+    (∑' n : ℕ,
+      ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => 𝓟)).filter
+          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
+        |ursellCoefficient ω| * clusterSeqActivity t ω)
+      ≤ ∑' n : ℕ, K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) :=
+        hleft.tsum_le_tsum hterm hdom
+    _ = K * (1 - ρ)⁻¹ ^ 2 := by
+        rw [tsum_mul_left, tsum_nat_succ_mul_geometric_eq_inv_sq hρ0 hρlt]
+    _ = (1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
+          * (1 - 4 * c * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+            / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2)⁻¹ ^ 2 := by
+        rw [hK, hρdef, hrr]
+
 /-- **Fixed-vertex touching clusters are summably bounded.**  Summing the per-order fixed-vertex
 bound gives the local KP constant `(1-rr)⁻¹(1-ρ)⁻²`, with
-`rr = Δ² e |t|` and `ρ = 4rr/(1-rr)²`. -/
+`rr = Δ² e |t|` and `ρ = 4rr/(1-rr)²`.  Even-gas (`c = 1`) instance of
+`fixedVertexGasTouching_tsum_le`. -/
 theorem fixedVertexTouching_tsum_le
     (G : SimpleGraph ι) [DecidableRel G.Adj] [Fintype G.edgeSet] (v : ι) {t : ℝ}
     (ht : 0 ≤ t)
@@ -102,60 +200,14 @@ theorem fixedVertexTouching_tsum_le
       ≤ (1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
           * (1 - 4 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
             / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2)⁻¹ ^ 2 := by
-  classical
-  set rr : ℝ := (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|) with hrr
-  set ρ : ℝ := 4 * rr / (1 - rr) ^ 2 with hρdef
-  set K : ℝ := 1 / (1 - rr) with hK
-  have hρlt : ρ < 1 := by
-    rw [hρdef, hrr]
-    exact hρ
-  have hρ0 : 0 ≤ ρ := by
-    rw [hρdef]
-    positivity
-  have hsuccSumm : Summable fun n : ℕ => ((n + 1 : ℕ) : ℝ) * ρ ^ n := by
-    have hnorm : ‖ρ‖ < 1 := by
-      rw [Real.norm_eq_abs, abs_of_nonneg hρ0]
-      exact hρlt
-    have hn : Summable fun n : ℕ => (n : ℝ) * ρ ^ n :=
-      (hasSum_coe_mul_geometric_of_norm_lt_one hnorm).summable
-    have hg : Summable fun n : ℕ => ρ ^ n := summable_geometric_of_lt_one hρ0 hρlt
-    have hsplit : (fun n : ℕ => ((n + 1 : ℕ) : ℝ) * ρ ^ n)
-        = fun n : ℕ => (n : ℝ) * ρ ^ n + ρ ^ n := by
-      funext n
-      norm_num [Nat.cast_add, add_mul]
-    rw [hsplit]
-    exact hn.add hg
-  have hdom : Summable fun n : ℕ => K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) :=
-    hsuccSumm.mul_left K
-  have hterm : ∀ n : ℕ,
-      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
-          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
-        |ursellCoefficient ω| * clusterSeqActivity t ω)
-        ≤ K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) := by
-    intro n
-    have h := fixedVertexTouching_termAbsSum_succ_le_nat_mul_geometric
-      (G := G) (v := v) (n := n) (t := t) ht hkp
-    rw [← hrr, ← hρdef, ← hK] at h
-    calc
-      (∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
-          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
-        |ursellCoefficient ω| * clusterSeqActivity t ω)
-          ≤ ((n + 1 : ℕ) : ℝ) * (K * ρ ^ n) := h
-      _ = K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) := by ring
-  have hleft := summable_fixedVertexTouching_termAbsSum_succ G v ht hkp hρ
-  calc
-    (∑' n : ℕ,
-      ∑ ω ∈ (Fintype.piFinset (fun _ : Fin (n + 1) => allPolymers G)).filter
-          (fun ω => ∃ i : Fin (n + 1), v ∈ polymerSupport (ω i)),
-        |ursellCoefficient ω| * clusterSeqActivity t ω)
-      ≤ ∑' n : ℕ, K * (((n + 1 : ℕ) : ℝ) * ρ ^ n) :=
-        hleft.tsum_le_tsum hterm hdom
-    _ = K * (1 - ρ)⁻¹ ^ 2 := by
-        rw [tsum_mul_left, tsum_nat_succ_mul_geometric_eq_inv_sq hρ0 hρlt]
-    _ = (1 / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)))
-          * (1 - 4 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
-            / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2)⁻¹ ^ 2 := by
-        rw [hK, hρdef, hrr]
+  have hsupp : ∀ P ∈ allPolymers G, ((polymerSupport P).card : ℝ) ≤ 1 * (P.card : ℝ) := by
+    intro P hP
+    rw [one_mul]; exact_mod_cast polymerSupport_card_le_card_of_mem_allPolymers G hP
+  have hρc : 4 * 1 * ((G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|))
+      / (1 - (G.maxDegree : ℝ) ^ 2 * (Real.exp 1 * |t|)) ^ 2 < 1 := by
+    rw [mul_one]; exact hρ
+  have h := fixedVertexGasTouching_tsum_le G (evenPolymerGasData G) zero_le_one hsupp v ht hkp hρc
+  simpa using h
 
 open Classical in
 /-- **Touching `C` is bounded by a union over the vertices of `polymerSupport C`.**  If a


### PR DESCRIPTION
## Purpose: F3-pre — gas-parametrize fixed-vertex touching chain

Gas-parametrize the fixed-vertex TOUCHING moment chain (the ~5–7 β-route files `FixedVertexChainEnds/ChainMid/PeelBound/TouchingUnion/TouchingPerOrder.lean` + the real `MayerSumDiffSupportBound.lean`, currently hardcoded to `allPolymers G`) over an abstract polymer set `PolymerGasData G 𝓟` + support hyp `hsupp`/`c`.

This exactly mirrors the completed R1–R3 pattern and is the prerequisite for F3's avoiding-gas ratio (which needs the touching moment over `allConnectedPolymers`, since `allConnectedPolymers ⊇ allPolymers` gives no domination shortcut).

## Design & Implementation

β route recovered VERBATIM by `𝓟 := allPolymers G` (`evenPolymerGasData`, c=1) thin wrappers — existing β statements preserved.

Design reference: math note `.self-local/tex/field-ce-F3pre-fixedvertex-touching-gasparam.tex` (in progress) + F3 design (this session).

## Nature

最弱仮説抽象化 in service of the new F3 theorem (same authorized pattern as R1–R3 / F2-pre), NOT gratuitous refactor; β kept green (test-first).

## Follow-up

F3 (connected-Gavoid characterizations + field per-order difference + avoiding-ratio exp capstone) follows.

Refs #4433
