### PR TITLE
R3 PR-1: extract bounded-holomorphic-family equicontinuity core into IsingModel/Analysis/HolomorphicEquicontinuity.lean

### DIFF
--- a/IsingModel.lean
+++ b/IsingModel.lean
@@ -442,6 +442,7 @@ import IsingModel.TransferMatrix.InfiniteVolumeOneDSusceptibility
 import IsingModel.TransferMatrix.InfiniteVolumeOneDMass
 import IsingModel.TransferMatrix.ClusterExpansionSupersession
 
+import IsingModel.Analysis.HolomorphicEquicontinuity
 import IsingModel.AmbientComplexAnalyticity.AscoliData.Constructors.AnalyticSideConditions
 import IsingModel.AmbientComplexAnalyticity.Basic.BranchBounds
 import IsingModel.AmbientComplexAnalyticity.Vitali.BranchUniformBounds

--- a/IsingModel/AmbientComplexAnalyticity/AscoliData/Constructors/AnalyticSideConditions.lean
+++ b/IsingModel/AmbientComplexAnalyticity/AscoliData/Constructors/AnalyticSideConditions.lean
@@ -1,20 +1,15 @@
-import Mathlib.Analysis.Complex.Schwarz
-import Mathlib.Analysis.Calculus.MeanValue
-import Mathlib.Analysis.Analytic.Basic
-import Mathlib.Topology.MetricSpace.Equicontinuity
+import IsingModel.Analysis.HolomorphicEquicontinuity
 import IsingModel.AmbientComplexAnalyticity.AscoliData.Structures.BranchLocallyBounded
 
 /-!
-# Equicontinuity of uniformly bounded analytic families (GJ §4.6 Thm 4.6.2)
+# Equicontinuity Ascoli side-conditions from a stage-uniform bound (GJ §4.6 Thm 4.6.2)
 
-The general analytic layer of the Ascoli side-condition constructors (Issue #628): a family of
-analytic functions on a ball, uniformly bounded there, has uniformly bounded derivatives on
-interior sub-balls (Schwarz/Cauchy estimate), hence a uniform local Lipschitz estimate, hence is
-pointwise equicontinuous. This discharges the `equicontinuous` field of the branch-deviation
-Ascoli data from a stage-uniform closed-ball bound, with no per-stage input.
-
-* `norm_deriv_le_of_analyticOnNhd_of_bounded` — the Schwarz-lemma derivative bound `2C/ρ`.
-* `norm_sub_le_of_analyticOnNhd_of_bounded` — the uniform local Lipschitz estimate.
+The analytic layer of the Ascoli side-condition constructors (Issue #628): from a stage-uniform
+closed-ball bound on a Lee–Yang branch family, the `equicontinuous` field of the branch-deviation
+Ascoli data is discharged with no per-stage input. The underlying Schwarz/Cauchy derivative bound,
+the uniform local Lipschitz estimate, and the subtype-ball equicontinuity now live in the shared
+core `IsingModel.Analysis.HolomorphicEquicontinuity` (Issue #4501); this file wires them into the
+`Ambient` branch-restriction carriers.
 
 References: Glimm–Jaffe, *Quantum Physics*, 2nd ed. (Springer, 1987), §4.6, Theorem 4.6.2.
 -/
@@ -22,103 +17,6 @@ References: Glimm–Jaffe, *Quantum Physics*, 2nd ed. (Springer, 1987), §4.6, T
 namespace IsingModel
 
 open Metric
-
-/-- **Derivative bound for a bounded analytic function** (Schwarz): if `f` is analytic on
-`ball c R` with `‖f‖ ≤ C` there, then at any `ξ` whose `ρ`-ball stays inside,
-`‖deriv f ξ‖ ≤ 2C/ρ`. -/
-theorem norm_deriv_le_of_analyticOnNhd_of_bounded {f : ℂ → ℂ} {c : ℂ} {R C : ℝ}
-    (hf : AnalyticOnNhd ℂ f (ball c R))
-    (hb : ∀ z ∈ ball c R, ‖f z‖ ≤ C)
-    {ξ : ℂ} {ρ : ℝ} (hρ : 0 < ρ) (hsub : ball ξ ρ ⊆ ball c R) :
-    ‖deriv f ξ‖ ≤ 2 * C / ρ := by
-  have hξmem : ξ ∈ ball c R := hsub (mem_ball_self hρ)
-  have hd : DifferentiableOn ℂ f (ball ξ ρ) :=
-    fun z hz => ((hf z (hsub hz)).differentiableAt).differentiableWithinAt
-  have hmaps : Set.MapsTo f (ball ξ ρ) (closedBall (f ξ) (2 * C)) := by
-    intro z hz
-    rw [mem_closedBall, dist_eq_norm]
-    calc ‖f z - f ξ‖ ≤ ‖f z‖ + ‖f ξ‖ := norm_sub_le _ _
-      _ ≤ C + C := add_le_add (hb z (hsub hz)) (hb ξ hξmem)
-      _ = 2 * C := by ring
-  exact Complex.norm_deriv_le_div_of_mapsTo_ball hd hmaps hρ
-
-/-- **Uniform local Lipschitz estimate for a bounded analytic function**: on the half-ball
-`ball z₀ (ρ/2)` inside the domain, `‖f y - f x‖ ≤ (2C/(ρ/2)) · ‖y - x‖`, with a constant
-depending only on the bound `C` and the geometry — uniform over the family. -/
-theorem norm_sub_le_of_analyticOnNhd_of_bounded {f : ℂ → ℂ} {c : ℂ} {R C : ℝ}
-    (hf : AnalyticOnNhd ℂ f (ball c R))
-    (hb : ∀ z ∈ ball c R, ‖f z‖ ≤ C)
-    {z₀ : ℂ} {ρ : ℝ} (hρ : 0 < ρ) (hsub : ball z₀ ρ ⊆ ball c R)
-    {x y : ℂ} (hx : x ∈ ball z₀ (ρ / 2)) (hy : y ∈ ball z₀ (ρ / 2)) :
-    ‖f y - f x‖ ≤ 2 * C / (ρ / 2) * ‖y - x‖ := by
-  have hhalf : ball z₀ (ρ / 2) ⊆ ball c R :=
-    (ball_subset_ball (by linarith)).trans hsub
-  refine Convex.norm_image_sub_le_of_norm_deriv_le
-    (fun ξ hξ => (hf ξ (hhalf hξ)).differentiableAt)
-    (fun ξ hξ => ?_) (convex_ball z₀ (ρ / 2)) hx hy
-  have hξsub : ball ξ (ρ / 2) ⊆ ball c R := by
-    refine (ball_subset_ball' ?_).trans hsub
-    rw [mem_ball] at hξ
-    linarith [hξ.le]
-  exact norm_deriv_le_of_analyticOnNhd_of_bounded hf hb (by positivity) hξsub
-
-/-- **Pointwise equicontinuity of a uniformly bounded analytic family on a ball**: the uniform
-local Lipschitz estimate gives equicontinuity at every interior point, with no boundary-uniform
-control. Stated on the subtype ball, matching the Ascoli-data range carriers. -/
-theorem equicontinuous_restrict_of_analyticOnNhd_of_bounded {ι : Type*} {F : ι → ℂ → ℂ}
-    {c : ℂ} {R C : ℝ} (hC : 0 ≤ C)
-    (hf : ∀ i, AnalyticOnNhd ℂ (F i) (ball c R))
-    (hb : ∀ i, ∀ z ∈ ball c R, ‖F i z‖ ≤ C) :
-    Equicontinuous (fun i (z : ball c R) => F i (z : ℂ)) := by
-  intro x₀
-  rw [Metric.equicontinuousAt_iff]
-  intro ε hε
-  obtain ⟨z₀, hz₀⟩ := x₀
-  set ρ : ℝ := R - dist z₀ c with hρdef
-  have hz₀' : dist z₀ c < R := mem_ball.mp hz₀
-  have hρ : 0 < ρ := by rw [hρdef]; linarith
-  have hsubρ : ball z₀ ρ ⊆ ball c R := by
-    intro w hw
-    rw [mem_ball] at hw ⊢
-    calc dist w c ≤ dist w z₀ + dist z₀ c := dist_triangle _ _ _
-      _ < ρ + dist z₀ c := by linarith
-      _ = R := by rw [hρdef]; ring
-  set M : ℝ := 2 * C / (ρ / 2) with hMdef
-  have hM0 : 0 ≤ M := by positivity
-  refine ⟨min (ρ / 2) (ε / (M + 1)), by positivity, ?_⟩
-  intro x hx i
-  have hd : dist (x : ℂ) z₀ < min (ρ / 2) (ε / (M + 1)) := by
-    rw [Subtype.dist_eq] at hx
-    exact hx
-  have hxball : (x : ℂ) ∈ ball z₀ (ρ / 2) :=
-    mem_ball.mpr (lt_of_lt_of_le hd (min_le_left _ _))
-  have hz₀ball : z₀ ∈ ball z₀ (ρ / 2) := mem_ball_self (by positivity)
-  have hlip := norm_sub_le_of_analyticOnNhd_of_bounded (hf i) (hb i) hρ hsubρ
-    hxball hz₀ball
-  rw [dist_eq_norm]
-  calc ‖F i z₀ - F i (x : ℂ)‖ ≤ M * ‖z₀ - (x : ℂ)‖ := hlip
-    _ ≤ M * (ε / (M + 1)) := by
-        refine mul_le_mul_of_nonneg_left ?_ hM0
-        rw [← dist_eq_norm, dist_comm]
-        exact le_of_lt (lt_of_lt_of_le hd (min_le_right _ _))
-    _ < ε := by
-        rw [mul_div_assoc']
-        rw [div_lt_iff₀ (by positivity : (0 : ℝ) < M + 1)]
-        nlinarith
-
-/-- **Equicontinuity transfers to the range carrier**: the coercion family indexed by the range
-of a map into continuous maps is a re-indexing of the underlying family. -/
-theorem equicontinuous_range_coe {X : Type*} [TopologicalSpace X] {ι : Type*}
-    (Φ : ι → C(X, ℂ)) (h : Equicontinuous (fun i => (Φ i : X → ℂ))) :
-    Equicontinuous ((↑) : Set.range Φ → X → ℂ) := by
-  classical
-  have hcomp := h.comp (fun g : Set.range Φ => g.2.choose)
-  have heq : ((fun i => (Φ i : X → ℂ)) ∘ (fun g : Set.range Φ => g.2.choose))
-      = ((↑) : Set.range Φ → X → ℂ) := by
-    funext g
-    simp only [Function.comp_apply]
-    rw [g.2.choose_spec]
-  rwa [heq] at hcomp
 
 namespace Ambient
 

--- a/IsingModel/Analysis/HolomorphicEquicontinuity.lean
+++ b/IsingModel/Analysis/HolomorphicEquicontinuity.lean
@@ -1,0 +1,167 @@
+import Mathlib.Analysis.Complex.Schwarz
+import Mathlib.Analysis.Calculus.MeanValue
+import Mathlib.Analysis.Analytic.Basic
+import Mathlib.Topology.MetricSpace.Equicontinuity
+
+/-!
+# Equicontinuity of uniformly bounded holomorphic families (shared Montel/Ascoli core)
+
+Common analysis core for the two Montel-type equicontinuity arguments used in the project
+(Issue #4501): a family of holomorphic functions on a ball, uniformly bounded there, has
+uniformly bounded derivatives on interior sub-balls (Schwarz/Cauchy estimate), hence a uniform
+local Lipschitz estimate, hence is equicontinuous. Both the Ascoli side-condition constructors
+(`AmbientComplexAnalyticity.AscoliData.Constructors.AnalyticSideConditions`) and the Vitali–Porter
+Montel input (`ComplexAnalyticity.VitaliPorter.Equicontinuity`) are thin wrappers over the lemmas
+below; the latter converts its `DifferentiableOn` hypothesis to `AnalyticOnNhd` via
+`DifferentiableOn.analyticOnNhd` (holomorphic ⟹ analytic on ℂ).
+
+* `norm_deriv_le_of_analyticOnNhd_of_bounded` — the Schwarz-lemma derivative bound `2C/ρ`.
+* `norm_sub_le_of_analyticOnNhd_of_bounded` — the uniform local Lipschitz estimate.
+* `equicontinuous_restrict_of_analyticOnNhd_of_bounded` — subtype-ball `Equicontinuous` form.
+* `equicontinuous_range_coe` — transfer of equicontinuity to a range carrier.
+* `equicontinuousAt_of_analyticOnNhd_of_ballBound` — ambient pointwise `EquicontinuousAt` form.
+
+References: Glimm–Jaffe, *Quantum Physics*, 2nd ed. (Springer, 1987), §4.6, Theorem 4.6.2; Conway,
+*Functions of One Complex Variable I*, VII §2 (normal families / Montel).
+-/
+
+namespace IsingModel
+
+open Metric
+
+/-- **Derivative bound for a bounded analytic function** (Schwarz): if `f` is analytic on
+`ball c R` with `‖f‖ ≤ C` there, then at any `ξ` whose `ρ`-ball stays inside,
+`‖deriv f ξ‖ ≤ 2C/ρ`. -/
+theorem norm_deriv_le_of_analyticOnNhd_of_bounded {f : ℂ → ℂ} {c : ℂ} {R C : ℝ}
+    (hf : AnalyticOnNhd ℂ f (ball c R))
+    (hb : ∀ z ∈ ball c R, ‖f z‖ ≤ C)
+    {ξ : ℂ} {ρ : ℝ} (hρ : 0 < ρ) (hsub : ball ξ ρ ⊆ ball c R) :
+    ‖deriv f ξ‖ ≤ 2 * C / ρ := by
+  have hξmem : ξ ∈ ball c R := hsub (mem_ball_self hρ)
+  have hd : DifferentiableOn ℂ f (ball ξ ρ) :=
+    fun z hz => ((hf z (hsub hz)).differentiableAt).differentiableWithinAt
+  have hmaps : Set.MapsTo f (ball ξ ρ) (closedBall (f ξ) (2 * C)) := by
+    intro z hz
+    rw [mem_closedBall, dist_eq_norm]
+    calc ‖f z - f ξ‖ ≤ ‖f z‖ + ‖f ξ‖ := norm_sub_le _ _
+      _ ≤ C + C := add_le_add (hb z (hsub hz)) (hb ξ hξmem)
+      _ = 2 * C := by ring
+  exact Complex.norm_deriv_le_div_of_mapsTo_ball hd hmaps hρ
+
+/-- **Uniform local Lipschitz estimate for a bounded analytic function**: on the half-ball
+`ball z₀ (ρ/2)` inside the domain, `‖f y - f x‖ ≤ (2C/(ρ/2)) · ‖y - x‖`, with a constant
+depending only on the bound `C` and the geometry — uniform over the family. -/
+theorem norm_sub_le_of_analyticOnNhd_of_bounded {f : ℂ → ℂ} {c : ℂ} {R C : ℝ}
+    (hf : AnalyticOnNhd ℂ f (ball c R))
+    (hb : ∀ z ∈ ball c R, ‖f z‖ ≤ C)
+    {z₀ : ℂ} {ρ : ℝ} (hρ : 0 < ρ) (hsub : ball z₀ ρ ⊆ ball c R)
+    {x y : ℂ} (hx : x ∈ ball z₀ (ρ / 2)) (hy : y ∈ ball z₀ (ρ / 2)) :
+    ‖f y - f x‖ ≤ 2 * C / (ρ / 2) * ‖y - x‖ := by
+  have hhalf : ball z₀ (ρ / 2) ⊆ ball c R :=
+    (ball_subset_ball (by linarith)).trans hsub
+  refine Convex.norm_image_sub_le_of_norm_deriv_le
+    (fun ξ hξ => (hf ξ (hhalf hξ)).differentiableAt)
+    (fun ξ hξ => ?_) (convex_ball z₀ (ρ / 2)) hx hy
+  have hξsub : ball ξ (ρ / 2) ⊆ ball c R := by
+    refine (ball_subset_ball' ?_).trans hsub
+    rw [mem_ball] at hξ
+    linarith [hξ.le]
+  exact norm_deriv_le_of_analyticOnNhd_of_bounded hf hb (by positivity) hξsub
+
+/-- **Pointwise equicontinuity of a uniformly bounded analytic family on a ball**: the uniform
+local Lipschitz estimate gives equicontinuity at every interior point, with no boundary-uniform
+control. Stated on the subtype ball, matching the Ascoli-data range carriers. -/
+theorem equicontinuous_restrict_of_analyticOnNhd_of_bounded {ι : Type*} {F : ι → ℂ → ℂ}
+    {c : ℂ} {R C : ℝ} (hC : 0 ≤ C)
+    (hf : ∀ i, AnalyticOnNhd ℂ (F i) (ball c R))
+    (hb : ∀ i, ∀ z ∈ ball c R, ‖F i z‖ ≤ C) :
+    Equicontinuous (fun i (z : ball c R) => F i (z : ℂ)) := by
+  intro x₀
+  rw [Metric.equicontinuousAt_iff]
+  intro ε hε
+  obtain ⟨z₀, hz₀⟩ := x₀
+  set ρ : ℝ := R - dist z₀ c with hρdef
+  have hz₀' : dist z₀ c < R := mem_ball.mp hz₀
+  have hρ : 0 < ρ := by rw [hρdef]; linarith
+  have hsubρ : ball z₀ ρ ⊆ ball c R := by
+    intro w hw
+    rw [mem_ball] at hw ⊢
+    calc dist w c ≤ dist w z₀ + dist z₀ c := dist_triangle _ _ _
+      _ < ρ + dist z₀ c := by linarith
+      _ = R := by rw [hρdef]; ring
+  set M : ℝ := 2 * C / (ρ / 2) with hMdef
+  have hM0 : 0 ≤ M := by positivity
+  refine ⟨min (ρ / 2) (ε / (M + 1)), by positivity, ?_⟩
+  intro x hx i
+  have hd : dist (x : ℂ) z₀ < min (ρ / 2) (ε / (M + 1)) := by
+    rw [Subtype.dist_eq] at hx
+    exact hx
+  have hxball : (x : ℂ) ∈ ball z₀ (ρ / 2) :=
+    mem_ball.mpr (lt_of_lt_of_le hd (min_le_left _ _))
+  have hz₀ball : z₀ ∈ ball z₀ (ρ / 2) := mem_ball_self (by positivity)
+  have hlip := norm_sub_le_of_analyticOnNhd_of_bounded (hf i) (hb i) hρ hsubρ
+    hxball hz₀ball
+  rw [dist_eq_norm]
+  calc ‖F i z₀ - F i (x : ℂ)‖ ≤ M * ‖z₀ - (x : ℂ)‖ := hlip
+    _ ≤ M * (ε / (M + 1)) := by
+        refine mul_le_mul_of_nonneg_left ?_ hM0
+        rw [← dist_eq_norm, dist_comm]
+        exact le_of_lt (lt_of_lt_of_le hd (min_le_right _ _))
+    _ < ε := by
+        rw [mul_div_assoc']
+        rw [div_lt_iff₀ (by positivity : (0 : ℝ) < M + 1)]
+        nlinarith
+
+/-- **Equicontinuity transfers to the range carrier**: the coercion family indexed by the range
+of a map into continuous maps is a re-indexing of the underlying family. -/
+theorem equicontinuous_range_coe {X : Type*} [TopologicalSpace X] {ι : Type*}
+    (Φ : ι → C(X, ℂ)) (h : Equicontinuous (fun i => (Φ i : X → ℂ))) :
+    Equicontinuous ((↑) : Set.range Φ → X → ℂ) := by
+  classical
+  have hcomp := h.comp (fun g : Set.range Φ => g.2.choose)
+  have heq : ((fun i => (Φ i : X → ℂ)) ∘ (fun g : Set.range Φ => g.2.choose))
+      = ((↑) : Set.range Φ → X → ℂ) := by
+    funext g
+    simp only [Function.comp_apply]
+    rw [g.2.choose_spec]
+  rwa [heq] at hcomp
+
+/-- **Ambient pointwise equicontinuity of a uniformly bounded analytic family** (Montel input,
+ball form): if every `F i` is analytic on `ball x₀ ρ` (`ρ > 0`) and uniformly bounded by `M ≥ 0`
+there, then the family `F` is equicontinuous at the centre `x₀` as maps on the ambient space `ℂ`.
+
+Proof: the uniform local Lipschitz estimate `norm_sub_le_of_analyticOnNhd_of_bounded` on the inner
+ball `ball x₀ (ρ/2)` gives a common Lipschitz constant `2M/(ρ/2)`, which is a common modulus of
+continuity at `x₀`. -/
+theorem equicontinuousAt_of_analyticOnNhd_of_ballBound {ι : Type*} {F : ι → ℂ → ℂ}
+    {x₀ : ℂ} {ρ M : ℝ} (hρ : 0 < ρ) (hM : 0 ≤ M)
+    (hF : ∀ i, AnalyticOnNhd ℂ (F i) (ball x₀ ρ))
+    (hbound : ∀ i, ∀ w ∈ ball x₀ ρ, ‖F i w‖ ≤ M) :
+    EquicontinuousAt (fun i => F i) x₀ := by
+  have hsub : ball x₀ ρ ⊆ ball x₀ ρ := subset_rfl
+  set L : ℝ := 2 * M / (ρ / 2) with hL_def
+  have hL0 : 0 ≤ L := by rw [hL_def]; positivity
+  have hLip : ∀ i, ∀ x ∈ ball x₀ (ρ / 2), ∀ x' ∈ ball x₀ (ρ / 2),
+      ‖F i x' - F i x‖ ≤ L * ‖x' - x‖ := by
+    intro i x hx x' hx'
+    rw [hL_def]
+    exact norm_sub_le_of_analyticOnNhd_of_bounded (hF i) (hbound i) hρ hsub hx hx'
+  rw [Metric.equicontinuousAt_iff]
+  intro ε hε
+  refine ⟨min (ρ / 2) (ε / (L + 1)), lt_min (by linarith) (by positivity), ?_⟩
+  intro x hx i
+  have hx_in : x ∈ ball x₀ (ρ / 2) := mem_ball.mpr (lt_of_lt_of_le hx (min_le_left _ _))
+  have hx₀_in : x₀ ∈ ball x₀ (ρ / 2) := mem_ball_self (by linarith)
+  have hbnd := hLip i x hx_in x₀ hx₀_in
+  rw [dist_eq_norm]
+  calc ‖F i x₀ - F i x‖ ≤ L * ‖x₀ - x‖ := hbnd
+    _ = L * dist x x₀ := by rw [← dist_eq_norm, dist_comm]
+    _ < ε := by
+        have hdistlt : dist x x₀ < ε / (L + 1) := lt_of_lt_of_le hx (min_le_right _ _)
+        have hLp1 : 0 < L + 1 := by linarith
+        calc L * dist x x₀ ≤ (L + 1) * dist x x₀ :=
+              mul_le_mul_of_nonneg_right (by linarith) dist_nonneg
+          _ < (L + 1) * (ε / (L + 1)) := mul_lt_mul_of_pos_left hdistlt hLp1
+          _ = ε := by field_simp
+
+end IsingModel

--- a/IsingModel/ComplexAnalyticity/VitaliPorter/Equicontinuity.lean
+++ b/IsingModel/ComplexAnalyticity/VitaliPorter/Equicontinuity.lean
@@ -1,22 +1,18 @@
-import Mathlib.Analysis.Complex.LocallyUniformLimit
-import Mathlib.Analysis.Calculus.MeanValue
-import Mathlib.Topology.MetricSpace.Equicontinuity
+import IsingModel.Analysis.HolomorphicEquicontinuity
+import Mathlib.Analysis.Complex.CauchyIntegral
 
 /-!
 # Vitali–Porter: Montel equicontinuity from local boundedness (Cauchy estimates)
 
 Second building block of the in-project proof eliminating the declared scope-excluded axiom
 `vitaliPorter_tendstoLocallyUniformlyOn` (Issue #4280). It supplies the **Montel** half's
-equicontinuity input: a holomorphic function bounded by `M` on a closed disc is, on a strictly
-smaller concentric disc, Lipschitz with constant `M / (R − r)` — *uniformly in the bound*, so a
-locally uniformly bounded family is locally equicontinuous.
+equicontinuity input: a locally uniformly bounded family of holomorphic functions is locally
+equicontinuous.
 
-The two key facts are pure complex analysis:
-- `cauchy_norm_deriv_le`: the Cauchy derivative estimate `‖deriv f z‖ ≤ M / r` from a sup bound on
-  the circle (via `Complex.cderiv_eq_deriv` + `Complex.norm_cderiv_le`).
-- `lipschitzBound_of_bounded_on_closedBall`: the uniform Lipschitz bound on the inner disc (Cauchy
-  estimate at every inner point + the convex mean-value inequality
-  `Convex.norm_image_sub_le_of_norm_fderiv_le`).
+This is now a thin `DifferentiableOn` wrapper over the shared holomorphic-equicontinuity core
+`IsingModel.equicontinuousAt_of_analyticOnNhd_of_ballBound` (Issue #4501): on ℂ, holomorphy on an
+open set is analyticity (`DifferentiableOn.analyticOnNhd`), so the `ℕ`-indexed `DifferentiableOn`
+family is fed into the general `AnalyticOnNhd` core.
 
 **Reference:** Conway, *Functions of One Complex Variable I*, VII §2 (normal families / Montel). -/
 
@@ -25,117 +21,24 @@ namespace FunctionTheory
 
 open Complex Metric Set
 
-/-- **Cauchy derivative estimate**: if `f` is holomorphic on an open `U`, `closedBall z r ⊆ U`
-(`r > 0`), and `‖f w‖ ≤ M` on the circle `sphere z r`, then `‖deriv f z‖ ≤ M / r`.
-
-Direct from `Complex.cderiv_eq_deriv` (the circle integral equals the derivative under the Cauchy
-formula) and `Complex.norm_cderiv_le`. -/
-theorem cauchy_norm_deriv_le
-    {U : Set ℂ} (hU : IsOpen U) {f : ℂ → ℂ} (hf : DifferentiableOn ℂ f U)
-    {z : ℂ} {r M : ℝ} (hr : 0 < r) (hball : closedBall z r ⊆ U)
-    (hbound : ∀ w ∈ sphere z r, ‖f w‖ ≤ M) :
-    ‖deriv f z‖ ≤ M / r := by
-  rw [← Complex.cderiv_eq_deriv hU hf hr hball]
-  exact Complex.norm_cderiv_le hr hbound
-
-/-- **Uniform Lipschitz bound on the inner disc from a sup bound on the outer disc**.
-
-If `f` is holomorphic on an open `U`, `closedBall z₀ R ⊆ U`, `‖f w‖ ≤ M` on `closedBall z₀ R`, and
-`0 < r < R`, then for all `w, w' ∈ closedBall z₀ r`,
-`‖f w − f w'‖ ≤ (M / (R − r)) · ‖w − w'‖`.
-
-The Lipschitz constant `M / (R − r)` depends only on `M, R, r` (not on `f`), so a family of
-holomorphic functions sharing the bound `M` is uniformly Lipschitz — hence locally equicontinuous —
-on the inner disc. Proof: at each inner point `x` the Cauchy estimate on the radius-`(R−r)` circle
-(contained in `closedBall z₀ R`) gives `‖deriv f x‖ ≤ M / (R − r)`; the convex mean-value inequality
-`Convex.norm_image_sub_le_of_norm_fderiv_le` then yields the Lipschitz bound on the convex inner
-disc. -/
-theorem lipschitzBound_of_bounded_on_closedBall
-    {U : Set ℂ} (hU : IsOpen U) {f : ℂ → ℂ} (hf : DifferentiableOn ℂ f U)
-    {z₀ : ℂ} {R r M : ℝ} (hrR : r < R)
-    (hball : closedBall z₀ R ⊆ U) (hbound : ∀ w ∈ closedBall z₀ R, ‖f w‖ ≤ M)
-    {w w' : ℂ} (hw : w ∈ closedBall z₀ r) (hw' : w' ∈ closedBall z₀ r) :
-    ‖f w - f w'‖ ≤ M / (R - r) * ‖w - w'‖ := by
-  have hRr : 0 < R - r := by linarith
-  -- Derivative bound at every inner point `x`.
-  have hderiv : ∀ x ∈ closedBall z₀ r, ‖deriv f x‖ ≤ M / (R - r) := by
-    intro x hx
-    have hx_le : dist x z₀ ≤ r := by simpa [Metric.mem_closedBall] using hx
-    -- `closedBall x (R − r) ⊆ closedBall z₀ R ⊆ U`.
-    have hxball : closedBall x (R - r) ⊆ closedBall z₀ R :=
-      Metric.closedBall_subset_closedBall' (by linarith [hx_le])
-    have hxU : closedBall x (R - r) ⊆ U := hxball.trans hball
-    have hsphere : ∀ y ∈ sphere x (R - r), ‖f y‖ ≤ M := by
-      intro y hy
-      exact hbound y (hxball (Metric.sphere_subset_closedBall hy))
-    exact cauchy_norm_deriv_le hU hf hRr hxU hsphere
-  -- Convex mean-value inequality on the inner disc.
-  have hconv : Convex ℝ (closedBall z₀ r) := convex_closedBall z₀ r
-  have hdiff : ∀ x ∈ closedBall z₀ r, DifferentiableAt ℂ f x := by
-    intro x hx
-    have hxU : x ∈ U := hball (Metric.closedBall_subset_closedBall (by linarith) hx)
-    exact hf.differentiableAt (hU.mem_nhds hxU)
-  have hfd : ∀ x ∈ closedBall z₀ r, ‖fderiv ℂ f x‖ ≤ M / (R - r) := by
-    intro x hx
-    rw [← norm_deriv_eq_norm_fderiv]
-    exact hderiv x hx
-  exact hconv.norm_image_sub_le_of_norm_fderiv_le hdiff hfd hw' hw
-
 /-- **Equicontinuity at a point from a local uniform bound** (Montel input, ball form).
 
 If every `F n` is holomorphic on the open `U`, `ball x₀ ρ ⊆ U` (`ρ > 0`), and `‖F n w‖ ≤ M` for all
 `n` and `w ∈ ball x₀ ρ`, then the family `F` is equicontinuous at `x₀`.
 
-Proof: on `closedBall x₀ (ρ/2) ⊆ ball x₀ ρ` every `F n` is bounded by `M`, so by
-`lipschitzBound_of_bounded_on_closedBall` every `F n` is `(M/(ρ/4))`-Lipschitz on the inner disc
-`closedBall x₀ (ρ/4)` — a common modulus of continuity, which is exactly equicontinuity at `x₀`. -/
+Thin wrapper: holomorphy on the open `U` upgrades to `AnalyticOnNhd` via
+`DifferentiableOn.analyticOnNhd`, restricted to `ball x₀ ρ`; the shared core
+`equicontinuousAt_of_analyticOnNhd_of_ballBound` then supplies the common modulus of continuity. -/
 theorem equicontinuousAt_of_ball_bound
     {U : Set ℂ} (hU : IsOpen U) {F : ℕ → ℂ → ℂ}
     (hF : ∀ n, DifferentiableOn ℂ (F n) U)
     {x₀ : ℂ} {ρ M : ℝ} (hρ : 0 < ρ) (hballU : ball x₀ ρ ⊆ U)
     (hbound : ∀ n, ∀ w ∈ ball x₀ ρ, ‖F n w‖ ≤ M) :
     EquicontinuousAt (fun n => F n) x₀ := by
-  -- Geometry: inner radius `ρ/4 < ρ/2`, and `closedBall x₀ (ρ/2) ⊆ ball x₀ ρ ⊆ U`.
-  have hhalf_lt : ρ / 2 < ρ := by linarith
-  have hquart_lt : ρ / 4 < ρ / 2 := by linarith
-  have hCB_sub : closedBall x₀ (ρ / 2) ⊆ ball x₀ ρ :=
-    Metric.closedBall_subset_ball hhalf_lt
-  have hCB_U : closedBall x₀ (ρ / 2) ⊆ U := hCB_sub.trans hballU
-  have hbound_CB : ∀ n, ∀ w ∈ closedBall x₀ (ρ / 2), ‖F n w‖ ≤ M :=
-    fun n w hw => hbound n w (hCB_sub hw)
-  -- The common Lipschitz constant `L = M / (ρ/2 − ρ/4) = M / (ρ/4) = 4M/ρ`.
-  set L : ℝ := M / (ρ / 2 - ρ / 4) with hL_def
   have hM0 : 0 ≤ M := (norm_nonneg _).trans (hbound 0 x₀ (Metric.mem_ball_self hρ))
-  have hden : 0 < ρ / 2 - ρ / 4 := by linarith
-  have hL0 : 0 ≤ L := div_nonneg hM0 hden.le
-  -- Uniform Lipschitz bound on the inner disc.
-  have hLip : ∀ n, ∀ x ∈ closedBall x₀ (ρ / 4), ∀ x' ∈ closedBall x₀ (ρ / 4),
-      ‖F n x - F n x'‖ ≤ L * ‖x - x'‖ := by
-    intro n x hx x' hx'
-    exact lipschitzBound_of_bounded_on_closedBall hU (hF n) hquart_lt hCB_U (hbound_CB n) hx hx'
-  -- Convert the common modulus into equicontinuity at `x₀`.
-  rw [Metric.equicontinuousAt_iff]
-  intro ε hε
-  refine ⟨min (ρ / 4) (ε / (L + 1)), lt_min (by linarith) (by positivity), ?_⟩
-  intro x hx n
-  have hx_in : x ∈ closedBall x₀ (ρ / 4) := by
-    rw [Metric.mem_closedBall]
-    exact le_of_lt (lt_of_lt_of_le hx (min_le_left _ _))
-  have hx₀_in : x₀ ∈ closedBall x₀ (ρ / 4) := Metric.mem_closedBall_self (by linarith)
-  have hbnd := hLip n x₀ hx₀_in x hx_in
-  -- `dist (F n x₀) (F n x) = ‖F n x₀ − F n x‖ ≤ L * ‖x₀ − x‖ = L * dist x x₀`.
-  rw [dist_eq_norm]
-  calc ‖F n x₀ - F n x‖ ≤ L * ‖x₀ - x‖ := hbnd
-    _ = L * dist x x₀ := by rw [← dist_eq_norm, dist_comm]
-    _ < ε := by
-        have hdistlt : dist x x₀ < ε / (L + 1) :=
-          lt_of_lt_of_le hx (min_le_right _ _)
-        have hLp1 : 0 < L + 1 := by linarith
-        calc L * dist x x₀ ≤ (L + 1) * dist x x₀ := by
-              apply mul_le_mul_of_nonneg_right (by linarith) dist_nonneg
-          _ < (L + 1) * (ε / (L + 1)) :=
-              mul_lt_mul_of_pos_left hdistlt hLp1
-          _ = ε := by field_simp
+  have hana : ∀ n, AnalyticOnNhd ℂ (F n) (ball x₀ ρ) :=
+    fun n => ((hF n).analyticOnNhd hU).mono hballU
+  exact equicontinuousAt_of_analyticOnNhd_of_ballBound hρ hM0 hana hbound
 
 /-- **Equicontinuity at a point from the local-boundedness hypothesis** (Montel input).
 

--- a/IsingModel/ComplexAnalyticity/VitaliPorter/MontelExtraction.lean
+++ b/IsingModel/ComplexAnalyticity/VitaliPorter/MontelExtraction.lean
@@ -1,5 +1,6 @@
 import IsingModel.ComplexAnalyticity.VitaliPorter.PerCompact
 import IsingModel.ComplexAnalyticity.VitaliPorter.Exhaustion
+import Mathlib.Analysis.Complex.LocallyUniformLimit
 
 /-!
 # Vitali–Porter: Montel diagonal extraction


### PR DESCRIPTION
## Summary

Extract bounded-holomorphic-family equicontinuity core (5 key lemmas) into new canonical module `IsingModel/Analysis/HolomorphicEquicontinuity.lean` (Montel precursor infrastructure).

Rewire downstream consumers (`VitaliPorter/Equicontinuity` and `AscoliData/AnalyticSideConditions`) as backward-compatible wrapper layers; preserve all public names.

Remove 2 internal reference-0 declarations (`cauchy_norm_deriv_le`, `lipschitzBound_of_bounded_on_closedBall`) now redundant by consolidation.

## Changes

- New canonical module: `IsingModel/Analysis/HolomorphicEquicontinuity.lean` (5 lemmas, no public API change)
- Rewire existing wrapper modules to import from canonical core
- Zero public name breakage; internal housekeeping only
- Full build green (5467 jobs), warning-zero, `#print axioms` unchanged, downstream green

## Rationale

Eliminate the only genuine structural duplication (5-lemma equicontinuity core); preserve structures and specializations (over-consolidation avoided). This is the legitimate consolidation scope; further merges of AscoliData/VitaliPorter wrapper layers deferred.

## Addresses

#4501 (R3 PR-1 core extraction)
Tracker: #4506 (R3 refactoring phase)
