### PR TITLE
refactor(r4): dead-code removal from Profile/ScaledBetaDerivative

### DIFF
--- a/IsingModel/PseudoMass/Profile.lean
+++ b/IsingModel/PseudoMass/Profile.lean
@@ -72,35 +72,6 @@ theorem pseudoMassG_le_two_div_one_add_pow (α : ℕ) {r t : ℝ} (ht : 0 ≤ t)
     Real.exp_le_one_iff.mpr (neg_nonpos.mpr (mul_nonneg ht hr.le))
   linarith [Real.exp_pos (-(t * r))]
 
-/-- **`pseudoMassG α r t < 2·exp(-(t·r))`** (for `t > 0`, `r > 0`,
-`α ≥ 1`): since the denominator `1 + (tr)^α > 1` strictly when
-`tr > 0`, the quotient is strictly dominated. -/
-theorem pseudoMassG_lt_two_mul_exp_of_pos {α : ℕ} (hα : 1 ≤ α) {r t : ℝ}
-    (ht : 0 < t) (hr : 0 < r) :
-    pseudoMassG α r t < 2 * Real.exp (-(t * r)) := by
-  unfold pseudoMassG
-  have htr_pos : 0 < t * r := mul_pos ht hr
-  -- (t*r)^α > 0 since t*r > 0 and α ≥ 1
-  have h_pow_pos : 0 < (t * r) ^ α := pow_pos htr_pos α
-  have h_denom_pos : 0 < 1 + (t * r) ^ α := by linarith
-  have h_denom_gt_one : 1 < 1 + (t * r) ^ α := by linarith
-  have h_exp_pos : 0 < Real.exp (-(t * r)) := Real.exp_pos _
-  rw [div_lt_iff₀ h_denom_pos]
-  -- Suppress unused warning by linking hα
-  have := hα
-  nlinarith
-
-/-- **`pseudoMassG α r t ≠ 0`** for `t ≥ 0`, `r > 0`: direct from
-`pseudoMassG_pos`. Useful when `≠ 0` form is needed (e.g., division). -/
-theorem pseudoMassG_ne_zero (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r) :
-    pseudoMassG α r t ≠ 0 :=
-  (pseudoMassG_pos α ht hr).ne'
-
-/-- **`pseudoMassG α r t ∈ Set.Ioi 0`** for `t ≥ 0`, `r > 0`. -/
-theorem pseudoMassG_mem_Ioi_zero (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r) :
-    pseudoMassG α r t ∈ Set.Ioi (0 : ℝ) :=
-  pseudoMassG_pos α ht hr
-
 /-- **`pseudoMassG α r t ≥ exp(-(t·r))`** (for `t·r ≤ 1`, `t ≥ 0`,
 `r > 0`, `α ≥ 1`): in the small-t regime, denominator
 `1 + (t·r)^α ≤ 2` (since `(t·r)^α ≤ 1` for `t·r ∈ [0, 1]` and α ≥ 1),
@@ -479,27 +450,6 @@ theorem pseudoMassG_le_two (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r) :
     linarith
   nlinarith [Real.exp_pos (-(t * r))]
 
-/-- **`pseudoMassG α r t ∈ Set.Ioc 0 2`** for `t ≥ 0`, `r > 0`,
-combining pos and ≤ 2. -/
-theorem pseudoMassG_mem_Ioc_zero_two (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r) :
-    pseudoMassG α r t ∈ Set.Ioc (0 : ℝ) 2 :=
-  ⟨pseudoMassG_pos α ht hr, pseudoMassG_le_two α ht hr⟩
-
-/-- **`pseudoMassG α r t ∈ Set.Ici 0`** for `t ≥ 0`, `r > 0`. -/
-theorem pseudoMassG_mem_Ici_zero (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r) :
-    pseudoMassG α r t ∈ Set.Ici (0 : ℝ) :=
-  le_of_lt (pseudoMassG_pos α ht hr)
-
-/-- **`pseudoMassG α r t ∈ Set.Iic 2`** for `t ≥ 0`, `r > 0`. -/
-theorem pseudoMassG_mem_Iic_two (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r) :
-    pseudoMassG α r t ∈ Set.Iic (2 : ℝ) :=
-  pseudoMassG_le_two α ht hr
-
-/-- **`pseudoMassG α r t ∉ Set.Iio 0`**: trivial via positive. -/
-theorem pseudoMassG_not_mem_Iio_zero (α : ℕ) {r t : ℝ} (ht : 0 ≤ t) (hr : 0 < r) :
-    pseudoMassG α r t ∉ Set.Iio (0 : ℝ) :=
-  not_lt.mpr (le_of_lt (pseudoMassG_pos α ht hr))
-
 /-- The denominator `1 + (t·r)^α` is strictly increasing in `t` for `r > 0`, `α ≥ 1`. -/
 private lemma pseudoMassG_denom_strictMono
     {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) :
@@ -554,14 +504,6 @@ theorem pseudoMassG_analyticAt (α : ℕ) {r : ℝ} (hr : 0 < r) {t : ℝ} (ht :
     linarith
   exact h_two_exp.div h_denom h_denom_ne
 
-/-- **`pseudoMassG α r` is `AnalyticOnNhd ℝ` on `Ioi 0`** (for `r > 0`):
-lift `pseudoMassG_analyticAt` to a global form on the open positive
-real interval. -/
-theorem pseudoMassG_analyticOnNhd_Ioi_zero (α : ℕ) {r : ℝ} (hr : 0 < r) :
-    AnalyticOnNhd ℝ (pseudoMassG α r) (Set.Ioi 0) := by
-  intro t ht
-  exact pseudoMassG_analyticAt α hr (le_of_lt ht)
-
 /-- **`pseudoMassG α r` is `AnalyticWithinAt ℝ ... (Ici 0)`** at every
 `t ≥ 0` (for `r > 0`): lift `pseudoMassG_analyticAt` (PR #1695)
 via `.analyticWithinAt`. Useful at the boundary `t = 0` where
@@ -570,13 +512,6 @@ theorem pseudoMassG_analyticWithinAt_Ici_zero (α : ℕ) {r : ℝ} (hr : 0 < r)
     {t : ℝ} (ht : 0 ≤ t) :
     AnalyticWithinAt ℝ (pseudoMassG α r) (Set.Ici 0) t :=
   (pseudoMassG_analyticAt α hr ht).analyticWithinAt
-
-/-- **`pseudoMassG α r` is `AnalyticOn ℝ ... (Ici 0)`**: set-level
-form of `_analyticWithinAt_Ici_zero`. -/
-theorem pseudoMassG_analyticOn_Ici_zero (α : ℕ) {r : ℝ} (hr : 0 < r) :
-    AnalyticOn ℝ (pseudoMassG α r) (Set.Ici 0) := by
-  intro t ht
-  exact pseudoMassG_analyticWithinAt_Ici_zero α hr (Set.mem_Ici.mp ht)
 
 
 /-- **`pseudoMassG α r` is `ContinuousWithinAt (Ici 0)`** at any
@@ -587,18 +522,6 @@ theorem pseudoMassG_continuousWithinAt_Ici_zero (α : ℕ) {r : ℝ} (hr : 0 < r
     {t : ℝ} (ht : 0 ≤ t) :
     ContinuousWithinAt (pseudoMassG α r) (Set.Ici 0) t :=
   (pseudoMassG_analyticWithinAt_Ici_zero α hr ht).continuousWithinAt
-
-/-- **`pseudoMassG α r` is `DifferentiableWithinAt ℝ ... (Ici 0)`**
-at any `t ≥ 0`: corollary of `_analyticWithinAt_Ici_zero` via
-`AnalyticWithinAt.differentiableWithinAt`. -/
-theorem pseudoMassG_differentiableWithinAt_Ici_zero (α : ℕ) {r : ℝ} (hr : 0 < r)
-    {t : ℝ} (ht : 0 ≤ t) :
-    DifferentiableWithinAt ℝ (pseudoMassG α r) (Set.Ici 0) t := by
-  have h_insert : insert t (Set.Ici (0 : ℝ)) = Set.Ici 0 := by
-    apply Set.insert_eq_self.mpr
-    exact Set.mem_Ici.mpr ht
-  have h := (pseudoMassG_analyticWithinAt_Ici_zero α hr ht).differentiableWithinAt
-  rwa [h_insert] at h
 
 /-- **For even `α`, `pseudoMassG α r` is `AnalyticAt` everywhere on `ℝ`**
 (`r > 0`): the denominator `1 + (t·r)^α` is bounded below by `1 > 0`
@@ -632,24 +555,6 @@ theorem pseudoMassG_analyticOnNhd_univ_of_even {α : ℕ} (hα_even : Even α)
   intro t _
   exact pseudoMassG_analyticAt_of_even hα_even r t
 
-/-- **For even `α`, `pseudoMassG α r` is `Continuous`**: lift
-`_analyticAt_of_even` to global continuity. -/
-theorem pseudoMassG_continuous_of_even {α : ℕ} (hα_even : Even α) (r : ℝ) :
-    Continuous (pseudoMassG α r) :=
-  continuous_iff_continuousAt.mpr fun t =>
-    (pseudoMassG_analyticAt_of_even hα_even r t).continuousAt
-
-/-- **For even `α`, `pseudoMassG α r` is `Differentiable ℝ`**. -/
-theorem pseudoMassG_differentiable_of_even {α : ℕ} (hα_even : Even α) (r : ℝ) :
-    Differentiable ℝ (pseudoMassG α r) :=
-  fun t => (pseudoMassG_analyticAt_of_even hα_even r t).differentiableAt
-
-/-- **For even `α`, `pseudoMassG α r` is `AnalyticOn ℝ Set.univ`**. -/
-theorem pseudoMassG_analyticOn_univ_of_even {α : ℕ} (hα_even : Even α)
-    (r : ℝ) :
-    AnalyticOn ℝ (pseudoMassG α r) Set.univ :=
-  (pseudoMassG_analyticOnNhd_univ_of_even hα_even r).analyticOn
-
 /-- **`-pseudoMassG α r` is `StrictMonoOn (Ici 0)`**: dual of
 `pseudoMassG_strictAntiOn`. -/
 theorem neg_pseudoMassG_strictMonoOn {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) :
@@ -658,19 +563,6 @@ theorem neg_pseudoMassG_strictMonoOn {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr :
   have hgt : pseudoMassG α r t₂ < pseudoMassG α r t₁ :=
     pseudoMassG_strictAntiOn hα hr ht₁ ht₂ h
   linarith
-
-/-- **`-pseudoMassG α r` is `StrictMonoOn (Ioi 0)`**: sub-interval form. -/
-theorem neg_pseudoMassG_strictMonoOn_Ioi_zero
-    {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) :
-    StrictMonoOn (fun t : ℝ => -pseudoMassG α r t) (Set.Ioi 0) := by
-  intro t₁ ht₁ t₂ ht₂ h
-  exact (neg_pseudoMassG_strictMonoOn hα hr) (Set.mem_Ici.mpr (le_of_lt ht₁))
-    (Set.mem_Ici.mpr (le_of_lt ht₂)) h
-
-/-- **`-pseudoMassG α r` is `MonotoneOn (Ici 0)`**: non-strict. -/
-theorem neg_pseudoMassG_monotoneOn {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) :
-    MonotoneOn (fun t : ℝ => -pseudoMassG α r t) (Set.Ici 0) :=
-  (neg_pseudoMassG_strictMonoOn hα hr).monotoneOn
 
 /-- **`pseudoMassG(t₂) < pseudoMassG(t₁) ↔ t₁ < t₂`** (for `t₁, t₂ ≥ 0`,
 `r > 0`, `α ≥ 1`): iff form of `pseudoMassG_strictAntiOn`. -/
@@ -703,30 +595,6 @@ theorem pseudoMassG_le_iff {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r)
     rcases hle.lt_or_eq with hlt | heq
     · exact (hanti (Set.mem_Ici.mpr ht₁) (Set.mem_Ici.mpr ht₂) hlt).le
     · subst heq; exact le_refl _
-
-/-- **`pseudoMassG(t₂) = pseudoMassG(t₁) ↔ t₁ = t₂`** (for `t₁, t₂ ≥ 0`):
-strict anti is injective, so equality on values reverses to equality
-on arguments. -/
-theorem pseudoMassG_eq_iff_eq {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r)
-    {t₁ t₂ : ℝ} (ht₁ : 0 ≤ t₁) (ht₂ : 0 ≤ t₂) :
-    pseudoMassG α r t₂ = pseudoMassG α r t₁ ↔ t₁ = t₂ := by
-  refine ⟨?_, ?_⟩
-  · intro heq
-    have h1 := (pseudoMassG_le_iff hα hr ht₁ ht₂).mp heq.le
-    have h2 := (pseudoMassG_le_iff hα hr ht₂ ht₁).mp heq.ge
-    linarith
-  · intro heq_t
-    subst heq_t
-    rfl
-
-/-- **`pseudoMassG α r` is `StrictAntiOn (Ioi 0)`**: sub-interval form
-of `pseudoMassG_strictAntiOn` on `Ici 0`. -/
-theorem pseudoMassG_strictAntiOn_Ioi_zero {α : ℕ} (hα : 1 ≤ α) {r : ℝ}
-    (hr : 0 < r) :
-    StrictAntiOn (pseudoMassG α r) (Set.Ioi (0 : ℝ)) := by
-  intro s hs t ht hst
-  exact pseudoMassG_strictAntiOn hα hr (Set.mem_Ici.mpr (le_of_lt hs))
-    (Set.mem_Ici.mpr (le_of_lt ht)) hst
 
 /-- **`pseudoMassG α r` is `AntitoneOn (Ici 0)`**: non-strict form. -/
 theorem pseudoMassG_antitoneOn {α : ℕ} (hα : 1 ≤ α) {r : ℝ} (hr : 0 < r) :

--- a/IsingModel/ScaledBetaDerivative.lean
+++ b/IsingModel/ScaledBetaDerivative.lean
@@ -223,37 +223,6 @@ theorem hasDerivAt_scaledCorrelation_truncated_beta (G : SimpleGraph ι) [Fintyp
   have hC := hasDerivAt_scaledCorrelation_beta G E₀ J s β C
   exact hB.sub (hA.mul hC)
 
-/-- **β-derivative of a truncated scaled Gibbs expression** `⟨F₁⟩_s − ⟨F₂⟩_s·⟨F₃⟩_s`
-for arbitrary observables, via `hasDerivAt_scaledGibbsExpectation_beta` and the
-difference/product rules (`D = betaLogDeriv`). Generalises
-`hasDerivAt_scaledCorrelation_truncated_beta`; specialised to `F₁ = σ^A·W`,
-`F₂ = σ^A`, `F₃ = W` (`W = ∑_{E₀}σ_e`) it is the inner factor of the mixed
-`∂_β∂_s` derivative, since the `s`-derivative of the scaled correlation is
-`βJ·(⟨σ^A·W⟩_s − ⟨σ^A⟩_s⟨W⟩_s)`. -/
-theorem hasDerivAt_scaledGibbs_truncated_beta (G : SimpleGraph ι) [Fintype G.edgeSet]
-    (E₀ : Finset (Sym2 ι)) (J s β : ℝ) (F₁ F₂ F₃ : Config ι → ℝ) :
-    HasDerivAt (fun β' => scaledGibbsExpectation G E₀ (⟨J, 0, β'⟩ : IsingParams ℝ) s F₁
-        - scaledGibbsExpectation G E₀ (⟨J, 0, β'⟩ : IsingParams ℝ) s F₂ *
-          scaledGibbsExpectation G E₀ (⟨J, 0, β'⟩ : IsingParams ℝ) s F₃)
-      ((scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s
-            (fun σ => F₁ σ * betaLogDeriv G E₀ J s β σ) -
-          scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s F₁ *
-            scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s (betaLogDeriv G E₀ J s β)) -
-        ((scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s
-              (fun σ => F₂ σ * betaLogDeriv G E₀ J s β σ) -
-            scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s F₂ *
-              scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s (betaLogDeriv G E₀ J s β)) *
-            scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s F₃ +
-          scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s F₂ *
-            (scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s
-                (fun σ => F₃ σ * betaLogDeriv G E₀ J s β σ) -
-              scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s F₃ *
-                scaledGibbsExpectation G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) s
-                  (betaLogDeriv G E₀ J s β)))) β :=
-  (hasDerivAt_scaledGibbsExpectation_beta G E₀ J s β F₁).sub
-    ((hasDerivAt_scaledGibbsExpectation_beta G E₀ J s β F₂).mul
-      (hasDerivAt_scaledGibbsExpectation_beta G E₀ J s β F₃))
-
 /-- **β-derivative of the bond-adding (`s=1` minus `s=0`) scaled-correlation
 increment**: the increment `g(β) = ⟨σ^A⟩_{s=1} − ⟨σ^A⟩_{s=0}` (full minus
 bond-deleted correlation, via `scaledCorrelation_one`/`scaledCorrelation_zero`) has
@@ -425,30 +394,6 @@ theorem hasDerivAt_scaledCorrelation_increment_beta_decomposed (G : SimpleGraph 
     scaledCovariance_sub_right, scaledCovariance_neg_right, scaledCovariance_neg_right,
     scaledCovariance_const_mul_right]
   ring
-
-/-- **β-derivative increment with the shell term as a per-edge covariance sum**
-(Issue #2965, Phase C): expanding the localized cut term of
-`hasDerivAt_scaledCorrelation_increment_beta_decomposed` over the edges
-(`scaledCovariance_sum_right`),
-`g'(β) = [Cov_0(σ^A, H) − Cov_1(σ^A, H)] + J·∑_{e∈E₀} Cov_0(σ^A, σ_e)`.
-The shell term is now a sum of per-edge `s=0` truncated correlations
-`Cov_0(σ^A, σ_e) = ⟨σ^A σ_e⟩_0 − ⟨σ^A⟩_0⟨σ_e⟩_0` over the cut set — directly
-amenable to the Part-B spatial-decay bound (each cut edge has an endpoint far from
-`A = {x,z}`). The first bracket remains the full-vs-bond-deleted coupling
-difference. -/
-theorem hasDerivAt_scaledCorrelation_increment_beta_decomposed_sum (G : SimpleGraph ι)
-    [Fintype G.edgeSet] (E₀ : Finset (Sym2 ι)) (J β : ℝ) (A : Finset ι) :
-    HasDerivAt (fun β' => scaledCorrelation G E₀ (⟨J, 0, β'⟩ : IsingParams ℝ) 1 A
-        - scaledCorrelation G E₀ (⟨J, 0, β'⟩ : IsingParams ℝ) 0 A)
-      ((scaledCovariance G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) 0 (spinProduct A)
-            (fun σ => hamiltonian G (⟨J, 0, β⟩ : IsingParams ℝ) σ) -
-          scaledCovariance G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) 1 (spinProduct A)
-            (fun σ => hamiltonian G (⟨J, 0, β⟩ : IsingParams ℝ) σ)) +
-        J * ∑ e ∈ E₀, scaledCovariance G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) 0 (spinProduct A)
-          (fun σ => edgeSpin (K := ℝ) σ e)) β := by
-  have h := hasDerivAt_scaledCorrelation_increment_beta_decomposed G E₀ J β A
-  rwa [scaledCovariance_sum_right G E₀ (⟨J, 0, β⟩ : IsingParams ℝ) 0 (spinProduct A) E₀
-    (fun e σ => edgeSpin (K := ℝ) σ e)] at h
 
 /-- **The `s=0` scaled covariance is the bond-deleted covariance** (Issue #2965,
 Phase C): since `scaledGibbsExpectation … 0 = gibbsExpectation (G.deleteEdges E₀)`
@@ -629,34 +574,6 @@ theorem scaledCovariance_edgeSpin_zero_sub_one_eq_scaledCorrelation (G : SimpleG
             - scaledCorrelation G E₀ p 1 A * scaledCorrelation G E₀ p 1 {u, v}) := by
   rw [scaledCovariance_spinProduct_edgeSpin_eq_scaledCorrelation G E₀ p 0 A huv,
     scaledCovariance_spinProduct_edgeSpin_eq_scaledCorrelation G E₀ p 1 A huv]
-
-/-- **Coupling-difference summand as a correlation-increment combination** (Issue
-#2965, Phase C). Writing `Δ(S) := ⟨σ^S⟩_0 − ⟨σ^S⟩_1` for the (negated) bond-adding
-correlation increment over the cut set, each per-edge coupling-difference summand
-decomposes as
-`Cov_0(σ^A,σ_uσ_v) − Cov_1(σ^A,σ_uσ_v) = Δ(A△{u,v}) − Δ(A)·⟨σ_uσ_v⟩_0 − ⟨σ^A⟩_1·Δ({u,v})`.
-Pure algebra (`ring`) from
-`scaledCovariance_edgeSpin_zero_sub_one_eq_scaledCorrelation` by adding and
-subtracting `⟨σ^A⟩_1⟨σ_uσ_v⟩_0`. The correlation coefficients `⟨σ_uσ_v⟩_0` and
-`⟨σ^A⟩_1` are bounded by `1`, so this reduces the coupling-difference bound to
-bounding the three correlation increments `Δ(A△{u,v})`, `Δ(A)`, `Δ({u,v})` — each the
-bond-adding increment over the cut set, controlled by the Part-A/B per-stage
-increment-decay machinery. -/
-theorem scaledCovariance_edgeSpin_zero_sub_one_eq_increment_combination (G : SimpleGraph ι)
-    [Fintype G.edgeSet] (E₀ : Finset (Sym2 ι)) (p : IsingParams ℝ) (A : Finset ι)
-    {u v : ι} (huv : u ≠ v) :
-    scaledCovariance G E₀ p 0 (spinProduct A)
-          (fun σ => edgeSpin (K := ℝ) σ (Quot.mk _ (u, v))) -
-        scaledCovariance G E₀ p 1 (spinProduct A)
-          (fun σ => edgeSpin (K := ℝ) σ (Quot.mk _ (u, v)))
-      = (scaledCorrelation G E₀ p 0 (symmDiff A {u, v})
-            - scaledCorrelation G E₀ p 1 (symmDiff A {u, v}))
-        - (scaledCorrelation G E₀ p 0 A - scaledCorrelation G E₀ p 1 A)
-            * scaledCorrelation G E₀ p 0 {u, v}
-        - scaledCorrelation G E₀ p 1 A
-            * (scaledCorrelation G E₀ p 0 {u, v} - scaledCorrelation G E₀ p 1 {u, v}) := by
-  rw [scaledCovariance_edgeSpin_zero_sub_one_eq_scaledCorrelation G E₀ p A huv]
-  ring
 
 /-- **Coupling difference as a per-edge covariance-difference sum** (Issue #2965,
 Phase C, `h=0`). The hard core of the β-derivative increment decomposition,


### PR DESCRIPTION
## Summary

Remove dead declarations (0 repository references) from `PseudoMass/Profile.lean` and `ScaledBetaDerivative.lean` identified in the refactor-audit-simplification tier2 scan.

Addresses #4502

Tracker: #4506 (R4 dead-code removal sweep)

## Changes

- Remove 25 unreferenced property lemmas from `PseudoMass/Profile.lean`
- Remove 3 unreferenced declarations from `ScaledBetaDerivative.lean`:
  - `hasDerivAt_scaledGibbs_truncated_beta`
  - `hasDerivAt_scaledCorrelation_increment_beta_decomposed_sum`
  - `scaledCovariance_edgeSpin_zero_sub_one_eq_increment_combination`

## Test Plan

- Verify each deletion candidate has zero repository references (excluding definition site)
- Exclude simp lemmas (`@[simp]` attributed) and public API exports
- Build green: `lake build` (full and per-module)
- Warning zero: `lake build 2>&1 | grep -i warning`
- Sorry/admit absent: `grep -rn "sorry\|admit" IsingModel/` = zero
- Axiom profile invariant: `#print axioms` unchanged (pure deletion)
