### PR TITLE
refactor(r7): vitaliPorter stale axiom doc corrections

### DIFF
--- a/IsingModel/ComplexAnalyticity/VitaliPorter/Theorem.lean
+++ b/IsingModel/ComplexAnalyticity/VitaliPorter/Theorem.lean
@@ -7,9 +7,9 @@ import Mathlib.Topology.Compactness.LocallyCompact
 # Vitali–Porter convergence theorem (proved)
 
 This file **proves** the Vitali–Porter convergence theorem
-`vitaliPorter_tendstoLocallyUniformlyOn`, previously a declared scope-excluded axiom (Issue #4280).
-It combines the complex Montel theorem (`MontelExtraction.lean`) with the identity-theorem
-uniqueness core (`Uniqueness.lean`):
+`vitaliPorter_tendstoLocallyUniformlyOn`, originally a scope-excluded axiom (Issue #4280),
+now fully formalized. It combines the complex Montel theorem (`MontelExtraction.lean`) with
+the identity-theorem uniqueness core (`Uniqueness.lean`):
 
 * Montel gives **one** locally-uniformly convergent subsequence with holomorphic limit `f`; the
   pointwise hypothesis on the accumulating set `S` identifies `f` with `g` on `S`.
@@ -18,7 +18,7 @@ uniqueness core (`Uniqueness.lean`):
   further Montel subsequence whose limit again agrees with `g` on `S`, hence equals `f` by the
   identity theorem; so all subsequential limits coincide and the sequence converges to `f`.
 
-Proving this removes the `vitaliPorter_tendstoLocallyUniformlyOn` axiom from the project.
+This proof removes the `vitaliPorter_tendstoLocallyUniformlyOn` axiom from the project.
 
 **Reference:** Conway, *Functions of One Complex Variable I*, VII §2–3 (Montel / Vitali). -/
 

--- a/IsingModel/ComplexAnalyticity/VitaliPorter/Uniqueness.lean
+++ b/IsingModel/ComplexAnalyticity/VitaliPorter/Uniqueness.lean
@@ -6,8 +6,8 @@ import Mathlib.Topology.ClusterPt
 # Vitali–Porter: the uniqueness (identity-theorem) core
 
 This is the first building block of an in-project proof of the Vitali–Porter convergence theorem
-(`vitaliPorter_tendstoLocallyUniformlyOn`, currently a declared scope-excluded axiom —
-Issue #4280). It isolates the **uniqueness** half: two holomorphic functions
+(`vitaliPorter_tendstoLocallyUniformlyOn`, proved as a theorem in `VitaliPorter/Theorem.lean`
+via Issue #4280). It isolates the **uniqueness** half: two holomorphic functions
 on an open preconnected set `U` that agree with the same function `g` on a subset `S` having an
 accumulation point in `U` must agree on all of `U`.
 


### PR DESCRIPTION
## Summary

The theorem `vitaliPorter_tendstoLocallyUniformlyOn` was previously declared as a scope-excluded axiom (#4280) but has since been **fully proved** in `IsingModel/ComplexAnalyticity/VitaliPorter/Theorem.lean` as a genuine theorem. This PR corrects the stale documentation in `Uniqueness.lean` that still refers to it as an axiom, bringing it into alignment with the current code state.

**Nature**: doc/comment clarifications only. No code behaviour changes.

## Change

- **`IsingModel/ComplexAnalyticity/VitaliPorter/Uniqueness.lean:9`**: Updated docstring from "currently a declared scope-excluded axiom" to "proved as a theorem in `VitaliPorter/Theorem.lean`", reflecting the actual proof status.

## Verification

- `lake build` green on all modules (5679 jobs, no warnings).
- No Japanese characters in edited Lean files.
- No code logic changes.

Addresses #4505, #4506.
